### PR TITLE
Get rid of Sprintf and refactor logging

### DIFF
--- a/cmd/gobmp/gobmp.go
+++ b/cmd/gobmp/gobmp.go
@@ -83,7 +83,7 @@ func main() {
 			glog.Errorf("restarting gobmp...")
 			os.Exit(1)
 		}
-		glog.V(6).Infof("Kafka publisher has been successfully initialized.")
+		glog.V(5).Infof("Kafka publisher has been successfully initialized.")
 	}
 
 	// Initializing bmp server

--- a/cmd/player/player.go
+++ b/cmd/player/player.go
@@ -49,7 +49,7 @@ func main() {
 		glog.Errorf("fail to initialize Kafka publisher with error: %+v", err)
 		os.Exit(1)
 	}
-	glog.V(6).Infof("Kafka publisher has been successfully initialized.")
+	glog.V(5).Infof("Kafka publisher has been successfully initialized.")
 	defer publisher.Stop()
 
 	msgs, err := loadMessages(f)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-test/deep v1.0.6
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/segmentio/kafka-go v0.3.6
+	github.com/segmentio/kafka-go v0.4.2
 	golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529 // indirect
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9 // indirect
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/segmentio/kafka-go v0.3.6 h1:+JauPDvHurc4XSJVGniNwFuv4NmRLr1CxWvhWkRAtXA=
 github.com/segmentio/kafka-go v0.3.6/go.mod h1:8rEphJEczp+yDE/R5vwmaqZgF1wllrl4ioQcNKB8wVA=
+github.com/segmentio/kafka-go v0.4.2 h1:QXZ6q9Bu1JkAJQ/CQBb2Av8pFRG8LQ0kWCrLXgQyL8c=
+github.com/segmentio/kafka-go v0.4.2/go.mod h1:Inh7PqOsxmfgasV8InZYKVXWsdjcCq2d9tFV75GLbuM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=

