### PR TITLE
Make Kafka topics configurable

### DIFF
--- a/cmd/player/player.go
+++ b/cmd/player/player.go
@@ -31,6 +31,22 @@ func init() {
 	flag.IntVar(&iterations, "iterations", 1, "Number of iterations to replay messages")
 }
 
+var defaultTopicsConfig = kafka.TopicsConfig{
+	UnicastIPv4Topic:  "gobmp.parsed.unicast_prefix",
+	UnicastIPv6Topic:  "gobmp.parsed.unicast_prefix",
+	LSNodeTopic:       "gobmp.parsed.ls_node",
+	LSLinkTopic:       "gobmp.parsed.ls_link",
+	LSPrefixTopic:     "gobmp.parsed.ls_prefix",
+	LSSRv6SIDTopic:    "gobmp.parsed.ls_srv6_sid",
+	L3VPNIPv4Topic:    "gobmp.parsed.l3vpn",
+	L3VPNIPv6Topic:    "gobmp.parsed.l3vpn",
+	EVPNTopic:         "gobmp.parsed.evpn",
+	SRPolicyIPv4Topic: "gobmp.parsed.sr_policy",
+	SRPolicyIPv6Topic: "gobmp.parsed.sr_policy",
+	FlowSpecIPv4Topic: "gobmp.parsed.flowspec",
+	FlowSpecIPv6Topic: "gobmp.parsed.flowspec",
+}
+
 func main() {
 	flag.Parse()
 	_ = flag.Set("logtostderr", "true")
@@ -44,7 +60,7 @@ func main() {
 	defer f.Close()
 
 	// Initializing publisher process
-	publisher, err := kafka.NewKafkaPublisher(msgSrvAddr)
+	publisher, err := kafka.NewKafkaPublisher(msgSrvAddr, defaultTopicsConfig)
 	if err != nil {
 		glog.Errorf("fail to initialize Kafka publisher with error: %+v", err)
 		os.Exit(1)

--- a/pkg/gobmpsrv/gobmpsrv.go
+++ b/pkg/gobmpsrv/gobmpsrv.go
@@ -19,7 +19,6 @@ type BMPServer interface {
 }
 
 type bmpServer struct {
-	splitAF         bool
 	intercept       bool
 	publisher       pub.Publisher
 	sourcePort      int
@@ -68,7 +67,7 @@ func (srv *bmpServer) bmpWorker(client net.Conn) {
 		glog.V(5).Infof("connection to destination server %v established, start intercepting", server.RemoteAddr())
 	}
 	var producerQueue chan bmp.Message
-	prod := message.NewProducer(srv.publisher, srv.splitAF)
+	prod := message.NewProducer(srv.publisher)
 	prodStop := make(chan struct{})
 	producerQueue = make(chan bmp.Message)
 	// Starting messages producer per client with dedicated work queue
@@ -117,7 +116,7 @@ func (srv *bmpServer) bmpWorker(client net.Conn) {
 }
 
 // NewBMPServer instantiates a new instance of BMP Server
-func NewBMPServer(sPort, dPort int, intercept bool, p pub.Publisher, splitAF bool) (BMPServer, error) {
+func NewBMPServer(sPort, dPort int, intercept bool, p pub.Publisher) (BMPServer, error) {
 	incoming, err := net.Listen("tcp", fmt.Sprintf(":%d", sPort))
 	if err != nil {
 		glog.Errorf("fail to setup listener on port %d with error: %+v", sPort, err)
@@ -130,7 +129,6 @@ func NewBMPServer(sPort, dPort int, intercept bool, p pub.Publisher, splitAF boo
 		intercept:       intercept,
 		publisher:       p,
 		incoming:        incoming,
-		splitAF:         splitAF,
 	}
 
 	return &bmp, nil

--- a/pkg/message/process-mp-update.go
+++ b/pkg/message/process-mp-update.go
@@ -45,14 +45,11 @@ func (p *producer) processMPUpdate(nlri bgp.MPNLRI, operation int, ph *bmp.PerPe
 		}
 		// Loop through and publish all collected messages
 		for _, m := range msgs {
-			topicType := bmp.UnicastPrefixMsg
-			if p.splitAF {
-				if m.IsIPv4 {
-					topicType = bmp.UnicastPrefixV4Msg
-				} else {
-					topicType = bmp.UnicastPrefixV6Msg
-				}
+			topicType := bmp.UnicastPrefixV6Msg
+			if m.IsIPv4 {
+				topicType = bmp.UnicastPrefixV4Msg
 			}
+
 			if err := p.marshalAndPublish(&m, topicType, []byte(m.RouterHash), false); err != nil {
 				glog.Errorf("failed to process Unicast Prefix message with error: %+v", err)
 				return
@@ -67,13 +64,9 @@ func (p *producer) processMPUpdate(nlri bgp.MPNLRI, operation int, ph *bmp.PerPe
 			return
 		}
 		for _, m := range msgs {
-			topicType := bmp.L3VPNMsg
-			if p.splitAF {
-				if m.IsIPv4 {
-					topicType = bmp.L3VPNV4Msg
-				} else {
-					topicType = bmp.L3VPNV6Msg
-				}
+			topicType := bmp.L3VPNV6Msg
+			if m.IsIPv4 {
+				topicType = bmp.L3VPNV4Msg
 			}
 			if err := p.marshalAndPublish(&m, topicType, []byte(m.RouterHash), false); err != nil {
 				glog.Errorf("failed to process L3VPN message with error: %+v", err)
@@ -101,13 +94,9 @@ func (p *producer) processMPUpdate(nlri bgp.MPNLRI, operation int, ph *bmp.PerPe
 			return
 		}
 		for _, m := range msgs {
-			topicType := bmp.SRPolicyMsg
-			if p.splitAF {
-				if m.IsIPv4 {
-					topicType = bmp.SRPolicyV4Msg
-				} else {
-					topicType = bmp.SRPolicyV6Msg
-				}
+			topicType := bmp.SRPolicyV6Msg
+			if m.IsIPv4 {
+				topicType = bmp.SRPolicyV4Msg
 			}
 			if err := p.marshalAndPublish(&m, topicType, []byte(m.RouterHash), false); err != nil {
 				glog.Errorf("failed to process SRPolicy message with error: %+v", err)
@@ -121,13 +110,9 @@ func (p *producer) processMPUpdate(nlri bgp.MPNLRI, operation int, ph *bmp.PerPe
 			return
 		}
 		for _, m := range msgs {
-			topicType := bmp.FlowspecMsg
-			if p.splitAF {
-				if m.IsIPv4 {
-					topicType = bmp.FlowspecV4Msg
-				} else {
-					topicType = bmp.FlowspecV6Msg
-				}
+			topicType := bmp.FlowspecV6Msg
+			if m.IsIPv4 {
+				topicType = bmp.FlowspecV4Msg
 			}
 			if err := p.marshalAndPublish(&m, topicType, []byte(m.SpecHash), false); err != nil {
 				glog.Errorf("failed to process Flowspec message with error: %+v", err)

--- a/pkg/message/producer.go
+++ b/pkg/message/producer.go
@@ -22,7 +22,6 @@ type producer struct {
 	speakerHash string
 	as4Capable  bool
 	// If splitAF is set to true, ipv4 and ipv6 messages will go into separate topics
-	splitAF bool
 }
 
 // Producer dispatches kafka workers upon request received from the channel
@@ -52,9 +51,8 @@ func (p *producer) producingWorker(msg bmp.Message) {
 }
 
 // NewProducer instantiates a new instance of a producer with Publisher interface
-func NewProducer(publisher pub.Publisher, splitAF bool) Producer {
+func NewProducer(publisher pub.Publisher) Producer {
 	return &producer{
 		publisher: publisher,
-		splitAF:   splitAF,
 	}
 }

--- a/pkg/message/route-monitor.go
+++ b/pkg/message/route-monitor.go
@@ -55,10 +55,7 @@ func (p *producer) produceRouteMonitorMessage(msg bmp.Message) {
 		}
 		p.processMPUpdate(nlri, DelPrefix, msg.PeerHeader, routeMonitorMsg.Update)
 	default:
-		t := bmp.UnicastPrefixMsg
-		if p.splitAF {
-			t = bmp.UnicastPrefixV4Msg
-		}
+		t := bmp.UnicastPrefixV4Msg
 		// Original BGP's NLRI messages processing
 		msgs := make([]UnicastPrefix, 0)
 		if routeMonitorMsg.Update.WithdrawnRoutesLength != 0 {


### PR DESCRIPTION
Making Kafka output topics configurable using an optional JSON config file. Topics that don't have a topic name assigned are ignored. This allows streaming only specific message types to Kafka and also makes it possible to run multiple GoBMP instances against the same Kafka cluster.