### PR TITLE
Srte fixes

### DIFF
--- a/BMP.md
+++ b/BMP.md
@@ -14,7 +14,7 @@ base attribute
 GoBMP will collect and parse the following BMP message types (details below):
 ```
 peer
-unicast_prefix 
+unicast_prefix
 ls_node
 ls_link
 ls_prefix
@@ -34,23 +34,23 @@ https://www.snas.io/docs/
 2: (sequence): 84
 3: (hash): d67b274c33ea1ff0ffe9dd781938b0de
 4: (router_hash): fb5d34c594dff80c59019b6d132185f7
-5: (name): 
+5: (name):
 6: (remote_bgp_id): 10.0.0.7
 7: (router_ip): 10.1.34.1
 8: (timestamp): 2020-03-18 14:36:54.114438
 9: (remote_asn): 100000
 10: (remote_ip): 10.0.0.7
 11: (peer_rd): 0:0
-12: (remote_port): 
-13: (local_asn): 
-14: (local_ip): 
-15: (local_port): 
-16: (local_bgp_id): 
-17: (info_data): 
-18: (adv_cap): 
-19: (recv_cap): 
-20: (remote_holddown): 
-21: (adv_holddown): 
+12: (remote_port):
+13: (local_asn):
+14: (local_ip):
+15: (local_port):
+16: (local_bgp_id):
+17: (info_data):
+18: (adv_cap):
+19: (recv_cap):
+20: (remote_holddown):
+21: (adv_holddown):
 22: (bmp_reason): 1
 23: (bgp_error_code): 6
 24: (bgp_error_sub_code): 4
@@ -60,7 +60,7 @@ https://www.snas.io/docs/
 28: (is_ipv4): 1
 29: (is_locrib): 0
 30: (is_locrib_filtered): 0
-31: (table_name): 
+31: (table_name):
 
 // Peer Up
 
@@ -68,7 +68,7 @@ https://www.snas.io/docs/
 2: (sequence): 93
 3: (hash): d67b274c33ea1ff0ffe9dd781938b0de
 4: (router_hash): fb5d34c594dff80c59019b6d132185f7
-5: (name): 
+5: (name):
 6: (remote_bgp_id): 10.0.0.7
 7: (router_ip): 10.1.34.1
 8: (timestamp): 2020-03-18 14:37:13.836872
@@ -80,21 +80,21 @@ https://www.snas.io/docs/
 14: (local_ip): 10.0.0.10
 15: (local_port): 179
 16: (local_bgp_id): 10.0.0.10
-17: (info_data): 
+17: (info_data):
 18: (adv_cap): MPBGP (1) : afi=1 safi=1 : Unicast IPv4, MPBGP (1) : afi=1 safi=4 : Labeled Unicast IPv4, MPBGP (1) : afi=1 safi=128 : MPLS-Labeled VPN IPv4, MPBGP (1) : afi=2 safi=1 : Unicast IPv6, MPBGP (1) : afi=2 safi=128 : MPLS-Labeled VPN IPv6, MPBGP (1) : afi=16388 safi=71 : BGP-LS BGP-LS, MPBGP (1) : afi=1 safi=73 :  IPv4, Route Refresh Old (128), Route Refresh (2), 4 Octet ASN (65), ADD Path (69) : afi=1 safi=1 send/receive=3 : Unicast IPv4 Send/Receive, ADD Path (69) : afi=1 safi=4 send/receive=3 : Labeled Unicast IPv4 Send/Receive, ADD Path (69) : afi=2 safi=1 send/receive=3 : Unicast IPv6 Send/Receive, 5
 19: (recv_cap): MPBGP (1) : afi=1 safi=1 : Unicast IPv4, MPBGP (1) : afi=1 safi=4 : Labeled Unicast IPv4, MPBGP (1) : afi=1 safi=128 : MPLS-Labeled VPN IPv4, MPBGP (1) : afi=2 safi=1 : Unicast IPv6, MPBGP (1) : afi=2 safi=128 : MPLS-Labeled VPN IPv6, MPBGP (1) : afi=16388 safi=71 : BGP-LS BGP-LS, MPBGP (1) : afi=1 safi=73 :  IPv4, Route Refresh Old (128), Route Refresh (2), 4 Octet ASN (65), ADD Path (69) : afi=1 safi=1 send/receive=3 : Unicast IPv4 Send/Receive, ADD Path (69) : afi=1 safi=4 send/receive=3 : Labeled Unicast IPv4 Send/Receive, ADD Path (69) : afi=2 safi=1 send/receive=3 : Unicast IPv6 Send/Receive, 5
 20: (remote_holddown): 180
 21: (adv_holddown): 180
-22: (bmp_reason): 
-23: (bgp_error_code): 
-24: (bgp_error_sub_code): 
-25: (error_text): 
+22: (bmp_reason):
+23: (bgp_error_code):
+24: (bgp_error_sub_code):
+25: (error_text):
 26: (is_l): 0
 27: (is_prepolicy): 1
 28: (is_ipv4): 1
 29: (is_locrib): 0
 30: (is_locrib_filtered): 0
-31: (table_name): 
+31: (table_name):
 
 // Peer initialization - any peer message that comes in with action "first" is not needed and should be dropped
 
@@ -111,7 +111,7 @@ https://www.snas.io/docs/
 3: (hash): 5214a8eb996f030b3d96784c1890ab3d
 4: (router_hash): 963b507b39731b0675d3422e6f6be44c
 5: (router_ip): 10.1.62.1
-6: (base_attr_hash): 
+6: (base_attr_hash):
 7: (peer_hash): a4935a0f520cd5f72ed483d2b37f58ae
 8: (peer_ip): 2.2.71.1
 9: (peer_asn): 7100
@@ -119,22 +119,22 @@ https://www.snas.io/docs/
 11: (prefix): 71.71.8.0
 12: (prefix_len): 22
 13: (is_ipv4): 1
-14: (origin): 
-15: (as_path): 
-16: (as_path_count): 
-17: (origin_as): 
-18: (nexthop): 
-19: (med): 
-20: (local_pref): 
-21: (aggregator): 
-22: (community_list): 
-23: (ext_community_list): 
-24: (cluster_list): 
-25: (isatomicagg): 
-26: (is_nexthop_ipv4): 
-27: (originator_id): 
+14: (origin):
+15: (as_path):
+16: (as_path_count):
+17: (origin_as):
+18: (nexthop):
+19: (med):
+20: (local_pref):
+21: (aggregator):
+22: (community_list):
+23: (ext_community_list):
+24: (cluster_list):
+25: (isatomicagg):
+26: (is_nexthop_ipv4):
+27: (originator_id):
 28: (path_id): 0
-29: (labels): 
+29: (labels):
 30: (is_prepolicy): 1
 31: (is_adj_rib_in): 1
 
@@ -160,15 +160,15 @@ https://www.snas.io/docs/
 18: (nexthop): 2.2.71.1
 19: (med): 0
 20: (local_pref): 0
-21: (aggregator): 
-22: (community_list): 
-23: (ext_community_list): 
-24: (cluster_list): 
+21: (aggregator):
+22: (community_list):
+23: (ext_community_list):
+24: (cluster_list):
 25: (isatomicagg): 0
 26: (is_nexthop_ipv4): 1
-27: (originator_id): 
+27: (originator_id):
 28: (path_id): 0
-29: (labels): 
+29: (labels):
 30: (is_prepolicy): 1
 31: (is_adj_rib_in): 1
 ```
