### PR TITLE
remove igp metric attribute from ls prefix

### DIFF
--- a/pkg/message/ls-prefix.go
+++ b/pkg/message/ls-prefix.go
@@ -69,7 +69,6 @@ func (p *producer) lsPrefix(prfx *base.PrefixNLRI, nextHop string, op int, ph *b
 			msg.RouterID = lsprefix.GetLocalIPv4RouterID()
 		}
 		msg.PrefixMetric = lsprefix.GetPrefixMetric()
-		msg.IGPMetric = lsprefix.GetIGPMetric()
 		msg.IGPRouteTag = lsprefix.GetPrefixIGPRouteTag()
 		if f, err := lsprefix.GetPrefixIGPFlags(); err == nil {
 			msg.IGPFlags = f

--- a/pkg/message/types.go
+++ b/pkg/message/types.go
@@ -236,7 +236,6 @@ type LSPrefix struct {
 	IGPRouteTag          []uint32                      `json:"route_tag,omitempty"`
 	IGPExtRouteTag       []uint64                      `json:"ext_route_tag,omitempty"`
 	OSPFFwdAddr          string                        `json:"ospf_fwd_addr,omitempty"`
-	IGPMetric            uint32                        `json:"igp_metric,omitempty"`
 	Prefix               string                        `json:"prefix,omitempty"`
 	PrefixLen            int32                         `json:"prefix_len,omitempty"`
 	PrefixMetric         uint32                        `json:"prefix_metric,omitempty"`


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>
closes: #189 