### PR TITLE
Add protocol_id to LSSRv6SID

### DIFF
--- a/pkg/message/ls-srv6-sid.go
+++ b/pkg/message/ls-srv6-sid.go
@@ -29,6 +29,7 @@ func (p *producer) lsSRv6SID(nlri6 *srv6.SIDNLRI, nextHop string, op int, ph *bm
 	}
 	msg.Nexthop = nextHop
 	msg.PeerIP = ph.GetPeerAddrString()
+	msg.ProtocolID = nlri6.ProtocolID
 	msg.Protocol = nlri6.GetSRv6SIDProtocolID()
 	msg.LocalNodeHash = nlri6.LocalNodeHash
 	msg.LSID = nlri6.GetSRv6SIDLSID()

--- a/pkg/message/types.go
+++ b/pkg/message/types.go
@@ -261,6 +261,7 @@ type LSSRv6SID struct {
 	RouterID             string                        `json:"router_id,omitempty"`
 	LSID                 uint32                        `json:"ls_id,omitempty"`
 	AreaID               string                        `json:"area_id,omitempty"`
+	ProtocolID           base.ProtoID                  `json:"protocol_id,omitempty"`
 	Protocol             string                        `json:"protocol,omitempty"`
 	Nexthop              string                        `json:"nexthop,omitempty"`
 	LocalNodeHash        string                        `json:"local_node_hash,omitempty"`


### PR DESCRIPTION
A minor omission in the struct, where others include the numeric protocol ID along with the string.