@@ -192,11 +192,11 @@ https://www.snas.io/docs/
 13: (routing_id): 0
 14: (ls_id): 0
 15: (mt_id): 0, 2
-16: (ospf_area_id): 
+16: (ospf_area_id):
 17: (isis_area_id): 49.0901
 18: (protocol): IS-IS_L2
-19: (flags): 
-20: (as_path): 
+19: (flags):
+20: (as_path):
 21: (local_pref): 100
 22: (med): 0
 23: (nexthop): 10.0.0.1
@@ -210,7 +210,7 @@ Additional segment routing and SRv6 items not accounted for by OpenBMP:
 BGP-LS TLV Type: 1035 (SR Algorithm) - int (i think)
 BGP-LS TLV Type: 1036 (SR Local Block) - might arrive as a pair of integers
 BGP-LS TLV Type: 1038 (SRv6 Capabilities TLV) - string
-BGP-LS TLV Type: 266 (Node MSD) 
+BGP-LS TLV Type: 266 (Node MSD)
 
 Future:
      +----------+------------------------------+
@@ -239,19 +239,19 @@ Future:
 12: (router_id): 0.0.0.0
 13: (routing_id): 0
 14: (ls_id): 0
-15: (mt_id): 
-16: (ospf_area_id): 
-17: (isis_area_id): 
+15: (mt_id):
+16: (ospf_area_id):
+17: (isis_area_id):
 18: (protocol): IS-IS_L2
-19: (flags): 
-20: (as_path): 
+19: (flags):
+20: (as_path):
 21: (local_pref): 0
 22: (med): 0
-23: (nexthop): 
-24: (name): 
+23: (nexthop):
+24: (name):
 25: (is_prepolicy): 1
 26: (is_adj_rib_in): 1
-27: (ls_sr_capabilities): 
+27: (ls_sr_capabilities):
 
 ```
 #### BMP ls_link message:
@@ -272,10 +272,10 @@ Future:
 12: (router_id): 10.0.0.2
 13: (routing_id): 0
 14: (ls_id): 0
-15: (ospf_area_id): 
-16: (isis_area_id): 
+15: (ospf_area_id):
+16: (isis_area_id):
 17: (protocol): IS-IS_L2
-18: (as_path): 
+18: (as_path):
 19: (local_pref): 100
 20: (med): 0
 21: (nexthop): 10.0.0.1
@@ -290,17 +290,17 @@ Future:
 30: (max_resv_bw): 0
 31: (unresv_bw): 0, 0, 0, 0, 0, 0, 0, 0
 32: (te_default_metric): 1
-33: (link_protection): 
-34: (mpls_proto_mask): 
-35: (srlg): 
-36: (link_name): 
+33: (link_protection):
+34: (mpls_proto_mask):
+35: (srlg):
+36: (link_name):
 37: (remote_node_hash): 6ed5aeb7f5ca0bbea84bdbadb61996e9
 38: (local_node_hash): c2679dc1c0d5615c23b3ec45f59f6b15
 39: (remote_igp_router_id): 0000.0000.0000.0000
 40: (remote_router_id): 10.0.0.0
 41: (local_node_asn): 100000
 42: (remote_node_asn): 100000
-43: (peer_node_sid): 
+43: (peer_node_sid):
 44: (is_prepolicy): 1
 45: (is_adj_rib_in): 1
 46: (ls_adjacency_sid): BVL 0 24004, VL 0 24005
@@ -310,15 +310,15 @@ Additional segment routing not accounted for by OpenBMP:
 BGP-LS TLV Type: 267 (Link MSD)
 per https://tools.ietf.org/html/draft-ietf-idr-bgp-ls-segment-routing-ext-16#section-2.3.2:
 BGP-LS TLV:
-   |     1114    | Unidirectional link delay         
-   |     1115    | Min/Max Unidirectional link delay  
-   |     1116    | Unidirectional Delay Variation    
-   |     1117    | Unidirectional packet loss        
-   |     1118    | Unidirectional residual bandwidth  
-   |     1119    | Unidirectional available bandwidth 
-   |     1120    | Unidirectional bandwidth utilization      
+   |     1114    | Unidirectional link delay
+   |     1115    | Min/Max Unidirectional link delay
+   |     1116    | Unidirectional Delay Variation
+   |     1117    | Unidirectional packet loss
+   |     1118    | Unidirectional residual bandwidth
+   |     1119    | Unidirectional available bandwidth
+   |     1120    | Unidirectional bandwidth utilization
 
-SRv6 items 
+SRv6 items
 
    BGP-LS TLV Type: 1106 (SRv6 End.X SID TLV)
       SRv6 End.X SID TLV:
@@ -327,7 +327,7 @@ SRv6 items
          Algorithm: 0
          Weight: 0
          SID: [ 01 92 01 68 00 08 00 00 00 40 00 00 00 00 00 00  ]
-         
+
 Bonus item (OpenBMP never carried remote node router ID field, which would be very nice to add):
 
    BGP-LS TLV Type: 1030 (IPv4 Router-ID of Remote Node)
@@ -350,13 +350,13 @@ Bonus item (OpenBMP never carried remote node router ID field, which would be ve
 12: (router_id): ::
 13: (routing_id): 0
 14: (ls_id): 0
-15: (ospf_area_id): 
-16: (isis_area_id): 
+15: (ospf_area_id):
+16: (isis_area_id):
 17: (protocol): IS-IS_L2
-18: (as_path): 
+18: (as_path):
 19: (local_pref): 0
 20: (med): 0
-21: (nexthop): 
+21: (nexthop):
 22: (mt_id): 2
 23: (local_link_id): 0
 24: (remote_link_id): 0
@@ -366,22 +366,22 @@ Bonus item (OpenBMP never carried remote node router ID field, which would be ve
 28: (admin_group): 0
 29: (max_link_bw): 0
 30: (max_resv_bw): 0
-31: (unresv_bw): 
+31: (unresv_bw):
 32: (te_default_metric): 0
-33: (link_protection): 
-34: (mpls_proto_mask): 
-35: (srlg): 
-36: (link_name): 
+33: (link_protection):
+34: (mpls_proto_mask):
+35: (srlg):
+36: (link_name):
 37: (remote_node_hash): 9b20947913e9b23f4d5ccf4174e9eba4
 38: (local_node_hash): 6ed5aeb7f5ca0bbea84bdbadb61996e9
 39: (remote_igp_router_id): 0000.0000.0001.0000
 40: (remote_router_id): ::
 41: (local_node_asn): 100000
 42: (remote_node_asn): 100000
-43: (peer_node_sid): 
+43: (peer_node_sid):
 44: (is_prepolicy): 1
 45: (is_adj_rib_in): 1
-46: (ls_adjacency_sid): 
+46: (ls_adjacency_sid):
 
 ```
 #### BMP ls_prefix message:
