### PR TITLE
Ls link link ip

### DIFF
--- a/pkg/base/link-descriptor.go
+++ b/pkg/base/link-descriptor.go
@@ -28,35 +28,35 @@ func (l *LinkDescriptor) GetLinkID() ([]uint32, error) {
 }
 
 // GetLinkIPv4InterfaceAddr returns Link Interface IPv4 address as a string
-func (l *LinkDescriptor) GetLinkIPv4InterfaceAddr() string {
+func (l *LinkDescriptor) GetLinkIPv4InterfaceAddr() net.IP {
 	if tlv, ok := l.LinkTLV[259]; ok {
-		return net.IP(tlv.Value).To4().String()
+		return net.IP(tlv.Value).To4()
 	}
-	return ""
+	return nil
 }
 
 // GetLinkIPv4NeighborAddr returns Link's neighbor IPv4 address as a string
-func (l *LinkDescriptor) GetLinkIPv4NeighborAddr() string {
+func (l *LinkDescriptor) GetLinkIPv4NeighborAddr() net.IP {
 	if tlv, ok := l.LinkTLV[260]; ok {
-		return net.IP(tlv.Value).To4().String()
+		return net.IP(tlv.Value).To4()
 	}
-	return ""
+	return nil
 }
 
 // GetLinkIPv6InterfaceAddr returns Link Interface IPv6 address as a string
-func (l *LinkDescriptor) GetLinkIPv6InterfaceAddr() string {
+func (l *LinkDescriptor) GetLinkIPv6InterfaceAddr() net.IP {
 	if tlv, ok := l.LinkTLV[261]; ok {
-		return net.IP(tlv.Value).To16().String()
+		return net.IP(tlv.Value).To16()
 	}
-	return ""
+	return nil
 }
 
 // GetLinkIPv6NeighborAddr returns Link's neighbor IPv6 address as a string
-func (l *LinkDescriptor) GetLinkIPv6NeighborAddr() string {
+func (l *LinkDescriptor) GetLinkIPv6NeighborAddr() net.IP {
 	if tlv, ok := l.LinkTLV[262]; ok {
-		return net.IP(tlv.Value).To16().String()
+		return net.IP(tlv.Value).To16()
 	}
-	return ""
+	return nil
 }
 
 // GetLinkMTID returns Link Multi-Topology identifiers

--- a/pkg/base/link-nlri.go
+++ b/pkg/base/link-nlri.go
@@ -4,6 +4,7 @@ import (
 	"crypto/md5"
 	"encoding/binary"
 	"fmt"
+	"net"
 
 	"github.com/golang/glog"
 	"github.com/sbezverk/gobmp/pkg/tools"
@@ -78,27 +79,19 @@ func (l *LinkNLRI) GetLinkID() ([]uint32, error) {
 }
 
 // GetLinkInterfaceAddr returns Link Interface IPv4 address as a string
-func (l *LinkNLRI) GetLinkInterfaceAddr() []string {
-	addr := make([]string, 0)
-	if a := l.Link.GetLinkIPv4InterfaceAddr(); a != "" {
-		addr = append(addr, a)
+func (l *LinkNLRI) GetLinkInterfaceAddr() net.IP {
+	if a := l.Link.GetLinkIPv4InterfaceAddr(); a != nil {
+		return a
 	}
-	if a := l.Link.GetLinkIPv6InterfaceAddr(); a != "" {
-		addr = append(addr, a)
-	}
-	return addr
+	return l.Link.GetLinkIPv6InterfaceAddr()
 }
 
 // GetLinkNeighborAddr returns Link's neighbor IPv4 address as a string
-func (l *LinkNLRI) GetLinkNeighborAddr() []string {
-	addr := make([]string, 0)
-	if a := l.Link.GetLinkIPv4NeighborAddr(); a != "" {
-		addr = append(addr, a)
+func (l *LinkNLRI) GetLinkNeighborAddr() net.IP {
+	if a := l.Link.GetLinkIPv4NeighborAddr(); a != nil {
+		return a
 	}
-	if a := l.Link.GetLinkIPv6NeighborAddr(); a != "" {
-		addr = append(addr, a)
-	}
-	return addr
+	return l.Link.GetLinkIPv6NeighborAddr()
 }
 
 // GetLocalASN returns value of Local Node's ASN

--- a/pkg/base/node-descriptor.go
+++ b/pkg/base/node-descriptor.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"strconv"
 
 	"github.com/golang/glog"
 	"github.com/sbezverk/gobmp/pkg/tools"
@@ -41,9 +42,9 @@ func (nd *NodeDescriptor) GetLSID() uint32 {
 // GetOSPFAreaID returns OSPF Area-ID found in Node Descriptor sub tlv
 func (nd *NodeDescriptor) GetOSPFAreaID() string {
 	if tlv, ok := nd.SubTLV[514]; ok {
-		return net.IP(tlv.Value).To4().String()
+		return strconv.Itoa(int(binary.BigEndian.Uint32(tlv.Value)))
 	}
-	return ""
+	return "err"
 }
 
 // GetIGPRouterID returns a value of Node Descriptor sub TLV IGP Router ID

--- a/pkg/bgpls/bgpls-nlri.go
+++ b/pkg/bgpls/bgpls-nlri.go
@@ -69,6 +69,7 @@ func (ls *NLRI) GetNodeFlags() uint8 {
 		}
 		return uint8(tlv.Value[0])
 	}
+
 	return 0
 }
 

--- a/pkg/message/ls-link.go
+++ b/pkg/message/ls-link.go
@@ -44,8 +44,12 @@ func (p *producer) lsLink(link *base.LinkNLRI, nextHop string, op int, ph *bmp.P
 		msg.LocalLinkID = ids[0]
 		msg.RemoteLinkID = ids[1]
 	}
-	msg.LocalLinkIP = link.GetLinkInterfaceAddr()
-	msg.RemoteLinkIP = link.GetLinkNeighborAddr()
+	if a := link.GetLinkInterfaceAddr(); a != nil {
+		msg.LocalLinkIP = a.String()
+	}
+	if a := link.GetLinkNeighborAddr(); a != nil {
+		msg.RemoteLinkIP = a.String()
+	}
 	msg.LocalNodeHash = link.LocalNodeHash
 	msg.RemoteNodeHash = link.RemoteNodeHash
 	msg.LocalNodeASN = link.GetLocalASN()

--- a/pkg/message/ls-link.go
+++ b/pkg/message/ls-link.go
@@ -57,6 +57,20 @@ func (p *producer) lsLink(link *base.LinkNLRI, nextHop string, op int, ph *bmp.P
 	msg.RemoteIGPRouterID = link.GetRemoteIGPRouterID()
 	msg.IGPRouterID = link.GetLocalIGPRouterID()
 	msg.MTID = link.Link.GetLinkMTID()
+	switch link.ProtocolID {
+	case base.ISISL1:
+		fallthrough
+	case base.ISISL2:
+		// Proposed by Peter Psenak <ppsenak@cisco.com>
+		// 1027 TLV is not sent for ISIS links/prefixes, because ISIS has no
+		// concept of areas. The proposal is to use generic representation,
+		// so include area-id and always set to 0 for ISIS.
+		msg.AreaID = "0"
+	case base.OSPFv2:
+		fallthrough
+	case base.OSPFv3:
+		msg.AreaID = link.LocalNode.GetOSPFAreaID()
+	}
 	if lslink, err := update.GetNLRI29(); err == nil {
 		if ph.FlagV {
 			msg.RouterID = lslink.GetLocalIPv6RouterID()
@@ -103,20 +117,6 @@ func (p *producer) lsLink(link *base.LinkNLRI, nextHop string, op int, ph *bmp.P
 		msg.UnidirResidualBW = lslink.GetUnidirResidualBandwidth()
 		if adj, err := lslink.GetSRAdjacencySID(); err == nil {
 			msg.LSAdjacencySID = adj
-		}
-		switch link.ProtocolID {
-		case base.ISISL1:
-			fallthrough
-		case base.ISISL2:
-			// Proposed by Peter Psenak <ppsenak@cisco.com>
-			// 1027 TLV is not sent for ISIS links/prefixes, because ISIS has no
-			// concept of areas. The proposal is to use generic representation,
-			// so include area-id and always set to 0 for ISIS.
-			msg.AreaID = "0"
-		case base.OSPFv2:
-			fallthrough
-		case base.OSPFv3:
-			msg.AreaID = link.LocalNode.GetOSPFAreaID()
 		}
 	}
 

--- a/pkg/message/ls-node.go
+++ b/pkg/message/ls-node.go
@@ -40,6 +40,13 @@ func (p *producer) lsNode(node *base.NodeNLRI, nextHop string, op int, ph *bmp.P
 	msg.IGPRouterID = node.GetNodeIGPRouterID()
 	msg.LSID = node.GetNodeLSID()
 	msg.ASN = node.GetNodeASN()
+	switch node.ProtocolID {
+	case base.OSPFv2:
+		fallthrough
+	case base.OSPFv3:
+		msg.AreaID = node.GetNodeOSPFAreaID()
+	}
+
 	lsnode, err := update.GetNLRI29()
 	if err == nil {
 		msg.NodeFlags = lsnode.GetNodeFlags()
@@ -50,10 +57,6 @@ func (p *producer) lsNode(node *base.NodeNLRI, nextHop string, op int, ph *bmp.P
 			fallthrough
 		case base.ISISL2:
 			msg.AreaID = lsnode.GetISISAreaID()
-		case base.OSPFv2:
-			fallthrough
-		case base.OSPFv3:
-			msg.AreaID = node.GetNodeOSPFAreaID()
 		}
 		if ph.FlagV {
 			msg.RouterID = lsnode.GetLocalIPv6RouterID()

--- a/pkg/message/process-mp-update.go
+++ b/pkg/message/process-mp-update.go
@@ -168,7 +168,7 @@ func (p *producer) processNLRI71SubTypes(nlri bgp.MPNLRI, operation int, ph *bmp
 		case 2:
 			l, ok := e.LS.(*base.LinkNLRI)
 			if !ok {
-				glog.Errorf("failed to produce ls_node message with error: %+v", err)
+				glog.Errorf("failed to produce ls_link message with error: %+v", err)
 				continue
 			}
 			msg, err := p.lsLink(l, nlri.GetNextHop(), operation, ph, update)
@@ -186,7 +186,7 @@ func (p *producer) processNLRI71SubTypes(nlri bgp.MPNLRI, operation int, ph *bmp
 		case 4:
 			prfx, ok := e.LS.(*base.PrefixNLRI)
 			if !ok {
-				glog.Errorf("failed to produce ls_node message with error: %+v", err)
+				glog.Errorf("failed to produce ls_prefix message with error: %+v", err)
 				continue
 			}
 			msg, err := p.lsPrefix(prfx, nlri.GetNextHop(), operation, ph, update, ipv4Flag)

--- a/pkg/message/types.go
+++ b/pkg/message/types.go
@@ -138,8 +138,8 @@ type LSLink struct {
 	MTID                  *base.MultiTopologyIdentifier `json:"mt_id_tlv,omitempty"`
 	LocalLinkID           uint32                        `json:"local_link_id,omitempty"`
 	RemoteLinkID          uint32                        `json:"remote_link_id,omitempty"`
-	LocalLinkIP           []string                      `json:"local_link_ip,omitempty"`
-	RemoteLinkIP          []string                      `json:"remote_link_ip,omitempty"`
+	LocalLinkIP           string                        `json:"local_link_ip,omitempty"`
+	RemoteLinkIP          string                        `json:"remote_link_ip,omitempty"`
 	IGPMetric             uint32                        `json:"igp_metric,omitempty"`
 	AdminGroup            uint32                        `json:"admin_group,omitempty"`
 	MaxLinkBW             uint32                        `json:"max_link_bw,omitempty"`

--- a/pkg/message/types.go
+++ b/pkg/message/types.go
@@ -98,7 +98,7 @@ type LSNode struct {
 	ASN                 uint32                          `json:"asn,omitempty"`
 	LSID                uint32                          `json:"ls_id,omitempty"`
 	MTID                []*base.MultiTopologyIdentifier `json:"mt_id_tlv,omitempty"`
-	AreaID              string                          `json:"area_id,omitempty"`
+	AreaID              string                          `json:"area_id"`
 	Protocol            string                          `json:"protocol,omitempty"`
 	ProtocolID          base.ProtoID                    `json:"protocol_id,omitempty"`
 	NodeFlags           uint8                           `json:"node_flags"`


### PR DESCRIPTION
LS Link always carry a single Local IP address and Remote IP address, this PR switches to use a string instead of a slice for these fields. Also OSPF Area ID fix and clean up was done in this PR.