### PR TITLE
normalize state change to be consistent with other messages

### DIFF
--- a/pkg/message/peer.go
+++ b/pkg/message/peer.go
@@ -19,9 +19,9 @@ func (p *producer) producePeerMessage(op int, msg bmp.Message) {
 		glog.Errorf("got invalid Payload type in bmp.Message")
 		return
 	}
-	action := "up"
+	action := "add"
 	if op == peerDown {
-		action = "down"
+		action = "del"
 	}
 
 	var m PeerStateChange

--- a/pkg/message/types.go
+++ b/pkg/message/types.go
@@ -14,7 +14,7 @@ type PeerStateChange struct {
 	Key              string `json:"_key,omitempty"`
 	ID               string `json:"_id,omitempty"`
 	Rev              string `json:"_rev,omitempty"`
-	Action           string `json:"action,omitempty"` // Action can be "up" or "down"
+	Action           string `json:"action,omitempty"` // Action can be "add" for peer up and "del" for peer down message
 	Sequence         int    `json:"sequence,omitempty"`
 	Hash             string `json:"hash,omitempty"`
 	RouterHash       string `json:"router_hash,omitempty"`


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>

To be able to process messages with a generic function, this PR changes peer state Change action from up/down to add/del as with other messages.