### PR TITLE
change AS type from int32 to uint32

### DIFF
--- a/pkg/bgp/bgp-capability.go
+++ b/pkg/bgp/bgp-capability.go
@@ -83,7 +83,7 @@ func UnmarshalBGPCapability(b []byte) (Capability, error) {
 	if glog.V(6) {
 		glog.Infof("UnmarshalBGPCapability Raw: %s", tools.MessageHex(b))
 	}
-	caps := make(Capability, 0)
+	caps := make(Capability)
 	for p := 0; p < len(b); {
 		code := b[p]
 		p++

--- a/pkg/bgp/bgp-information-tlv.go
+++ b/pkg/bgp/bgp-information-tlv.go
@@ -18,7 +18,7 @@ func UnmarshalBGPTLV(b []byte) ([]InformationalTLV, Capability, error) {
 		glog.Infof("BGPTLV Raw: %s", tools.MessageHex(b))
 	}
 	tlvs := make([]InformationalTLV, 0)
-	caps := make(Capability, 0)
+	caps := make(Capability)
 	for p := 0; p < len(b); {
 		t := b[p]
 		p++
@@ -51,9 +51,7 @@ func UnmarshalBGPTLV(b []byte) ([]InformationalTLV, Capability, error) {
 func copyCapabilitiyMap(s, d Capability) {
 	for k, v := range s {
 		src := make([]*capabilityData, len(v))
-		for i, c := range v {
-			src[i] = c
-		}
+		copy(src, v)
 		dst, ok := d[k]
 		if !ok {
 			dst = make([]*capabilityData, 0)

--- a/pkg/bgp/bgp-open.go
+++ b/pkg/bgp/bgp-open.go
@@ -33,13 +33,13 @@ func (o *OpenMessage) GetCapabilities() Capability {
 
 // Is4BytesASCapable returns true or false if Open message originated by 4 bytes AS capable speaker
 // in case of true, it also returns 4 bytes Autonomous System Number.
-func (o *OpenMessage) Is4BytesASCapable() (int32, bool) {
+func (o *OpenMessage) Is4BytesASCapable() (uint32, bool) {
 	v, ok := o.Capabilities[65]
 	if !ok {
 		return 0, false
 	}
 
-	return int32(binary.BigEndian.Uint32(v[0].Value)), true
+	return binary.BigEndian.Uint32(v[0].Value), true
 }
 
 // IsMultiLabelCapable returns true or false if Open message originated by a bgp speaker

--- a/pkg/bmp/per-peer-header.go
+++ b/pkg/bmp/per-peer-header.go
@@ -25,7 +25,7 @@ type PerPeerHeader struct {
 	FlagO             bool
 	PeerDistinguisher []byte // *PeerDistinguisher
 	PeerAddress       []byte
-	PeerAS            int32
+	PeerAS            uint32
 	PeerBGPID         []byte
 	PeerTimestamp     []byte
 }
@@ -103,7 +103,7 @@ func UnmarshalPerPeerHeader(b []byte) (*PerPeerHeader, error) {
 	// Peer Address 16 bytes but for IPv4 case only last 4 bytes needed
 	copy(pph.PeerAddress, b[p:p+16])
 	p += 16
-	pph.PeerAS = int32(binary.BigEndian.Uint32(b[p : p+4]))
+	pph.PeerAS = binary.BigEndian.Uint32(b[p : p+4])
 	p += 4
 	copy(pph.PeerBGPID, b[p:p+4])
 	p += 4

--- a/pkg/message/peer.go
+++ b/pkg/message/peer.go
@@ -55,7 +55,7 @@ func (p *producer) producePeerMessage(op int, msg bmp.Message) {
 		m.RouterIP = p.speakerIP
 		m.RouterHash = p.speakerHash
 
-		m.LocalASN = int32(peerUpMsg.SentOpen.MyAS)
+		m.LocalASN = uint32(peerUpMsg.SentOpen.MyAS)
 		if lasn, ok := peerUpMsg.SentOpen.Is4BytesASCapable(); ok {
 			// Local BGP speaker is 4 bytes AS capable
 			m.LocalASN = lasn

--- a/pkg/message/types.go
+++ b/pkg/message/types.go
@@ -24,11 +24,11 @@ type PeerStateChange struct {
 	RemoteBGPID      string         `json:"remote_bgp_id,omitempty"`
 	RouterIP         string         `json:"router_ip,omitempty"`
 	Timestamp        string         `json:"timestamp,omitempty"`
-	RemoteASN        int32          `json:"remote_asn,omitempty"`
+	RemoteASN        uint32         `json:"remote_asn,omitempty"`
 	RemoteIP         string         `json:"remote_ip,omitempty"`
 	PeerRD           string         `json:"peer_rd,omitempty"`
 	RemotePort       int            `json:"remote_port,omitempty"`
-	LocalASN         int32          `json:"local_asn,omitempty"`
+	LocalASN         uint32         `json:"local_asn,omitempty"`
 	LocalIP          string         `json:"local_ip,omitempty"`
 	LocalPort        int            `json:"local_port,omitempty"`
 	LocalBGPID       string         `json:"local_bgp_id,omitempty"`
@@ -63,7 +63,7 @@ type UnicastPrefix struct {
 	BaseAttributes *bgp.BaseAttributes `json:"base_attrs,omitempty"`
 	PeerHash       string              `json:"peer_hash,omitempty"`
 	PeerIP         string              `json:"peer_ip,omitempty"`
-	PeerASN        int32               `json:"peer_asn,omitempty"`
+	PeerASN        uint32              `json:"peer_asn,omitempty"`
 	Timestamp      string              `json:"timestamp,omitempty"`
 	Prefix         string              `json:"prefix,omitempty"`
 	PrefixLen      int32               `json:"prefix_len,omitempty"`
@@ -91,7 +91,7 @@ type LSNode struct {
 	RouterIP            string                          `json:"router_ip,omitempty"`
 	PeerHash            string                          `json:"peer_hash,omitempty"`
 	PeerIP              string                          `json:"peer_ip,omitempty"`
-	PeerASN             int32                           `json:"peer_asn,omitempty"`
+	PeerASN             uint32                          `json:"peer_asn,omitempty"`
 	Timestamp           string                          `json:"timestamp,omitempty"`
 	IGPRouterID         string                          `json:"igp_router_id,omitempty"`
 	RouterID            string                          `json:"router_id,omitempty"`
@@ -126,7 +126,7 @@ type LSLink struct {
 	DomainID              int64                         `json:"domain_id"`
 	PeerHash              string                        `json:"peer_hash,omitempty"`
 	PeerIP                string                        `json:"peer_ip,omitempty"`
-	PeerASN               int32                         `json:"peer_asn,omitempty"`
+	PeerASN               uint32                        `json:"peer_asn,omitempty"`
 	Timestamp             string                        `json:"timestamp,omitempty"`
 	IGPRouterID           string                        `json:"igp_router_id,omitempty"`
 	RouterID              string                        `json:"router_id,omitempty"`
@@ -189,7 +189,7 @@ type L3VPNPrefix struct {
 	BaseAttributes *bgp.BaseAttributes `json:"base_attrs,omitempty"`
 	PeerHash       string              `json:"peer_hash,omitempty"`
 	PeerIP         string              `json:"peer_ip,omitempty"`
-	PeerASN        int32               `json:"peer_asn,omitempty"`
+	PeerASN        uint32              `json:"peer_asn,omitempty"`
 	Timestamp      string              `json:"timestamp,omitempty"`
 	Prefix         string              `json:"prefix,omitempty"`
 	PrefixLen      int32               `json:"prefix_len,omitempty"`
@@ -220,7 +220,7 @@ type LSPrefix struct {
 	DomainID             int64                         `json:"domain_id"`
 	PeerHash             string                        `json:"peer_hash,omitempty"`
 	PeerIP               string                        `json:"peer_ip,omitempty"`
-	PeerASN              int32                         `json:"peer_asn,omitempty"`
+	PeerASN              uint32                        `json:"peer_asn,omitempty"`
 	Timestamp            string                        `json:"timestamp,omitempty"`
 	IGPRouterID          string                        `json:"igp_router_id,omitempty"`
 	RouterID             string                        `json:"router_id,omitempty"`
@@ -260,7 +260,7 @@ type LSSRv6SID struct {
 	DomainID             int64                         `json:"domain_id"`
 	PeerHash             string                        `json:"peer_hash,omitempty"`
 	PeerIP               string                        `json:"peer_ip,omitempty"`
-	PeerASN              int32                         `json:"peer_asn,omitempty"`
+	PeerASN              uint32                        `json:"peer_asn,omitempty"`
 	Timestamp            string                        `json:"timestamp,omitempty"`
 	IGPRouterID          string                        `json:"igp_router_id,omitempty"`
 	LocalNodeASN         uint32                        `json:"local_node_asn,omitempty"`
@@ -300,7 +300,7 @@ type EVPNPrefix struct {
 	BaseAttributes *bgp.BaseAttributes `json:"base_attrs,omitempty"`
 	PeerHash       string              `json:"peer_hash,omitempty"`
 	PeerIP         string              `json:"peer_ip,omitempty"`
-	PeerASN        int32               `json:"peer_asn,omitempty"`
+	PeerASN        uint32              `json:"peer_asn,omitempty"`
 	Timestamp      string              `json:"timestamp,omitempty"`
 	IsIPv4         bool                `json:"is_ipv4"`
 	OriginAS       int32               `json:"origin_as,omitempty"`
@@ -339,7 +339,7 @@ type SRPolicy struct {
 	BaseAttributes *bgp.BaseAttributes     `json:"base_attrs,omitempty"`
 	PeerHash       string                  `json:"peer_hash,omitempty"`
 	PeerIP         string                  `json:"peer_ip,omitempty"`
-	PeerASN        int32                   `json:"peer_asn,omitempty"`
+	PeerASN        uint32                  `json:"peer_asn,omitempty"`
 	Timestamp      string                  `json:"timestamp,omitempty"`
 	IsIPv4         bool                    `json:"is_ipv4"`
 	OriginAS       int32                   `json:"origin_as,omitempty"`
@@ -372,7 +372,7 @@ type Flowspec struct {
 	RouterIP       string              `json:"router_ip,omitempty"`
 	BaseAttributes *bgp.BaseAttributes `json:"base_attrs,omitempty"`
 	PeerIP         string              `json:"peer_ip,omitempty"`
-	PeerASN        int32               `json:"peer_asn,omitempty"`
+	PeerASN        uint32              `json:"peer_asn,omitempty"`
 	Timestamp      string              `json:"timestamp,omitempty"`
 	IsIPv4         bool                `json:"is_ipv4"`
 	OriginAS       int32               `json:"origin_as,omitempty"`


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>

Closes: #183 

Fixes 4 byte private AS number formatting. 