### PR TITLE
Fix panic when route contains multiple path IDs

### DIFF
--- a/pkg/base/route.go
+++ b/pkg/base/route.go
@@ -37,6 +37,8 @@ func UnmarshalRoutes(b []byte) ([]Route, error) {
 		if b[p] == 0 && len(b) > 4 {
 			route.PathID = binary.BigEndian.Uint32(b[p : p+4])
 			p += 4
+			// Updating length
+			route.Length = b[p]
 		}
 		l := route.Length / 8
 		if route.Length%8 != 0 {

--- a/pkg/base/route_test.go
+++ b/pkg/base/route_test.go
@@ -79,6 +79,22 @@ func TestUnmarshalBaseNLRI(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "Panic_1",
+			input: []byte{0x00, 0x00, 0x00, 0x01, 0x18, 0x43, 0xd3, 0x35, 0x00, 0x00, 0x00, 0x01, 0x18, 0x2d, 0xa0, 0x00},
+			expect: []Route{
+				{
+					PathID: 1,
+					Length: 24,
+					Prefix: []byte{67, 211, 53},
+				},
+				{
+					PathID: 1,
+					Length: 24,
+					Prefix: []byte{45, 160, 0},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>