--- a/pkg/base/ip-reachability-information.go
+++ b/pkg/base/ip-reachability-information.go
@@ -14,7 +14,9 @@ type IPReachabilityInformation struct {
 
 // UnmarshalIPReachabilityInformation builds IP Reachability Information TLV object
 func UnmarshalIPReachabilityInformation(b []byte) (*IPReachabilityInformation, error) {
-	glog.V(6).Infof("IPReachabilityInformationTLV Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("IPReachabilityInformationTLV Raw: %s", tools.MessageHex(b))
+	}
 	ipr := IPReachabilityInformation{
 		LengthInBits: b[0],
 	}

--- a/pkg/base/link-descriptor.go
+++ b/pkg/base/link-descriptor.go
@@ -79,7 +79,9 @@ func (l *LinkDescriptor) GetLinkMTID() uint16 {
 
 // UnmarshalLinkDescriptor build Link Descriptor object
 func UnmarshalLinkDescriptor(b []byte) (*LinkDescriptor, error) {
-	glog.V(6).Infof("LinkDescriptor Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("LinkDescriptor Raw: %s", tools.MessageHex(b))
+	}
 	ld := LinkDescriptor{}
 	p := 0
 	ltlv, err := UnmarshalTLV(b[p : p+len(b)])

--- a/pkg/base/link-nlri.go
+++ b/pkg/base/link-nlri.go
@@ -118,7 +118,9 @@ func (l *LinkNLRI) GetRemoteIGPRouterID() string {
 
 // UnmarshalLinkNLRI builds Link NLRI object
 func UnmarshalLinkNLRI(b []byte) (*LinkNLRI, error) {
-	glog.V(6).Infof("LinkNLRI Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("LinkNLRI Raw: %s", tools.MessageHex(b))
+	}
 	if len(b) == 0 {
 		return nil, fmt.Errorf("NLRI length is 0")
 	}

--- a/pkg/base/local-remote-identifier.go
+++ b/pkg/base/local-remote-identifier.go
@@ -24,7 +24,9 @@ func (lri *LocalRemoteIdentifierTLV) GetLinkID(local bool) uint32 {
 
 // UnmarshalLocalRemoteIdentifierTLV builds Link Descriptor Local/Remote Identifiers TLV object
 func UnmarshalLocalRemoteIdentifierTLV(b []byte) (*LocalRemoteIdentifierTLV, error) {
-	glog.V(6).Infof("LocalRemoteIdentifierTLV Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("LocalRemoteIdentifierTLV Raw: %s", tools.MessageHex(b))
+	}
 	l := make([]byte, 4)
 	copy(l, b[:4])
 	r := make([]byte, 4)

--- a/pkg/base/msd-tv.go
+++ b/pkg/base/msd-tv.go
@@ -13,7 +13,9 @@ type MSDTV struct {
 
 // UnmarshalMSDTV builds slice of MSD Type Value tuples
 func UnmarshalMSDTV(b []byte) ([]*MSDTV, error) {
-	glog.V(6).Infof("UnmarshalMSDTV Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("UnmarshalMSDTV Raw: %s", tools.MessageHex(b))
+	}
 	tvs := make([]*MSDTV, 0)
 	for p := 0; p < len(b); {
 		tv := &MSDTV{}

--- a/pkg/base/multitopologyidentifier.go
+++ b/pkg/base/multitopologyidentifier.go
@@ -27,7 +27,9 @@ func (mti *MultiTopologyIdentifierTLV) GetMTID() []uint16 {
 
 // UnmarshalMultiTopologyIdentifierTLV builds Multi Topology Identifier TLV object
 func UnmarshalMultiTopologyIdentifierTLV(b []byte) (*MultiTopologyIdentifierTLV, error) {
-	glog.V(6).Infof("MultiTopologyIdentifierTLV Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("MultiTopologyIdentifierTLV Raw: %s", tools.MessageHex(b))
+	}
 	mti := MultiTopologyIdentifierTLV{
 		MTI: make([]MultiTopologyIdentifier, 0),
 	}

--- a/pkg/base/node-descriptor.go
+++ b/pkg/base/node-descriptor.go
@@ -79,7 +79,9 @@ func (nd *NodeDescriptor) GetConfedMemberASN() uint32 {
 
 // UnmarshalNodeDescriptor build Node Descriptor object
 func UnmarshalNodeDescriptor(b []byte) (*NodeDescriptor, error) {
-	glog.V(6).Infof("NodeDescriptor Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("NodeDescriptor Raw: %s", tools.MessageHex(b))
+	}
 	nd := NodeDescriptor{}
 	p := 0
 	//	nd.Type = binary.BigEndian.Uint16(b[p : p+2])

--- a/pkg/base/node-nlri.go
+++ b/pkg/base/node-nlri.go
@@ -53,7 +53,9 @@ func (n *NodeNLRI) GetNodeOSPFAreaID() string {
 
 // UnmarshalNodeNLRI builds Node NLRI object
 func UnmarshalNodeNLRI(b []byte) (*NodeNLRI, error) {
-	glog.V(6).Infof("NodeNLRI Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("NodeNLRI Raw: %s", tools.MessageHex(b))
+	}
 	if len(b) == 0 {
 		return nil, fmt.Errorf("NLRI length is 0")
 	}

--- a/pkg/base/prefix-descriptor.go
+++ b/pkg/base/prefix-descriptor.go
@@ -123,7 +123,9 @@ func (pd *PrefixDescriptor) GetPrefixOSPFForwardAddr() string {
 
 // UnmarshalPrefixDescriptor build Prefix Descriptor object
 func UnmarshalPrefixDescriptor(b []byte) (*PrefixDescriptor, error) {
-	glog.V(6).Infof("PrefixDescriptor Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("PrefixDescriptor Raw: %s", tools.MessageHex(b))
+	}
 	pd := PrefixDescriptor{}
 	p := 0
 	ptlv, err := UnmarshalTLV(b[p : p+len(b)])

--- a/pkg/base/prefix-nlri.go
+++ b/pkg/base/prefix-nlri.go
@@ -84,7 +84,9 @@ func (p *PrefixNLRI) GetLocalASN() uint32 {
 
 // UnmarshalPrefixNLRI builds Prefix NLRI object
 func UnmarshalPrefixNLRI(b []byte, ipv4 bool) (*PrefixNLRI, error) {
-	glog.V(6).Infof("PrefixNLRI Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("PrefixNLRI Raw: %s", tools.MessageHex(b))
+	}
 	if len(b) == 0 {
 		return nil, fmt.Errorf("NLRI length is 0")
 	}

--- a/pkg/base/route.go
+++ b/pkg/base/route.go
@@ -25,11 +25,13 @@ type Route struct {
 
 // UnmarshalRoutes builds BGP Withdrawn routes object
 func UnmarshalRoutes(b []byte) ([]Route, error) {
+	if glog.V(6) {
+		glog.Infof("Routes Raw: %s", tools.MessageHex(b))
+	}
 	routes := make([]Route, 0)
 	if len(b) == 0 {
 		return nil, nil
 	}
-	glog.V(6).Infof("Routes Raw: %s", tools.MessageHex(b))
 	for p := 0; p < len(b); {
 		route := Route{}
 		route.Length = b[p]

--- a/pkg/bgp/bgp-base-attributes.go
+++ b/pkg/bgp/bgp-base-attributes.go
@@ -45,7 +45,9 @@ type BaseAttributes struct {
 // UnmarshalBGPBaseAttributes discovers all present Base Attributes in BGP Update
 // and instantiates BaseAttributes object
 func UnmarshalBGPBaseAttributes(b []byte) (*BaseAttributes, error) {
-	glog.V(6).Infof("UnmarshalBGPBaseAttributes RAW: %+v", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("UnmarshalBGPBaseAttributes RAW: %+v", tools.MessageHex(b))
+	}
 	baseAttr := BaseAttributes{}
 	for p := 0; p < len(b); {
 		flag := b[p]

--- a/pkg/bgp/bgp-base-attributes.go
+++ b/pkg/bgp/bgp-base-attributes.go
@@ -3,9 +3,10 @@ package bgp
 import (
 	"crypto/md5"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"net"
+	"strconv"
 
 	"github.com/golang/glog"
 	"github.com/sbezverk/gobmp/pkg/tools"
@@ -112,7 +113,8 @@ func UnmarshalBGPBaseAttributes(b []byte) (*BaseAttributes, error) {
 	if err != nil {
 		return nil, err
 	}
-	baseAttr.BaseAttrHash = fmt.Sprintf("%x", md5.Sum(ba))
+	s := md5.Sum(ba)
+	baseAttr.BaseAttrHash = hex.EncodeToString(s[:])
 
 	return &baseAttr, nil
 }
@@ -245,7 +247,7 @@ func unmarshalAttrCommunity(b []byte) string {
 	var communities string
 	cs := getCommunity(b)
 	for i, c := range cs {
-		communities += fmt.Sprintf("%d:%d", (0xffff0000&c)>>16, 0xffff&c)
+		communities += strconv.Itoa(int((0xffff0000&c)>>16)) + ":" + strconv.Itoa(int(0xffff&c))
 		if i < len(cs)-1 {
 			communities += ", "
 		}

--- a/pkg/bgp/bgp-capability.go
+++ b/pkg/bgp/bgp-capability.go
@@ -21,8 +21,10 @@ type Capability struct {
 
 // UnmarshalBGPInformationalTLVCapability builds BGP Capability Information TLV object
 func UnmarshalBGPInformationalTLVCapability(b []byte) ([]Capability, error) {
+	if glog.V(6) {
+		glog.Infof("BGPInformationalTLVCapability Raw: %s", tools.MessageHex(b))
+	}
 	caps := make([]Capability, 0)
-	glog.V(6).Infof("BGPInformationalTLVCapability Raw: %s", tools.MessageHex(b))
 	for p := 0; p < len(b); {
 		cap := Capability{}
 		cap.Code = b[p]

--- a/pkg/bgp/bgp-information-tlv.go
+++ b/pkg/bgp/bgp-information-tlv.go
@@ -14,7 +14,9 @@ type InformationalTLV struct {
 
 // UnmarshalBGPTLV builds a slice of Informational TLVs
 func UnmarshalBGPTLV(b []byte) ([]InformationalTLV, error) {
-	glog.V(6).Infof("BGPTLV Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("BGPTLV Raw: %s", tools.MessageHex(b))
+	}
 	tlvs := make([]InformationalTLV, 0)
 	for p := 0; p < len(b); {
 		t := b[p]

--- a/pkg/bgp/bgp-open.go
+++ b/pkg/bgp/bgp-open.go
@@ -74,7 +74,9 @@ func (o *OpenMessage) IsMultiLabelCapable() bool {
 
 // UnmarshalBGPOpenMessage validate information passed in byte slice and returns BGPOpenMessage object
 func UnmarshalBGPOpenMessage(b []byte) (*OpenMessage, error) {
-	glog.V(6).Infof("BGPOpenMessage Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("BGPOpenMessage Raw: %s", tools.MessageHex(b))
+	}
 	var err error
 	p := 0
 	m := OpenMessage{

--- a/pkg/bgp/bgp-path-attribute.go
+++ b/pkg/bgp/bgp-path-attribute.go
@@ -17,7 +17,9 @@ type PathAttribute struct {
 
 // UnmarshalBGPPathAttributes builds BGP Path attributes slice
 func UnmarshalBGPPathAttributes(b []byte) ([]PathAttribute, error) {
-	glog.V(6).Infof("BGPPathAttributes Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("BGPPathAttributes Raw: %s", tools.MessageHex(b))
+	}
 	attrs := make([]PathAttribute, 0)
 
 	for p := 0; p < len(b); {

--- a/pkg/bgp/bgp-update.go
+++ b/pkg/bgp/bgp-update.go
@@ -109,8 +109,9 @@ func (up *Update) HasPrefixSID() bool {
 
 // UnmarshalBGPUpdate build BGP Update object from the byte slice provided
 func UnmarshalBGPUpdate(b []byte) (*Update, error) {
-	glog.V(6).Infof("BGPUpdate Raw: %s", tools.MessageHex(b))
-
+	if glog.V(6) {
+		glog.Infof("BGPUpdate Raw: %s", tools.MessageHex(b))
+	}
 	p := 0
 	u := Update{}
 	u.WithdrawnRoutesLength = binary.BigEndian.Uint16(b[p : p+2])

--- a/pkg/bgp/extended-community.go
+++ b/pkg/bgp/extended-community.go
@@ -69,7 +69,9 @@ func makeExtCommunity(b []byte) (*ExtCommunity, error) {
 func UnmarshalBGPExtCommunity(b []byte) ([]ExtCommunity, error) {
 	exts := make([]ExtCommunity, 0)
 	for p := 0; p < len(b); {
-		glog.V(6).Infof("Extended community: %s", tools.MessageHex(b[p:p+8]))
+		if glog.V(6) {
+			glog.Infof("Extended community: %s", tools.MessageHex(b[p:p+8]))
+		}
 		ext, err := makeExtCommunity(b[p : p+8])
 		if err != nil {
 			return nil, err

--- a/pkg/bgp/mp-reach-nlri.go
+++ b/pkg/bgp/mp-reach-nlri.go
@@ -149,7 +149,9 @@ func (mp *MPReachNLRI) GetNLRILU() (*base.MPNLRI, error) {
 
 // UnmarshalMPReachNLRI builds MP Reach NLRI attributes
 func UnmarshalMPReachNLRI(b []byte, srv6 bool) (MPNLRI, error) {
-	glog.V(6).Infof("MPReachNLRI Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("MPReachNLRI Raw: %s", tools.MessageHex(b))
+	}
 	if len(b) == 0 {
 		return nil, fmt.Errorf("NLRI length is 0")
 	}

--- a/pkg/bgp/mp-unreach-nlri.go
+++ b/pkg/bgp/mp-unreach-nlri.go
@@ -113,7 +113,9 @@ func (mp *MPUnReachNLRI) GetNLRILU() (*base.MPNLRI, error) {
 
 // UnmarshalMPUnReachNLRI builds MP Reach NLRI attributes
 func UnmarshalMPUnReachNLRI(b []byte) (MPNLRI, error) {
-	glog.V(6).Infof("MPUnReachNLRI Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("MPUnReachNLRI Raw: %s", tools.MessageHex(b))
+	}
 	if len(b) == 0 {
 		return nil, fmt.Errorf("NLRI length is 0")
 	}

--- a/pkg/bgpls/app_spec_link_attr.go
+++ b/pkg/bgpls/app_spec_link_attr.go
@@ -21,7 +21,9 @@ type AppSpecLinkAttr struct {
 
 // UnmarshalAppSpecLinkAttr builds Application Specific Link Attributes object
 func UnmarshalAppSpecLinkAttr(b []byte) (*AppSpecLinkAttr, error) {
-	glog.V(6).Infof("App SpecLink Attr Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("App SpecLink Attr Raw: %s", tools.MessageHex(b))
+	}
 	if len(b) < 4 {
 		return nil, fmt.Errorf("invalid length %d of FlexAlgo definition tlv", len(b))
 	}

--- a/pkg/bgpls/bgpls-nlri.go
+++ b/pkg/bgpls/bgpls-nlri.go
@@ -634,7 +634,9 @@ func (ls *NLRI) GetSRAdjacencySID() ([]*sr.AdjacencySIDTLV, error) {
 
 // UnmarshalBGPLSNLRI builds Prefix NLRI object
 func UnmarshalBGPLSNLRI(b []byte) (*NLRI, error) {
-	glog.V(6).Infof("BGPLSNLRI Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("BGPLSNLRI Raw: %s", tools.MessageHex(b))
+	}
 	if len(b) == 0 {
 		return nil, fmt.Errorf("NLRI length is 0")
 	}

--- a/pkg/bgpls/bgpls-tlv.go
+++ b/pkg/bgpls/bgpls-tlv.go
@@ -17,7 +17,9 @@ type TLV struct {
 
 // UnmarshalBGPLSTLV builds Collection of BGP-LS TLVs
 func UnmarshalBGPLSTLV(b []byte) ([]TLV, error) {
-	glog.V(6).Infof("BGPLSTLV Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("BGPLSTLV Raw: %s", tools.MessageHex(b))
+	}
 	lstlvs := make([]TLV, 0)
 	for p := 0; p < len(b); {
 		lstlv := TLV{}

--- a/pkg/bgpls/flexalgo.go
+++ b/pkg/bgpls/flexalgo.go
@@ -22,7 +22,9 @@ type FlexAlgoDefinition struct {
 
 // UnmarshalFlexAlgoDefinition builds Flexible Algorithm Definition (FAD) TLV object
 func UnmarshalFlexAlgoDefinition(b []byte) (*FlexAlgoDefinition, error) {
-	glog.V(6).Infof("FlexAlgo Definition Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("FlexAlgo Definition Raw: %s", tools.MessageHex(b))
+	}
 	if len(b) < 4 {
 		return nil, fmt.Errorf("invalid length %d of FlexAlgo definition tlv", len(b))
 	}
@@ -60,7 +62,9 @@ type FlexAlgoPrefixMetric struct {
 
 // UnmarshalFlexAlgoPrefixMetric builds Flexible Algorithm Prefix Metric TLV object
 func UnmarshalFlexAlgoPrefixMetric(b []byte) (*FlexAlgoPrefixMetric, error) {
-	glog.V(6).Infof("FlexAlgo Prefix Metric Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("FlexAlgo Prefix Metric Raw: %s", tools.MessageHex(b))
+	}
 	if len(b) < 8 {
 		return nil, fmt.Errorf("invalid length %d of FlexAlgo prefix metric tlv", len(b))
 	}

--- a/pkg/bmp/common-header.go
+++ b/pkg/bmp/common-header.go
@@ -21,7 +21,9 @@ type CommonHeader struct {
 
 // UnmarshalCommonHeader processes Common Header and returns BMPCommonHeader object
 func UnmarshalCommonHeader(b []byte) (*CommonHeader, error) {
-	glog.V(6).Infof("BMP CommonHeader Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("BMP CommonHeader Raw: %s", tools.MessageHex(b))
+	}
 	ch := &CommonHeader{}
 	if b[0] != 3 {
 		return nil, fmt.Errorf("invalid version in common header, expected 3 found %d", b[0])

--- a/pkg/bmp/information-tlv.go
+++ b/pkg/bmp/information-tlv.go
@@ -17,7 +17,9 @@ type InformationalTLV struct {
 
 // UnmarshalTLV builds a slice of Informational TLVs
 func UnmarshalTLV(b []byte) ([]InformationalTLV, error) {
-	glog.V(6).Infof("BMP Informational TLV Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("BMP Informational TLV Raw: %s", tools.MessageHex(b))
+	}
 	tlvs := make([]InformationalTLV, 0)
 	for i := 0; i < len(b); {
 		// Extracting TLV type 2 bytes

--- a/pkg/bmp/initiation.go
+++ b/pkg/bmp/initiation.go
@@ -15,7 +15,9 @@ type InitiationMessage struct {
 
 // UnmarshalInitiationMessage processes Initiation Message and returns BMPInitiationMessage object
 func UnmarshalInitiationMessage(b []byte) (*InitiationMessage, error) {
-	glog.V(6).Infof("BMP Initiation Message Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("BMP Initiation Message Raw: %s", tools.MessageHex(b))
+	}
 	im := &InitiationMessage{
 		TLV: make([]InformationalTLV, 0),
 	}

--- a/pkg/bmp/peer-down.go
+++ b/pkg/bmp/peer-down.go
@@ -15,7 +15,9 @@ type PeerDownMessage struct {
 
 // UnmarshalPeerDownMessage processes Peer Down message and returns BMPPeerDownMessage object
 func UnmarshalPeerDownMessage(b []byte) (*PeerDownMessage, error) {
-	glog.V(6).Infof("BMP Peer Down Message Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("BMP Peer Down Message Raw: %s", tools.MessageHex(b))
+	}
 	pdw := &PeerDownMessage{
 		Data: make([]byte, len(b)-1),
 	}

--- a/pkg/bmp/peer-up.go
+++ b/pkg/bmp/peer-up.go
@@ -20,7 +20,9 @@ type PeerUpMessage struct {
 
 // UnmarshalPeerUpMessage processes Peer Up message and returns BMPPeerUpMessage object
 func UnmarshalPeerUpMessage(b []byte) (*PeerUpMessage, error) {
-	glog.V(6).Infof("BMP Peer Up Message Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("BMP Peer Up Message Raw: %s", tools.MessageHex(b))
+	}
 	var err error
 	pu := &PeerUpMessage{
 		LocalAddress: make([]byte, 16),

--- a/pkg/bmp/per-peer-header.go
+++ b/pkg/bmp/per-peer-header.go
@@ -69,7 +69,9 @@ func (p *PerPeerHeader) Serialize() ([]byte, error) {
 
 // UnmarshalPerPeerHeader processes Per-Peer header
 func UnmarshalPerPeerHeader(b []byte) (*PerPeerHeader, error) {
-	glog.V(6).Infof("BMP Per Peer Header Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("BMP Per Peer Header Raw: %s", tools.MessageHex(b))
+	}
 	pph := &PerPeerHeader{
 		PeerDistinguisher: make([]byte, 8), // newPeerDistinguisher(),
 		PeerAddress:       make([]byte, 16),

--- a/pkg/bmp/route-monitor.go
+++ b/pkg/bmp/route-monitor.go
@@ -15,7 +15,9 @@ type RouteMonitor struct {
 
 // UnmarshalBMPRouteMonitorMessage builds BMP Route Monitor object
 func UnmarshalBMPRouteMonitorMessage(b []byte) (*RouteMonitor, error) {
-	glog.V(6).Infof("BMP Route Monitor Message Raw: %s length: %d", tools.MessageHex(b), len(b))
+	if glog.V(6) {
+		glog.Infof("BMP Route Monitor Message Raw: %s length: %d", tools.MessageHex(b), len(b))
+	}
 	rm := RouteMonitor{}
 	// 16 bytes marker + 2 bytes update length + 1 byte of type
 	if len(b) < 19 {

--- a/pkg/bmp/stats-report.go
+++ b/pkg/bmp/stats-report.go
@@ -16,7 +16,9 @@ type StatsReport struct {
 
 // UnmarshalBMPStatsReportMessage builds BMP Stats Reports object
 func UnmarshalBMPStatsReportMessage(b []byte) (*StatsReport, error) {
-	glog.V(6).Infof("BMP Stats Report Message Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("BMP Stats Report Message Raw: %s", tools.MessageHex(b))
+	}
 	sr := StatsReport{}
 	p := 0
 	l := int32(binary.BigEndian.Uint32(b[p : p+4]))

--- a/pkg/evpn/evpn.go
+++ b/pkg/evpn/evpn.go
@@ -92,7 +92,9 @@ func (n *NLRI) GetEVPNLabel() []uint32 {
 
 // UnmarshalEVPNNLRI instantiates an EVPN NLRI object
 func UnmarshalEVPNNLRI(b []byte) (*Route, error) {
-	glog.V(6).Infof("EVPN NLRI Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("EVPN NLRI Raw: %s", tools.MessageHex(b))
+	}
 	if len(b) == 0 {
 		return nil, fmt.Errorf("NLRI length is 0")
 	}

--- a/pkg/kafka/kafka-publisher.go
+++ b/pkg/kafka/kafka-publisher.go
@@ -112,7 +112,9 @@ func (p *publisher) produceMessage(topic string, key []byte, msg []byte) error {
 		glog.Errorf("Failed to write test message to the topic %s with error: %+v", topic, err)
 		return err
 	}
-	glog.V(6).Infof("Successfully wrote %d bytes to Kafka topic %s", n, topic)
+	if glog.V(6) {
+		glog.Infof("Successfully wrote %d bytes to Kafka topic %s", n, topic)
+	}
 
 	return nil
 }

--- a/pkg/l3vpn/l3-vpn.go
+++ b/pkg/l3vpn/l3-vpn.go
@@ -12,7 +12,9 @@ import (
 
 // UnmarshalL3VPNNLRI instantiates a L3 VPN NLRI object
 func UnmarshalL3VPNNLRI(b []byte, srv6 ...bool) (*base.MPNLRI, error) {
-	glog.V(6).Infof("L3VPN NLRI Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("L3VPN NLRI Raw: %s", tools.MessageHex(b))
+	}
 	if len(b) == 0 {
 		return nil, fmt.Errorf("NLRI length is 0")
 	}

--- a/pkg/ls/ls-nlri71.go
+++ b/pkg/ls/ls-nlri71.go
@@ -29,7 +29,9 @@ type NLRI71 struct {
 
 // UnmarshalLSNLRI71 builds Link State NLRI object ofor SAFI 71
 func UnmarshalLSNLRI71(b []byte) (*NLRI71, error) {
-	glog.V(6).Infof("LSNLRI71 Raw: %s ", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("LSNLRI71 Raw: %s ", tools.MessageHex(b))
+	}
 	if len(b) == 0 {
 		return nil, fmt.Errorf("NLRI length is 0")
 	}

--- a/pkg/message/ls-srv6-sid.go
+++ b/pkg/message/ls-srv6-sid.go
@@ -3,7 +3,6 @@ package message
 import (
 	"fmt"
 
-	"github.com/golang/glog"
 	"github.com/sbezverk/gobmp/pkg/bgp"
 	"github.com/sbezverk/gobmp/pkg/bmp"
 	"github.com/sbezverk/gobmp/pkg/srv6"
@@ -38,7 +37,6 @@ func (p *producer) lsSRv6SID(nlri6 *srv6.SIDNLRI, nextHop string, op int, ph *bm
 	msg.SRv6SID = nlri6.GetSRv6SID()
 	ls, err := update.GetNLRI29()
 	if err == nil {
-		glog.V(6).Infof("nlri29 attributes: %+v", ls.GetAllAttribute())
 		msg.SRv6EndpointBehavior = ls.GetSRv6EndpointBehavior()
 		msg.SRv6BGPPeerNodeSID = ls.GetSRv6BGPPeerNodeSID()
 		msg.SRv6SIDStructure = ls.GetSRv6SIDStructure()

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -91,10 +91,14 @@ func parsingWorker(b []byte, producerQueue chan bmp.Message) {
 			}
 		case bmp.TerminationMsg:
 			glog.V(5).Infof("Termination message")
-			glog.V(6).Infof("Message: %+v", b)
+			if glog.V(6) {
+				glog.Infof("Content: %s", tools.MessageHex(b))
+			}
 		case bmp.RouteMirrorMsg:
 			glog.V(5).Infof("Route Mirroring message")
-			glog.V(6).Infof("Message: %+v", b)
+			if glog.V(6) {
+				glog.Infof("Content:%s", tools.MessageHex(b))
+			}
 		}
 		perPerHeaderLen = 0
 		p += (int(ch.MessageLength) - bmp.CommonHeaderLength)

--- a/pkg/prefixsid/prefixsid.go
+++ b/pkg/prefixsid/prefixsid.go
@@ -44,7 +44,9 @@ type PSid struct {
 
 // UnmarshalBGPAttrPrefixSID instantiates a prefix sid object
 func UnmarshalBGPAttrPrefixSID(b []byte) (*PSid, error) {
-	glog.V(6).Infof("UnmarshalBGPAttrPrefixSID Raw: %+v", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("UnmarshalBGPAttrPrefixSID Raw: %+v", tools.MessageHex(b))
+	}
 	psid := PSid{
 		LabelIndex:     nil,
 		OriginatorSRGB: nil,

--- a/pkg/sr/sr-adjacencysid.go
+++ b/pkg/sr/sr-adjacencysid.go
@@ -15,7 +15,9 @@ type AdjacencySIDTLV struct {
 
 // UnmarshalAdjacencySIDTLV builds Adjacency SID TLV Object
 func UnmarshalAdjacencySIDTLV(b []byte) (*AdjacencySIDTLV, error) {
-	glog.V(6).Infof("Adjacency SID Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("Adjacency SID Raw: %s", tools.MessageHex(b))
+	}
 	asid := AdjacencySIDTLV{}
 	p := 0
 	asid.Flags = b[p]

--- a/pkg/sr/sr-capabilitiy-tlv.go
+++ b/pkg/sr/sr-capabilitiy-tlv.go
@@ -17,7 +17,9 @@ type CapabilityTLV struct {
 
 // UnmarshalSRCapabilityTLV builds SR Capability TLV object
 func UnmarshalSRCapabilityTLV(b []byte) ([]CapabilityTLV, error) {
-	glog.V(6).Infof("SR Capability TLV Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("SR Capability TLV Raw: %s", tools.MessageHex(b))
+	}
 	caps := make([]CapabilityTLV, 0)
 	for p := 0; p < len(b); {
 		cap := CapabilityTLV{}

--- a/pkg/sr/sr-capability.go
+++ b/pkg/sr/sr-capability.go
@@ -14,7 +14,9 @@ type Capability struct {
 
 // UnmarshalSRCapability builds SR Capability object
 func UnmarshalSRCapability(b []byte) (*Capability, error) {
-	glog.V(6).Infof("SR Capability Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("SR Capability Raw: %s", tools.MessageHex(b))
+	}
 	cap := Capability{}
 	p := 0
 	cap.Flags = b[p]

--- a/pkg/sr/sr-local-block-tlv.go
+++ b/pkg/sr/sr-local-block-tlv.go
@@ -18,7 +18,9 @@ type LocalBlockTLV struct {
 
 // UnmarshalSRLocalBlockTLV builds SR LocalBlock TLV object
 func UnmarshalSRLocalBlockTLV(b []byte) ([]LocalBlockTLV, error) {
-	glog.V(6).Infof("SR LocalBlock TLV Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("SR LocalBlock TLV Raw: %s", tools.MessageHex(b))
+	}
 	tlvs := make([]LocalBlockTLV, 0)
 	for p := 0; p < len(b); {
 		tlv := LocalBlockTLV{}

--- a/pkg/sr/sr-local-block.go
+++ b/pkg/sr/sr-local-block.go
@@ -14,7 +14,9 @@ type LocalBlock struct {
 
 // UnmarshalSRLocalBlock builds SR Local Block object
 func UnmarshalSRLocalBlock(b []byte) (*LocalBlock, error) {
-	glog.V(6).Infof("SR Local BLock Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("SR Local BLock Raw: %s", tools.MessageHex(b))
+	}
 	lb := LocalBlock{}
 	p := 0
 	lb.Flags = b[p]

--- a/pkg/sr/sr-prefixsid.go
+++ b/pkg/sr/sr-prefixsid.go
@@ -15,7 +15,9 @@ type PrefixSIDTLV struct {
 
 // UnmarshalPrefixSIDTLV builds Prefix SID TLV Object
 func UnmarshalPrefixSIDTLV(b []byte) (*PrefixSIDTLV, error) {
-	glog.V(6).Infof("Prefix SID TLV Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("Prefix SID TLV Raw: %s", tools.MessageHex(b))
+	}
 	psid := PrefixSIDTLV{}
 	p := 0
 	psid.Flags = b[p]

--- a/pkg/srv6/srv6-bgp-peer-node-sid-tlv.go
+++ b/pkg/srv6/srv6-bgp-peer-node-sid-tlv.go
@@ -18,7 +18,9 @@ type BGPPeerNodeSID struct {
 
 // UnmarshalSRv6BGPPeerNodeSIDTLV builds SRv6 BGP Peer Node SID TLV object
 func UnmarshalSRv6BGPPeerNodeSIDTLV(b []byte) (*BGPPeerNodeSID, error) {
-	glog.V(6).Infof("SRv6 BGP Peer Node SID TLV Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("SRv6 BGP Peer Node SID TLV Raw: %s", tools.MessageHex(b))
+	}
 	bgp := BGPPeerNodeSID{}
 	p := 0
 	bgp.Flag = b[p]

--- a/pkg/srv6/srv6-capabilities.go
+++ b/pkg/srv6/srv6-capabilities.go
@@ -15,7 +15,9 @@ type CapabilityTLV struct {
 
 // UnmarshalSRv6CapabilityTLV builds SRv6 Capability TLV object
 func UnmarshalSRv6CapabilityTLV(b []byte) (*CapabilityTLV, error) {
-	glog.V(6).Infof("SRv6 Capability TLV Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("SRv6 Capability TLV Raw: %s", tools.MessageHex(b))
+	}
 	cap := CapabilityTLV{}
 	p := 0
 	cap.Flag = binary.BigEndian.Uint16(b[p : p+2])

--- a/pkg/srv6/srv6-endpoint-behavior.go
+++ b/pkg/srv6/srv6-endpoint-behavior.go
@@ -17,7 +17,9 @@ type EndpointBehavior struct {
 
 // UnmarshalSRv6EndpointBehaviorTLV builds SRv6 Endpoint Behavior TLV object
 func UnmarshalSRv6EndpointBehaviorTLV(b []byte) (*EndpointBehavior, error) {
-	glog.V(6).Infof("SRv6 End.X SID TLV Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("SRv6 End.X SID TLV Raw: %s", tools.MessageHex(b))
+	}
 	e := EndpointBehavior{}
 	p := 0
 	e.EndpointBehavior = binary.BigEndian.Uint16(b[p : p+2])

--- a/pkg/srv6/srv6-endxsidtlv.go
+++ b/pkg/srv6/srv6-endxsidtlv.go
@@ -30,7 +30,9 @@ const (
 
 // UnmarshalSRv6EndXSIDTLV builds SRv6 End.X SID TLV object
 func UnmarshalSRv6EndXSIDTLV(b []byte) (*EndXSIDTLV, error) {
-	glog.V(6).Infof("SRv6 End.X SID TLV Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("SRv6 End.X SID TLV Raw: %s", tools.MessageHex(b))
+	}
 	if len(b) < EndXSIDTLVMinLen {
 		return nil, fmt.Errorf("invalid length of data %d, expected minimum of %d", len(b), EndXSIDTLVMinLen)
 	}

--- a/pkg/srv6/srv6-informationaltlv.go
+++ b/pkg/srv6/srv6-informationaltlv.go
@@ -16,7 +16,9 @@ type SIDInformationTLV struct {
 
 // UnmarshalSRv6SIDInformationTLV builds SRv6 SID Information TLV slice
 func UnmarshalSRv6SIDInformationTLV(b []byte) ([]SIDInformationTLV, error) {
-	glog.V(6).Infof("SRv6 SID Information TLV Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("SRv6 SID Information TLV Raw: %s", tools.MessageHex(b))
+	}
 	tlvs := make([]SIDInformationTLV, 0)
 	for p := 0; p < len(b); {
 		tlv := SIDInformationTLV{}

--- a/pkg/srv6/srv6-l3-service.go
+++ b/pkg/srv6/srv6-l3-service.go
@@ -170,7 +170,9 @@ func (l3s *L3Service) UnmarshalJSON(b []byte) error {
 
 // UnmarshalSRv6L3Service instantiate from the slice of byte SRv6 L3 Service Object
 func UnmarshalSRv6L3Service(b []byte) (*L3Service, error) {
-	glog.V(6).Infof("SRv6 L3 Service Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("SRv6 L3 Service Raw: %s", tools.MessageHex(b))
+	}
 	l3 := L3Service{
 		SubTLVs: make(map[uint8][]SubTLV),
 	}

--- a/pkg/srv6/srv6-locator.go
+++ b/pkg/srv6/srv6-locator.go
@@ -20,7 +20,9 @@ type LocatorTLV struct {
 
 // UnmarshalSRv6LocatorTLV builds a SRv6 Locator object
 func UnmarshalSRv6LocatorTLV(b []byte) (*LocatorTLV, error) {
-	glog.V(6).Infof("SRv6 Locator TLV Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("SRv6 Locator TLV Raw: %s", tools.MessageHex(b))
+	}
 	p := 0
 	loc := LocatorTLV{}
 	loc.Flag = b[p]

--- a/pkg/srv6/srv6-sid-structure-tlv.go
+++ b/pkg/srv6/srv6-sid-structure-tlv.go
@@ -16,7 +16,9 @@ type SIDStructure struct {
 
 // UnmarshalSRv6SIDStructureTLV builds SRv6 SID Structure TLV object
 func UnmarshalSRv6SIDStructureTLV(b []byte) (*SIDStructure, error) {
-	glog.V(6).Infof("SRv6 SID Structure TLV Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("SRv6 SID Structure TLV Raw: %s", tools.MessageHex(b))
+	}
 	st := SIDStructure{}
 	p := 0
 	st.LBLength = b[p]

--- a/pkg/srv6/srv6-siddescriptor.go
+++ b/pkg/srv6/srv6-siddescriptor.go
@@ -17,7 +17,9 @@ type SIDDescriptor struct {
 
 // UnmarshalSRv6SIDDescriptor build SRv6 Descriptor Object
 func UnmarshalSRv6SIDDescriptor(b []byte) (*SIDDescriptor, error) {
-	glog.V(6).Infof("SRv6 SID Descriptor Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("SRv6 SID Descriptor Raw: %s", tools.MessageHex(b))
+	}
 	srd := SIDDescriptor{}
 	for p := 0; p < len(b); {
 		t := binary.BigEndian.Uint16(b[p : p+2])

--- a/pkg/srv6/srv6-sidnlri.go
+++ b/pkg/srv6/srv6-sidnlri.go
@@ -78,7 +78,9 @@ func (sr *SIDNLRI) GetSRv6SID() []string {
 
 // UnmarshalSRv6SIDNLRI builds SRv6SIDNLRI NLRI object
 func UnmarshalSRv6SIDNLRI(b []byte) (*SIDNLRI, error) {
-	glog.V(6).Infof("SRv6 SID NLRI Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("SRv6 SID NLRI Raw: %s", tools.MessageHex(b))
+	}
 	if len(b) == 0 {
 		return nil, fmt.Errorf("NLRI length is 0")
 	}

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -18,7 +18,7 @@ func MessageHex(b []byte) string {
 	copy(buffer[p:], []byte("[ "))
 	p += 2
 	for i := 0; i < len(b); i++ {
-		copy(buffer[p:], []byte("0x"+convertToHex(b[i])))
+		copy(buffer[p:], []byte("0x"+ConvertToHex(b[i])))
 		p += 4
 		if i < len(b)-1 {
 			copy(buffer[p:], []byte(", "))
@@ -30,11 +30,12 @@ func MessageHex(b []byte) string {
 	return string(buffer)
 }
 
-func convertToHex(b byte) string {
+// ConvertToHex returns a hexadecimal string representation of a byte
+func ConvertToHex(b byte) string {
 	f := getHex(int(b / 16))
 	s := getHex(int(b % 16))
 
-	return string(f) + string(s)
+	return string([]byte{f, s})
 }
 
 func getHex(i int) byte {

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -18,7 +18,7 @@ func MessageHex(b []byte) string {
 	copy(buffer[p:], []byte("[ "))
 	p += 2
 	for i := 0; i < len(b); i++ {
-		copy(buffer[p:], []byte(fmt.Sprintf("0x%02x", b[i])))
+		copy(buffer[p:], []byte("0x"+convertToHex(b[i])))
 		p += 4
 		if i < len(b)-1 {
 			copy(buffer[p:], []byte(", "))
@@ -28,6 +28,21 @@ func MessageHex(b []byte) string {
 	copy(buffer[p:], []byte(" ]"))
 
 	return string(buffer)
+}
+
+func convertToHex(b byte) string {
+	f := getHex(int(b / 16))
+	s := getHex(int(b % 16))
+
+	return string(f) + string(s)
+}
+
+func getHex(i int) byte {
+	table := []byte{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'}
+	if i > len(table) {
+		return table[0]
+	}
+	return table[i]
 }
 
 // HostAddrValidator parser host address passed as a string, and make sure it follows X.X.X.X:YYZZ format

--- a/pkg/tools/tools_test.go
+++ b/pkg/tools/tools_test.go
@@ -31,7 +31,7 @@ func TestMessageHex(t *testing.T) {
 
 func TestConvertToHex(t *testing.T) {
 	for b := 0; b <= 0xff; b++ {
-		s := convertToHex(byte(b))
+		s := ConvertToHex(byte(b))
 		v, _ := hex.DecodeString(s)
 		if int(v[0]) != b {
 			t.Errorf("original %d and decoded %d values do not match", b, v)

--- a/pkg/tools/tools_test.go
+++ b/pkg/tools/tools_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"encoding/hex"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -25,5 +26,15 @@ func TestMessageHex(t *testing.T) {
 				t.Errorf("%+v", diff)
 			}
 		})
+	}
+}
+
+func TestConvertToHex(t *testing.T) {
+	for b := 0; b <= 0xff; b++ {
+		s := convertToHex(byte(b))
+		v, _ := hex.DecodeString(s)
+		if int(v[0]) != b {
+			t.Errorf("original %d and decoded %d values do not match", b, v)
+		}
 	}
 }

--- a/pkg/topology/processor/processor.go
+++ b/pkg/topology/processor/processor.go
@@ -156,6 +156,7 @@ func (p *processor) procWorker(m *queueMsg) {
 			return
 		}
 	}
-
-	glog.V(6).Infof("message of type %d was sent to the database for further processing", m.msgType)
+	if glog.V(6) {
+		glog.Infof("message of type %d was sent to the database for further processing", m.msgType)
+	}
 }

--- a/pkg/unicast/unicast.go
+++ b/pkg/unicast/unicast.go
@@ -12,7 +12,9 @@ import (
 
 // UnmarshalUnicastNLRI builds MP NLRI object from the slice of bytes
 func UnmarshalUnicastNLRI(b []byte) (*base.MPNLRI, error) {
-	glog.V(6).Infof("MP Unicast NLRI Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("MP Unicast NLRI Raw: %s", tools.MessageHex(b))
+	}
 	if len(b) == 0 {
 		return nil, fmt.Errorf("NLRI length is 0")
 	}
@@ -43,7 +45,9 @@ func UnmarshalUnicastNLRI(b []byte) (*base.MPNLRI, error) {
 
 // UnmarshalLUNLRI builds MP NLRI object from the slice of bytes
 func UnmarshalLUNLRI(b []byte) (*base.MPNLRI, error) {
-	glog.V(6).Infof("MP Label Unicast NLRI Raw: %s", tools.MessageHex(b))
+	if glog.V(6) {
+		glog.Infof("MP Label Unicast NLRI Raw: %s", tools.MessageHex(b))
+	}
 	mpnlri := base.MPNLRI{
 		NLRI: make([]base.Route, 0),
 	}


### PR DESCRIPTION
Getting rid of Sprintf in MessageHex and refactoring logging allowed to save tons of cpu cycles to improve over all performance.