@@ -403,17 +403,17 @@ Bonus item (OpenBMP never carried remote node router ID field, which would be ve
 12: (router_id): 0.0.0.0
 13: (routing_id): 0
 14: (ls_id): 0
-15: (ospf_area_id): 
-16: (isis_area_id): 
+15: (ospf_area_id):
+16: (isis_area_id):
 17: (protocol): IS-IS_L2
-18: (as_path): 
+18: (as_path):
 19: (local_pref): 100
 20: (med): 0
 21: (nexthop): 10.0.0.1
 22: (local_node_hash): c2679dc1c0d5615c23b3ec45f59f6b15
 23: (mt_id): 0
-24: (ospf_route_type): 
-25: (igp_flags): 
+24: (ospf_route_type):
+25: (igp_flags):
 26: (route_tag): 0
 27: (ext_route_tag): 0
 28: (ospf_fwd_addr): 0.0.0.0
@@ -440,17 +440,17 @@ Bonus item (OpenBMP never carried remote node router ID field, which would be ve
 12: (router_id): 0.0.0.0
 13: (routing_id): 0
 14: (ls_id): 0
-15: (ospf_area_id): 
-16: (isis_area_id): 
+15: (ospf_area_id):
+16: (isis_area_id):
 17: (protocol): IS-IS_L2
-18: (as_path): 
+18: (as_path):
 19: (local_pref): 0
 20: (med): 0
-21: (nexthop): 
+21: (nexthop):
 22: (local_node_hash): 9b20947913e9b23f4d5ccf4174e9eba4
 23: (mt_id): 0
-24: (ospf_route_type): 
-25: (igp_flags): 
+24: (ospf_route_type):
+25: (igp_flags):
 26: (route_tag): 0
 27: (ext_route_tag): 0
 28: (ospf_fwd_addr): 0.0.0.0
@@ -459,7 +459,7 @@ Bonus item (OpenBMP never carried remote node router ID field, which would be ve
 31: (prefix_len): 32
 32: (is_prepolicy): 1
 33: (is_adj_rib_in): 1
-34: (ls_prefix_sid): 
+34: (ls_prefix_sid):
 
 ```
 #### BMP ls_srv6_sid message:
@@ -478,7 +478,7 @@ Protocol ID: IS-IS Level 2                                    // aligns with fie
 Identifier: 0
 Node Descriptor TLVs:
    Node Descriptor Type: 256 (Local Node Descriptors)
-      Node Descriptor Sub TLV Type: 512 (Autonomous System)  
+      Node Descriptor Sub TLV Type: 512 (Autonomous System)
          Autonomous System: 5070                              // aligns with field 9 in openbmp ls_prefix
       Node Descriptor Sub TLV Type: 513 (BGP-LS Identifier)
          BGP-LS Identifier: [ 00 00 00 00  ]                  // aligns with field 14 in openbmp ls_prefix
@@ -498,7 +498,7 @@ Attribute Type: 5 (LOCAL_PREF)
 Attribute Type: 29 (BGP-LS)
 BGP-LS TLVs:
    BGP-LS TLV Type: 1250 (SRv6 Endpoint Function)               // totally new SRv6 "network programming" constructs (this gets awesome)
-      Endpoint Behavior: [ 00 28  ]                            // see also: 
+      Endpoint Behavior: [ 00 28  ]                            // see also:
                                                               // https://tools.ietf.org/html/draft-ietf-spring-srv6-network-programming-13#section-9.2.1
       Flag: 00
       Algorithm: 0
@@ -526,19 +526,19 @@ BGP-LS TLVs:
 12: (prefix_len): 24
 13: (is_ipv4): 1
 14: (origin): incomplete
-15: (as_path): 
+15: (as_path):
 16: (as_path_count): 0
 17: (origin_as): 0
 18: (nexthop): 10.0.0.7
 19: (med): 0
 20: (local_pref): 100
-21: (aggregator): 
-22: (community_list): 
+21: (aggregator):
+22: (community_list):
 23: (ext_community_list): rt=100:100
-24: (cluster_list): 
+24: (cluster_list):
 25: (isatomicagg): 0
 26: (is_nexthop_ipv4): 1
-27: (originator_id): 
+27: (originator_id):
 28: (path_id): 0
 29: (labels): 24000
 30: (is_prepolicy): 1
@@ -553,7 +553,7 @@ BGP-LS TLVs:
 3: (hash): 332047c6ca64451ed6f5ddb92710a29a
 4: (router_hash): fb5d34c594dff80c59019b6d132185f7
 5: (router_ip): 10.1.34.1
-6: (base_attr_hash): 
+6: (base_attr_hash):
 7: (peer_hash): d67b274c33ea1ff0ffe9dd781938b0de
 8: (peer_ip): 10.0.0.7
 9: (peer_asn): 100000
@@ -561,20 +561,20 @@ BGP-LS TLVs:
 11: (prefix): 100.100.100.0
 12: (prefix_len): 24
 13: (is_ipv4): 1
-14: (origin): 
-15: (as_path): 
-16: (as_path_count): 
-17: (origin_as): 
-18: (nexthop): 
-19: (med): 
-20: (local_pref): 
-21: (aggregator): 
-22: (community_list): 
-23: (ext_community_list): 
-24: (cluster_list): 
-25: (isatomicagg): 
-26: (is_nexthop_ipv4): 
-27: (originator_id): 
+14: (origin):
+15: (as_path):
+16: (as_path_count):
+17: (origin_as):
+18: (nexthop):
+19: (med):
+20: (local_pref):
+21: (aggregator):
+22: (community_list):
+23: (ext_community_list):
+24: (cluster_list):
+25: (isatomicagg):
+26: (is_nexthop_ipv4):
+27: (originator_id):
 28: (path_id): 0
 29: (labels): 524288
 30: (is_prepolicy): 1
@@ -587,39 +587,39 @@ BGP-LS TLVs:
 #### BMP evpn message:
 ```
 1: (action): add/del
-5: (router_ip): 
-8: (peer_ip): 
-9: (peer_asn): 
-10: (timestamp): 
+5: (router_ip):
+8: (peer_ip):
+9: (peer_asn):
+10: (timestamp):
 11: (origin):
-12: (as_path): 
-13: (as_path_count): 
-14: (origin_as): 
-15: (nexthop): 
-16: (med): 
-17: (local_pref): 
-18: (aggregator): 
-19: (community_list): 
+12: (as_path):
+13: (as_path_count):
+14: (origin_as):
+15: (nexthop):
+16: (med):
+17: (local_pref):
+18: (aggregator):
+19: (community_list):
 20: (ext_community_list)
-21: (cluster_list): 
-22: (isatomicagg): 
-23: (is_nexthop_ipv4): 
-24: (originator_id): 
-25: (path_id): 
-26: (is_prepolicy): 
-27: (is_adj_rib_in): 
-28: (rd): 
-29: (rd_type): 
-30: (rd_type): 
-31: (orig_router_ip_len): 
-32: (eth_tag): 
-33: (eth_segment_id): 
-34: (mac_len): 
-35: (mac): 
-36: (ip_len): 
-37: (ip): 
-38: (label): 
-39: (label): 
+21: (cluster_list):
+22: (isatomicagg):
+23: (is_nexthop_ipv4):
+24: (originator_id):
+25: (path_id):
+26: (is_prepolicy):
+27: (is_adj_rib_in):
+28: (rd):
+29: (rd_type):
+30: (rd_type):
+31: (orig_router_ip_len):
+32: (eth_tag):
+33: (eth_segment_id):
+34: (mac_len):
+35: (mac):
+36: (ip_len):
+37: (ip):
+38: (label):
+39: (label):
 ```
 ### SRv6 L3VPN Message (v4 overlay, SRv6 underlay)
 
@@ -640,21 +640,21 @@ BGP-LS TLVs:
 12: (prefix_len): 0
 13: (is_ipv4): 1
 14: (origin): incomplete
-15: (as_path): 
+15: (as_path):
 16: (as_path_count): 0
 17: (origin_as): 0
 18: (nexthop): 32.1.0.1                               // wrong
 19: (med): 0
 20: (local_pref): 100
-21: (aggregator): 
-22: (community_list): 
+21: (aggregator):
+22: (community_list):
 23: (ext_community_list): rt=300:10                   // this is ok
-24: (cluster_list): 
+24: (cluster_list):
 25: (isatomicagg): 0
 26: (is_nexthop_ipv4): 1
-27: (originator_id): 
+27: (originator_id):
 28: (path_id): 0
-29: (labels): 1072,0                                  // VPN label should be replaced with SRv6-VPN SID: 2001:1:1:f003:43::/128        
+29: (labels): 1072,0                                  // VPN label should be replaced with SRv6-VPN SID: 2001:1:1:f003:43::/128
 30: (is_prepolicy): 1
 31: (is_adj_rib_in): 1
 32: (vpn_rd): 1679764780:167976478                    // ? should be 300:10
@@ -668,7 +668,7 @@ BGP routing table entry for 3.30.30.0/24, Route Distinguisher: 300:10
 Versions:
   Process           bRIB/RIB  SendTblVer
   Speaker                 73          73
-    Flags: 0x00041001+0x00000000; 
+    Flags: 0x00041001+0x00000000;
 Last Modified: Mar 25 22:41:21.141 for 00:09:05
 Paths: (1 available, best #1)
   Not advertised to any peer
@@ -677,10 +677,10 @@ Paths: (1 available, best #1)
   Not advertised to any peer
   Local
     2001:1:1:f003::1 (metric 1) from 2001:1:1:f010::1 (10.0.0.3), if-handle 0x00000000
-      Received Label 17152 
+      Received Label 17152
       Origin incomplete, metric 0, localpref 100, valid, internal, best, group-best, import-candidate, imported
       Received Path ID 0, Local Path ID 1, version 73
-      Extended community: RT:300:10 
+      Extended community: RT:300:10
       Originator: 10.0.0.3, Cluster list: 10.0.0.10
       PSID-Type:L3, SubTLV Count:1, R:0x00,
        SubTLV:
@@ -726,7 +726,7 @@ Wed Mar 25 22:52:03.008 UTC
 3: (hash): 2f358ba42cb0a8a00c210b0accbf1af4
 4: (router_hash): fb5d34c594dff80c59019b6d132185f7
 5: (router_ip): 10.1.34.1
-6: (base_attr_hash): 
+6: (base_attr_hash):
 7: (peer_hash): 0146fce99cbd730d787487de31452f88
 8: (peer_ip): 2001:1:1:f003::1
 9: (peer_asn): 100000
@@ -734,20 +734,20 @@ Wed Mar 25 22:52:03.008 UTC
 11: (prefix): 3.30.30.0
 12: (prefix_len): 24
 13: (is_ipv4): 1
-14: (origin): 
-15: (as_path): 
-16: (as_path_count): 
-17: (origin_as): 
-18: (nexthop): 
-19: (med): 
-20: (local_pref): 
-21: (aggregator): 
-22: (community_list): 
-23: (ext_community_list): 
-24: (cluster_list): 
-25: (isatomicagg): 
-26: (is_nexthop_ipv4): 
-27: (originator_id): 
+14: (origin):
+15: (as_path):
+16: (as_path_count):
+17: (origin_as):
+18: (nexthop):
+19: (med):
+20: (local_pref):
+21: (aggregator):
+22: (community_list):
+23: (ext_community_list):
+24: (cluster_list):
+25: (isatomicagg):
+26: (is_nexthop_ipv4):
+27: (originator_id):
 28: (path_id): 0
 29: (labels): 524288
 30: (is_prepolicy): 1

--- a/BMP.md
+++ b/BMP.md
@@ -192,18 +192,17 @@ https://www.snas.io/docs/
 13: (routing_id): 0
 14: (ls_id): 0
 15: (mt_id): 0, 2
-16: (ospf_area_id):
-17: (isis_area_id): 49.0901
-18: (protocol): IS-IS_L2
-19: (flags):
-20: (as_path):
-21: (local_pref): 100
-22: (med): 0
-23: (nexthop): 10.0.0.1
-24: (name): R00
-25: (is_prepolicy): 1
-26: (is_adj_rib_in): 1
-27: (ls_sr_capabilities): I 64000 100000
+16: (area_id):
+17: (protocol): IS-IS_L2
+18: (flags):
+19: (as_path):
+20: (local_pref): 100
+21: (med): 0
+22: (nexthop): 10.0.0.1
+23: (name): R00
+24: (is_prepolicy): 1
+25: (is_adj_rib_in): 1
+26: (ls_sr_capabilities): I 64000 100000
 
 Additional segment routing and SRv6 items not accounted for by OpenBMP:
 
@@ -240,18 +239,17 @@ Future:
 13: (routing_id): 0
 14: (ls_id): 0
 15: (mt_id):
-16: (ospf_area_id):
-17: (isis_area_id):
-18: (protocol): IS-IS_L2
-19: (flags):
-20: (as_path):
-21: (local_pref): 0
-22: (med): 0
-23: (nexthop):
-24: (name):
-25: (is_prepolicy): 1
-26: (is_adj_rib_in): 1
-27: (ls_sr_capabilities):
+16: (area_id):
+17: (protocol): IS-IS_L2
+18: (flags):
+19: (as_path):
+20: (local_pref): 0
+21: (med): 0
+22: (nexthop):
+23: (name):
+24: (is_prepolicy): 1
+25: (is_adj_rib_in): 1
+26: (ls_sr_capabilities):
 
 ```
 #### BMP ls_link message:
@@ -272,38 +270,37 @@ Future:
 12: (router_id): 10.0.0.2
 13: (routing_id): 0
 14: (ls_id): 0
-15: (ospf_area_id):
-16: (isis_area_id):
-17: (protocol): IS-IS_L2
-18: (as_path):
-19: (local_pref): 100
-20: (med): 0
-21: (nexthop): 10.0.0.1
-22: (mt_id): 0
-23: (local_link_id): 0
-24: (remote_link_id): 0
-25: (intf_ip): 10.1.1.3
-26: (nei_ip): 10.1.1.2
-27: (igp_metric): 1
-28: (admin_group): 0
-29: (max_link_bw): 1000000
-30: (max_resv_bw): 0
-31: (unresv_bw): 0, 0, 0, 0, 0, 0, 0, 0
-32: (te_default_metric): 1
-33: (link_protection):
-34: (mpls_proto_mask):
-35: (srlg):
-36: (link_name):
-37: (remote_node_hash): 6ed5aeb7f5ca0bbea84bdbadb61996e9
-38: (local_node_hash): c2679dc1c0d5615c23b3ec45f59f6b15
-39: (remote_igp_router_id): 0000.0000.0000.0000
-40: (remote_router_id): 10.0.0.0
-41: (local_node_asn): 100000
-42: (remote_node_asn): 100000
-43: (peer_node_sid):
-44: (is_prepolicy): 1
-45: (is_adj_rib_in): 1
-46: (ls_adjacency_sid): BVL 0 24004, VL 0 24005
+15: (area_id): 0
+16: (protocol): IS-IS_L2
+17: (as_path):
+18: (local_pref): 100
+19: (med): 0
+20: (nexthop): 10.0.0.1
+21: (mt_id): 0
+22: (local_link_id): 0
+23: (remote_link_id): 0
+24: (intf_ip): 10.1.1.3
+25: (nei_ip): 10.1.1.2
+26: (igp_metric): 1
+27: (admin_group): 0
+28: (max_link_bw): 1000000
+29: (max_resv_bw): 0
+30: (unresv_bw): 0, 0, 0, 0, 0, 0, 0, 0
+31: (te_default_metric): 1
+32: (link_protection):
+33: (mpls_proto_mask):
+34: (srlg):
+35: (link_name):
+36: (remote_node_hash): 6ed5aeb7f5ca0bbea84bdbadb61996e9
+37: (local_node_hash): c2679dc1c0d5615c23b3ec45f59f6b15
+38: (remote_igp_router_id): 0000.0000.0000.0000
+39: (remote_router_id): 10.0.0.0
+40: (local_node_asn): 100000
+41: (remote_node_asn): 100000
+42: (peer_node_sid):
+43: (is_prepolicy): 1
+44: (is_adj_rib_in): 1
+45: (ls_adjacency_sid): BVL 0 24004, VL 0 24005
 
 Additional segment routing not accounted for by OpenBMP:
 
@@ -350,38 +347,37 @@ Bonus item (OpenBMP never carried remote node router ID field, which would be ve
 12: (router_id): ::
 13: (routing_id): 0
 14: (ls_id): 0
-15: (ospf_area_id):
-16: (isis_area_id):
-17: (protocol): IS-IS_L2
-18: (as_path):
-19: (local_pref): 0
-20: (med): 0
-21: (nexthop):
-22: (mt_id): 2
-23: (local_link_id): 0
-24: (remote_link_id): 0
-25: (intf_ip): 10:1:1::
-26: (nei_ip): 10:1:1::1
-27: (igp_metric): 0
-28: (admin_group): 0
-29: (max_link_bw): 0
-30: (max_resv_bw): 0
-31: (unresv_bw):
-32: (te_default_metric): 0
-33: (link_protection):
-34: (mpls_proto_mask):
-35: (srlg):
-36: (link_name):
-37: (remote_node_hash): 9b20947913e9b23f4d5ccf4174e9eba4
-38: (local_node_hash): 6ed5aeb7f5ca0bbea84bdbadb61996e9
-39: (remote_igp_router_id): 0000.0000.0001.0000
-40: (remote_router_id): ::
-41: (local_node_asn): 100000
-42: (remote_node_asn): 100000
-43: (peer_node_sid):
-44: (is_prepolicy): 1
-45: (is_adj_rib_in): 1
-46: (ls_adjacency_sid):
+15: (area_id):
+16: (protocol): IS-IS_L2
+17: (as_path):
+18: (local_pref): 0
+19: (med): 0
+20: (nexthop):
+21: (mt_id): 2
+22: (local_link_id): 0
+23: (remote_link_id): 0
+24: (intf_ip): 10:1:1::
+25: (nei_ip): 10:1:1::1
+26: (igp_metric): 0
+27: (admin_group): 0
+28: (max_link_bw): 0
+29: (max_resv_bw): 0
+30: (unresv_bw):
+31: (te_default_metric): 0
+32: (link_protection):
+33: (mpls_proto_mask):
+34: (srlg):
+35: (link_name):
+36: (remote_node_hash): 9b20947913e9b23f4d5ccf4174e9eba4
+37: (local_node_hash): 6ed5aeb7f5ca0bbea84bdbadb61996e9
+38: (remote_igp_router_id): 0000.0000.0001.0000
+39: (remote_router_id): ::
+40: (local_node_asn): 100000
+41: (remote_node_asn): 100000
+42: (peer_node_sid):
+43: (is_prepolicy): 1
+44: (is_adj_rib_in): 1
+45: (ls_adjacency_sid):
 
 ```
 #### BMP ls_prefix message:
@@ -403,26 +399,25 @@ Bonus item (OpenBMP never carried remote node router ID field, which would be ve
 12: (router_id): 0.0.0.0
 13: (routing_id): 0
 14: (ls_id): 0
-15: (ospf_area_id):
-16: (isis_area_id):
-17: (protocol): IS-IS_L2
-18: (as_path):
-19: (local_pref): 100
-20: (med): 0
-21: (nexthop): 10.0.0.1
-22: (local_node_hash): c2679dc1c0d5615c23b3ec45f59f6b15
-23: (mt_id): 0
-24: (ospf_route_type):
-25: (igp_flags):
-26: (route_tag): 0
-27: (ext_route_tag): 0
-28: (ospf_fwd_addr): 0.0.0.0
-29: (igp_metric): 0
-30: (prefix): 10.0.0.2
-31: (prefix_len): 32
-32: (is_prepolicy): 1
-33: (is_adj_rib_in): 1
-34: (ls_prefix_sid): N SPF 2
+15: (area_id):
+16: (protocol): IS-IS_L2
+17: (as_path):
+18: (local_pref): 100
+19: (med): 0
+20: (nexthop): 10.0.0.1
+21: (local_node_hash): c2679dc1c0d5615c23b3ec45f59f6b15
+22: (mt_id): 0
+23: (ospf_route_type):
+24: (igp_flags):
+25: (route_tag): 0
+26: (ext_route_tag): 0
+27: (ospf_fwd_addr): 0.0.0.0
+28: (igp_metric): 0
+29: (prefix): 10.0.0.2
+30: (prefix_len): 32
+31: (is_prepolicy): 1
+32: (is_adj_rib_in): 1
+33: (ls_prefix_sid): N SPF 2
 
 // delete ls_prefix
 
@@ -440,26 +435,25 @@ Bonus item (OpenBMP never carried remote node router ID field, which would be ve
 12: (router_id): 0.0.0.0
 13: (routing_id): 0
 14: (ls_id): 0
-15: (ospf_area_id):
-16: (isis_area_id):
-17: (protocol): IS-IS_L2
-18: (as_path):
-19: (local_pref): 0
-20: (med): 0
-21: (nexthop):
-22: (local_node_hash): 9b20947913e9b23f4d5ccf4174e9eba4
-23: (mt_id): 0
-24: (ospf_route_type):
-25: (igp_flags):
-26: (route_tag): 0
-27: (ext_route_tag): 0
-28: (ospf_fwd_addr): 0.0.0.0
-29: (igp_metric): 0
-30: (prefix): 10.0.0.1
-31: (prefix_len): 32
-32: (is_prepolicy): 1
-33: (is_adj_rib_in): 1
-34: (ls_prefix_sid):
+15: (area_id):
+16: (protocol): IS-IS_L2
+17: (as_path):
+18: (local_pref): 0
+29: (med): 0
+20: (nexthop):
+21: (local_node_hash): 9b20947913e9b23f4d5ccf4174e9eba4
+22: (mt_id): 0
+23: (ospf_route_type):
+24: (igp_flags):
+25: (route_tag): 0
+26: (ext_route_tag): 0
+27: (ospf_fwd_addr): 0.0.0.0
+28: (igp_metric): 0
+39: (prefix): 10.0.0.1
+30: (prefix_len): 32
+31: (is_prepolicy): 1
+32: (is_adj_rib_in): 1
+33: (ls_prefix_sid):
 
 ```
 #### BMP ls_srv6_sid message:

--- a/BMP.md
+++ b/BMP.md
@@ -56,7 +56,7 @@ https://www.snas.io/docs/
 24: (bgp_error_sub_code): 4
 25: (error_text): Administratively reset
 26: (is_l): 0
-27: (isprepolicy): 1
+27: (is_prepolicy): 1
 28: (is_ipv4): 1
 29: (is_locrib): 0
 30: (is_locrib_filtered): 0
@@ -90,7 +90,7 @@ https://www.snas.io/docs/
 24: (bgp_error_sub_code): 
 25: (error_text): 
 26: (is_l): 0
-27: (isprepolicy): 1
+27: (is_prepolicy): 1
 28: (is_ipv4): 1
 29: (is_locrib): 0
 30: (is_locrib_filtered): 0
@@ -135,7 +135,7 @@ https://www.snas.io/docs/
 27: (originator_id): 
 28: (path_id): 0
 29: (labels): 
-30: (isprepolicy): 1
+30: (is_prepolicy): 1
 31: (is_adj_rib_in): 1
 
 // add unicast_prefix
@@ -169,7 +169,7 @@ https://www.snas.io/docs/
 27: (originator_id): 
 28: (path_id): 0
 29: (labels): 
-30: (isprepolicy): 1
+30: (is_prepolicy): 1
 31: (is_adj_rib_in): 1
 ```
 
@@ -201,7 +201,7 @@ https://www.snas.io/docs/
 22: (med): 0
 23: (nexthop): 10.0.0.1
 24: (name): R00
-25: (isprepolicy): 1
+25: (is_prepolicy): 1
 26: (is_adj_rib_in): 1
 27: (ls_sr_capabilities): I 64000 100000
 
@@ -249,7 +249,7 @@ Future:
 22: (med): 0
 23: (nexthop): 
 24: (name): 
-25: (isprepolicy): 1
+25: (is_prepolicy): 1
 26: (is_adj_rib_in): 1
 27: (ls_sr_capabilities): 
 
@@ -301,7 +301,7 @@ Future:
 41: (local_node_asn): 100000
 42: (remote_node_asn): 100000
 43: (peer_node_sid): 
-44: (isprepolicy): 1
+44: (is_prepolicy): 1
 45: (is_adj_rib_in): 1
 46: (ls_adjacency_sid): BVL 0 24004, VL 0 24005
 
@@ -379,7 +379,7 @@ Bonus item (OpenBMP never carried remote node router ID field, which would be ve
 41: (local_node_asn): 100000
 42: (remote_node_asn): 100000
 43: (peer_node_sid): 
-44: (isprepolicy): 1
+44: (is_prepolicy): 1
 45: (is_adj_rib_in): 1
 46: (ls_adjacency_sid): 
 
@@ -420,7 +420,7 @@ Bonus item (OpenBMP never carried remote node router ID field, which would be ve
 29: (igp_metric): 0
 30: (prefix): 10.0.0.2
 31: (prefix_len): 32
-32: (isprepolicy): 1
+32: (is_prepolicy): 1
 33: (is_adj_rib_in): 1
 34: (ls_prefix_sid): N SPF 2
 
@@ -457,7 +457,7 @@ Bonus item (OpenBMP never carried remote node router ID field, which would be ve
 29: (igp_metric): 0
 30: (prefix): 10.0.0.1
 31: (prefix_len): 32
-32: (isprepolicy): 1
+32: (is_prepolicy): 1
 33: (is_adj_rib_in): 1
 34: (ls_prefix_sid): 
 
@@ -541,7 +541,7 @@ BGP-LS TLVs:
 27: (originator_id): 
 28: (path_id): 0
 29: (labels): 24000
-30: (isprepolicy): 1
+30: (is_prepolicy): 1
 31: (is_adj_rib_in): 1
 32: (vpn_rd): 100100:100
 33: (vpn_rd_type): 0
@@ -577,7 +577,7 @@ BGP-LS TLVs:
 27: (originator_id): 
 28: (path_id): 0
 29: (labels): 524288
-30: (isprepolicy): 1
+30: (is_prepolicy): 1
 31: (is_adj_rib_in): 1
 32: (vpn_rd): 100100:100
 33: (vpn_rd_type): 0
@@ -606,7 +606,7 @@ BGP-LS TLVs:
 23: (is_nexthop_ipv4): 
 24: (originator_id): 
 25: (path_id): 
-26: (isprepolicy): 
+26: (is_prepolicy): 
 27: (is_adj_rib_in): 
 28: (rd): 
 29: (rd_type): 
@@ -655,7 +655,7 @@ BGP-LS TLVs:
 27: (originator_id): 
 28: (path_id): 0
 29: (labels): 1072,0                                  // VPN label should be replaced with SRv6-VPN SID: 2001:1:1:f003:43::/128        
-30: (isprepolicy): 1
+30: (is_prepolicy): 1
 31: (is_adj_rib_in): 1
 32: (vpn_rd): 1679764780:167976478                    // ? should be 300:10
 33: (vpn_rd_type): 0
@@ -750,7 +750,7 @@ Wed Mar 25 22:52:03.008 UTC
 27: (originator_id): 
 28: (path_id): 0
 29: (labels): 524288
-30: (isprepolicy): 1
+30: (is_prepolicy): 1
 31: (is_adj_rib_in): 1
 32: (vpn_rd): 10300:10
 33: (vpn_rd_type): 0

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ sudo docker run --net=host sbezverk/ris2bmp:1
 Sample output :
 
 ```
-gobmp: 06:36:26.088307 {MsgType:7 MsgHash: Msg:{"action":"add","base_attrs":{"base_attr_hash":"c447165a4239db770f610e30dc5df7a7","origin":"igp","as_path":[49697,41047,24961,33891,58453,9808,56048],"as_path_count":7,"nexthop":"80.81.195.241","is_atomic_agg":false,"community_list":"49697:2302, 49697:2500","large_community_list":"24961:1:276, 24961:2:1, 24961:2:150, 24961:2:155, 24961:2:276, 24961:3:1, 24961:4:9002, 24961:5:9002, 24961:6:1, 24961:7:33891, 24961:9:4"},"peer_hash":"75fdb22262697e4b0fcc06f7a8d1496c","peer_ip":"80.81.195.241","peer_asn":49697,"timestamp":"Sep  9 06:34:58.000000","prefix":"223.104.44.0","prefix_len":24,"is_ipv4":true,"origin_as":56048,"nexthop":"80.81.195.241","is_nexthop_ipv4":true,"isprepolicy":false,"is_adj_rib_in":false}}
+gobmp: 06:36:26.088307 {MsgType:7 MsgHash: Msg:{"action":"add","base_attrs":{"base_attr_hash":"c447165a4239db770f610e30dc5df7a7","origin":"igp","as_path":[49697,41047,24961,33891,58453,9808,56048],"as_path_count":7,"nexthop":"80.81.195.241","is_atomic_agg":false,"community_list":"49697:2302, 49697:2500","large_community_list":"24961:1:276, 24961:2:1, 24961:2:150, 24961:2:155, 24961:2:276, 24961:3:1, 24961:4:9002, 24961:5:9002, 24961:6:1, 24961:7:33891, 24961:9:4"},"peer_hash":"75fdb22262697e4b0fcc06f7a8d1496c","peer_ip":"80.81.195.241","peer_asn":49697,"timestamp":"Sep  9 06:34:58.000000","prefix":"223.104.44.0","prefix_len":24,"is_ipv4":true,"origin_as":56048,"nexthop":"80.81.195.241","is_nexthop_ipv4":true,"is_prepolicy":false,"is_adj_rib_in":false}}
 ```
 
 ## Status

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,9 @@ go 1.14
 require (
 	github.com/Shopify/sarama v1.27.0
 	github.com/arangodb/go-driver v0.0.0-20200403100147-ca5dd87ffe93
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-test/deep v1.0.6
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/segmentio/kafka-go v0.4.2
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
-	golang.org/x/text v0.3.2 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 )

--- a/pkg/base/multitopologyidentifier.go
+++ b/pkg/base/multitopologyidentifier.go
@@ -25,7 +25,7 @@ func UnmarshalMultiTopologyIdentifierTLV(b []byte) ([]*MultiTopologyIdentifier, 
 	for i := 0; i < int(len(b)/2); i++ {
 		m := &MultiTopologyIdentifier{}
 		d := binary.BigEndian.Uint16(b[p : p+2])
-		m.MTID = d & 0x0ffff
+		m.MTID = d & 0x0fff
 		m.FlagO = d&0x8000 == 0x8000
 		m.FlagA = d&0x4000 == 0x4000
 		mti[i] = m

--- a/pkg/message/ls-node.go
+++ b/pkg/message/ls-node.go
@@ -49,11 +49,11 @@ func (p *producer) lsNode(node *base.NodeNLRI, nextHop string, op int, ph *bmp.P
 		case base.ISISL1:
 			fallthrough
 		case base.ISISL2:
-			msg.ISISAreaID = lsnode.GetISISAreaID()
+			msg.AreaID = lsnode.GetISISAreaID()
 		case base.OSPFv2:
 			fallthrough
 		case base.OSPFv3:
-			msg.OSPFAreaID = node.GetNodeOSPFAreaID()
+			msg.AreaID = node.GetNodeOSPFAreaID()
 		}
 		if ph.FlagV {
 			msg.RouterID = lsnode.GetLocalIPv6RouterID()

--- a/pkg/message/types.go
+++ b/pkg/message/types.go
@@ -40,7 +40,7 @@ type PeerStateChange struct {
 	BMPErrorSubCode  int            `json:"bmp_error_sub_code,omitempty"`
 	ErrorText        string         `json:"error_text,omitempty"`
 	IsL3VPN          bool           `json:"is_l"`
-	IsPrepolicy      bool           `json:"isprepolicy"`
+	IsPrepolicy      bool           `json:"is_prepolicy"`
 	IsIPv4           bool           `json:"is_ipv4"`
 	IsLocRIB         bool           `json:"is_locrib"`
 	IsLocRIBFiltered bool           `json:"is_locrib_filtered"`
@@ -71,7 +71,7 @@ type UnicastPrefix struct {
 	IsNexthopIPv4  bool                `json:"is_nexthop_ipv4"`
 	PathID         int32               `json:"path_id,omitempty"`
 	Labels         []uint32            `json:"labels,omitempty"`
-	IsPrepolicy    bool                `json:"isprepolicy"`
+	IsPrepolicy    bool                `json:"is_prepolicy"`
 	IsAdjRIBIn     bool                `json:"is_adj_rib_in"`
 	PrefixSID      *prefixsid.PSid     `json:"prefix_sid,omitempty"`
 }
@@ -108,7 +108,7 @@ type LSNode struct {
 	SRv6CapabilitiesTLV *srv6.CapabilityTLV             `json:"srv6_capabilities_tlv,omitempty"`
 	NodeMSD             []*base.MSDTV                   `json:"node_msd,omitempty"`
 	FlexAlgoDefinition  []*bgpls.FlexAlgoDefinition     `json:"flex_algo_definition,omitempty"`
-	IsPrepolicy         bool                            `json:"isprepolicy"`
+	IsPrepolicy         bool                            `json:"is_prepolicy"`
 	IsAdjRIBIn          bool                            `json:"is_adj_rib_in"`
 }
 
@@ -193,7 +193,7 @@ type L3VPNPrefix struct {
 	IsNexthopIPv4  bool                `json:"is_nexthop_ipv4"`
 	PathID         int32               `json:"path_id,omitempty"`
 	Labels         []uint32            `json:"labels,omitempty"`
-	IsPrepolicy    bool                `json:"isprepolicy"`
+	IsPrepolicy    bool                `json:"is_prepolicy"`
 	IsAdjRIBIn     bool                `json:"is_adj_rib_in"`
 	VPNRD          string              `json:"vpn_rd,omitempty"`
 	VPNRDType      uint16              `json:"vpn_rd_type"`
@@ -232,7 +232,7 @@ type LSPrefix struct {
 	IGPMetric            uint32                        `json:"igp_metric,omitempty"`
 	Prefix               string                        `json:"prefix,omitempty"`
 	PrefixLen            int32                         `json:"prefix_len,omitempty"`
-	IsPrepolicy          bool                          `json:"isprepolicy"`
+	IsPrepolicy          bool                          `json:"is_prepolicy"`
 	IsAdjRIBIn           bool                          `json:"is_adj_rib_in"`
 	LSPrefixSID          []*sr.PrefixSIDTLV            `json:"ls_prefix_sid,omitempty"`
 	PrefixAttrFlags      uint8                         `json:"prefix_attr_flags"`
@@ -272,7 +272,7 @@ type LSSRv6SID struct {
 	IGPMetric            uint32                        `json:"igp_metric,omitempty"`
 	Prefix               string                        `json:"prefix,omitempty"`
 	PrefixLen            int32                         `json:"prefix_len,omitempty"`
-	IsPrepolicy          bool                          `json:"isprepolicy"`
+	IsPrepolicy          bool                          `json:"is_prepolicy"`
 	IsAdjRIBIn           bool                          `json:"is_adj_rib_in"`
 	SRv6SID              string                        `json:"srv6_sid,omitempty"`
 	SRv6EndpointBehavior *srv6.EndpointBehavior        `json:"srv6_endpoint_behavior,omitempty"`
@@ -302,7 +302,7 @@ type EVPNPrefix struct {
 	IsNexthopIPv4  bool                `json:"is_nexthop_ipv4"`
 	PathID         int32               `json:"path_id,omitempty"`
 	Labels         []uint32            `json:"labels,omitempty"`
-	IsPrepolicy    bool                `json:"isprepolicy"`
+	IsPrepolicy    bool                `json:"is_prepolicy"`
 	IsAdjRIBIn     bool                `json:"is_adj_rib_in"`
 	VPNRD          string              `json:"vpn_rd,omitempty"`
 	VPNRDType      uint16              `json:"vpn_rd_type"`

--- a/pkg/message/types.go
+++ b/pkg/message/types.go
@@ -96,8 +96,7 @@ type LSNode struct {
 	ASN                 uint32                          `json:"asn,omitempty"`
 	LSID                uint32                          `json:"ls_id,omitempty"`
 	MTID                []*base.MultiTopologyIdentifier `json:"mt_id_tlv,omitempty"`
-	OSPFAreaID          string                          `json:"ospf_area_id,omitempty"`
-	ISISAreaID          string                          `json:"isis_area_id,omitempty"`
+	AreaID              string                          `json:"area_id,omitempty"`
 	Protocol            string                          `json:"protocol,omitempty"`
 	ProtocolID          base.ProtoID                    `json:"protocol_id,omitempty"`
 	NodeFlags           uint8                           `json:"node_flags"`
@@ -259,8 +258,7 @@ type LSSRv6SID struct {
 	LocalNodeASN         uint32                        `json:"local_node_asn,omitempty"`
 	RouterID             string                        `json:"router_id,omitempty"`
 	LSID                 uint32                        `json:"ls_id,omitempty"`
-	OSPFAreaID           string                        `json:"ospf_area_id,omitempty"`
-	ISISAreaID           string                        `json:"isis_area_id,omitempty"`
+	AreaID               string                        `json:"area_id,omitempty"`
 	Protocol             string                        `json:"protocol,omitempty"`
 	Nexthop              string                        `json:"nexthop,omitempty"`
 	LocalNodeHash        string                        `json:"local_node_hash,omitempty"`


### PR DESCRIPTION
The first commit is a fix to the 12-bit mt_id, wasn't noticed yesterday.
The isprepolicy name doesn't match the other is_flags.

An LSNode entry is always in one protocol, so let's make the area_id attribute consistent with LSLink and LSPrefix. While I didn't see either area id being set in LSSRv6SID, I kept the unified attribute anyway.
Some doc fixes.
The last one is an auto-generated change.