### PR TITLE
fix UnmarshalBGPOpenMessage

### DIFF
--- a/pkg/bgp/bgp-open.go
+++ b/pkg/bgp/bgp-open.go
@@ -57,7 +57,7 @@ func UnmarshalBGPOpenMessage(b []byte) (*OpenMessage, error) {
 	if glog.V(6) {
 		glog.Infof("BGPOpenMessage Raw: %s", tools.MessageHex(b))
 	}
-	if len(b) < BGPMinOpenMessageLength {
+	if len(b) < BGPMinOpenMessageLength-16 {
 		return nil, fmt.Errorf("BGP Open Message length %d is invalid", len(b))
 	}
 	var err error


### PR DESCRIPTION
The minimum length of the OPEN message is 29 octets (including the
message header). The callers of this function exclude the marker
bytes.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>