### PR TITLE
Add Filer publisher

### DIFF
--- a/pkg/bmp/route-monitor.go
+++ b/pkg/bmp/route-monitor.go
@@ -1,7 +1,7 @@
 package bmp
 
 import (
-	"encoding/binary"
+	"fmt"
 
 	"github.com/golang/glog"
 	"github.com/sbezverk/gobmp/pkg/bgp"
@@ -17,16 +17,28 @@ type RouteMonitor struct {
 func UnmarshalBMPRouteMonitorMessage(b []byte) (*RouteMonitor, error) {
 	glog.V(6).Infof("BMP Route Monitor Message Raw: %s", tools.MessageHex(b))
 	rm := RouteMonitor{}
+	// 16 bytes marker + 2 bytes update length + 1 byte of type
+	if len(b) < 19 {
+		return nil, fmt.Errorf("malformed route monitor message")
+	}
 	p := 0
 	// Skip 16 bytes of a marker
 	p += 16
-	l := binary.BigEndian.Uint16(b[p : p+2])
+	// Skip 2 bytes of the update length
 	p += 2
-	u, err := bgp.UnmarshalBGPUpdate(b[p+1 : p+int(l-18)])
-	if err != nil {
-		return nil, err
+	// Getting update type, currently only type 2 is processed
+	t := b[p]
+	p++
+	switch t {
+	case 2:
+		// Update type
+		u, err := bgp.UnmarshalBGPUpdate(b[p:])
+		if err != nil {
+			return nil, err
+		}
+		rm.Update = u
+	default:
 	}
-	rm.Update = u
 
 	return &rm, nil
 }

--- a/pkg/dumper/dumper.go
+++ b/pkg/dumper/dumper.go
@@ -17,16 +17,20 @@ type pubwriter struct {
 	output *log.Logger
 }
 
-func (pw *pubwriter) PublishMessage(msgType int, msgHash []byte, msg []byte) error {
+func (p *pubwriter) PublishMessage(msgType int, msgHash []byte, msg []byte) error {
 	m := msgOut{
 		MsgType: msgType,
 		MsgHash: string(msgHash),
 		Msg:     string(msg),
 	}
 
-	pw.output.Printf("%+v", m)
+	p.output.Printf("%+v", m)
 
 	return nil
+}
+
+func (p *pubwriter) Stop() {
+	p.output.Printf("gobmp is stopping...")
 }
 
 // NewDumper returns a new instance of standard out  dumper

--- a/pkg/filer/filer.go
+++ b/pkg/filer/filer.go
@@ -1,0 +1,52 @@
+package filer
+
+import (
+	"encoding/json"
+	"os"
+	"time"
+
+	"github.com/sbezverk/gobmp/pkg/pub"
+)
+
+type msgOut struct {
+	Type  int       `json:"type,omitempty"`
+	Key   []byte    `json:"key,omitempty"`
+	Value []byte    `json:"value,omitempty"`
+	Time  time.Time `json:"timestamp,omitempty"`
+}
+
+type pubfiler struct {
+	file *os.File
+}
+
+func (pf *pubfiler) PublishMessage(msgType int, msgHash []byte, msg []byte) error {
+	m := msgOut{
+		Type:  msgType,
+		Key:   msgHash,
+		Value: msg,
+		Time:  time.Now(),
+	}
+	b, err := json.Marshal(&m)
+	if err != nil {
+		return err
+	}
+	_, err = pf.file.Write(b)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// NewFiler returns a new instance of message filer
+func NewFiler(file string) pub.Publisher {
+	f, err := os.Create(file)
+	if err != nil {
+		return nil
+	}
+	pw := pubfiler{
+		file: f,
+	}
+
+	return &pw
+}

--- a/pkg/filer/filer.go
+++ b/pkg/filer/filer.go
@@ -19,7 +19,7 @@ type pubfiler struct {
 	file *os.File
 }
 
-func (pf *pubfiler) PublishMessage(msgType int, msgHash []byte, msg []byte) error {
+func (p *pubfiler) PublishMessage(msgType int, msgHash []byte, msg []byte) error {
 	m := msgOut{
 		Type:  msgType,
 		Key:   msgHash,
@@ -30,12 +30,17 @@ func (pf *pubfiler) PublishMessage(msgType int, msgHash []byte, msg []byte) erro
 	if err != nil {
 		return err
 	}
-	_, err = pf.file.Write(b)
+	b = append(b, '\n')
+	_, err = p.file.Write(b)
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func (p *pubfiler) Stop() {
+	p.file.Close()
 }
 
 // NewFiler returns a new instance of message filer

--- a/pkg/filer/filer.go
+++ b/pkg/filer/filer.go
@@ -3,16 +3,14 @@ package filer
 import (
 	"encoding/json"
 	"os"
-	"time"
 
 	"github.com/sbezverk/gobmp/pkg/pub"
 )
 
 type msgOut struct {
-	Type  int       `json:"type,omitempty"`
-	Key   []byte    `json:"key,omitempty"`
-	Value []byte    `json:"value,omitempty"`
-	Time  time.Time `json:"timestamp,omitempty"`
+	Type  int    `json:"type,omitempty"`
+	Key   []byte `json:"key,omitempty"`
+	Value []byte `json:"value,omitempty"`
 }
 
 type pubfiler struct {
@@ -24,7 +22,6 @@ func (p *pubfiler) PublishMessage(msgType int, msgHash []byte, msg []byte) error
 		Type:  msgType,
 		Key:   msgHash,
 		Value: msg,
-		Time:  time.Now(),
 	}
 	b, err := json.Marshal(&m)
 	if err != nil {

--- a/pkg/gobmpsrv/gobmpsrv.go
+++ b/pkg/gobmpsrv/gobmpsrv.go
@@ -35,6 +35,9 @@ func (srv *bmpServer) Start() {
 
 func (srv *bmpServer) Stop() {
 	glog.Infof("Stopping gobmp server\n")
+	if srv.publisher != nil {
+		srv.publisher.Stop()
+	}
 	close(srv.stop)
 }
 

--- a/pkg/kafka/kafka-publisher.go
+++ b/pkg/kafka/kafka-publisher.go
@@ -207,3 +207,6 @@ func validator(addr string) error {
 	}
 	return nil
 }
+
+func (p *publisher) Stop() {
+}

--- a/pkg/pub/publisher.go
+++ b/pkg/pub/publisher.go
@@ -6,4 +6,5 @@ package pub
 // msg is json marshaled message of msgType
 type Publisher interface {
 	PublishMessage(msgType int, msgHash []byte, msg []byte) error
+	Stop()
 }


### PR DESCRIPTION
File publisher allows to store generated messages in json encoded format in the file. The idea is to use this feature for debugging and performance testing purposes. 