### PR TITLE
Implement BMP RAW message type

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ When intercept set "true", all incomming BMP messages will be processed and a co
 
 Kafka server TCP/IP address
 
+```
+--bmp-raw
+```
+
+Publish BMP RAW messages (the default is to publish parsed messages)
 
 ```
 --msg-file={message file path and location} (default "/tmp/messages.json")

--- a/README.md
+++ b/README.md
@@ -130,6 +130,18 @@ The statically linked linux binary will be stored in ./bin sub folder.
 *goBMP parameters:*
 
 ```
+--admin-id={string} (default is os.hostname)
+```
+
+This collector's admin id (used in "bmp-raw" mode)
+
+```
+--bmp-raw
+```
+
+Publish BMP RAW messages (the default is to publish parsed messages)
+
+```
 --destination-port={port} (default 5050)
 ```
 
@@ -155,12 +167,6 @@ When intercept set "true", all incomming BMP messages will be processed and a co
 ```
 
 Kafka server TCP/IP address
-
-```
---bmp-raw
-```
-
-Publish BMP RAW messages (the default is to publish parsed messages)
 
 ```
 --msg-file={message file path and location} (default "/tmp/messages.json")

--- a/cmd/gobmp/gobmp.go
+++ b/cmd/gobmp/gobmp.go
@@ -30,6 +30,7 @@ var (
 	splitAF   string
 	dump      string
 	file      string
+	adminId   string
 )
 
 func init() {
@@ -43,6 +44,11 @@ func init() {
 	flag.IntVar(&perfPort, "performance-port", 56767, "port used for performance debugging")
 	flag.StringVar(&dump, "dump", "", "Dump resulting messages to file when \"dump=file\" or to the standard output when \"dump=console\"")
 	flag.StringVar(&file, "msg-file", "/tmp/messages.json", "Full path anf file name to store messages when \"dump=file\"")
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "dummy"
+	}
+	flag.StringVar(&adminId, "admin-id", hostname, "This collector's admin id (used in \"bmp-raw\" mode)")
 }
 
 func main() {
@@ -90,7 +96,7 @@ func main() {
 		glog.Errorf("failed to parse to bool the value of the intercept flag with error: %+v", err)
 		os.Exit(1)
 	}
-	bmpSrv, err := gobmpsrv.NewBMPServer(srcPort, dstPort, interceptFlag, publisher, splitAFFlag, bmpRaw)
+	bmpSrv, err := gobmpsrv.NewBMPServer(srcPort, dstPort, interceptFlag, publisher, splitAFFlag, bmpRaw, adminId)
 	if err != nil {
 		glog.Errorf("failed to setup new gobmp server with error: %+v", err)
 		os.Exit(1)

--- a/cmd/gobmp/gobmp.go
+++ b/cmd/gobmp/gobmp.go
@@ -25,6 +25,7 @@ var (
 	srcPort   int
 	perfPort  int
 	kafkaSrv  string
+	bmpRaw    bool
 	intercept string
 	splitAF   string
 	dump      string
@@ -36,6 +37,7 @@ func init() {
 	flag.IntVar(&srcPort, "source-port", 5000, "port exposed to outside")
 	flag.IntVar(&dstPort, "destination-port", 5050, "port openBMP is listening")
 	flag.StringVar(&kafkaSrv, "kafka-server", "", "URL to access Kafka server")
+	flag.BoolVar(&bmpRaw, "bmp-raw", false, "publish BMP RAW messages instead of default parsed messages")
 	flag.StringVar(&intercept, "intercept", "false", "When intercept set \"true\", all incomming BMP messges will be copied to TCP port specified by destination-port, otherwise received BMP messages will be published to Kafka.")
 	flag.StringVar(&splitAF, "split-af", "true", "When set \"true\" (default) ipv4 and ipv6 will be published in separate topics. if set \"false\" the same topic will be used for both address families.")
 	flag.IntVar(&perfPort, "performance-port", 56767, "port used for performance debugging")
@@ -88,7 +90,7 @@ func main() {
 		glog.Errorf("failed to parse to bool the value of the intercept flag with error: %+v", err)
 		os.Exit(1)
 	}
-	bmpSrv, err := gobmpsrv.NewBMPServer(srcPort, dstPort, interceptFlag, publisher, splitAFFlag)
+	bmpSrv, err := gobmpsrv.NewBMPServer(srcPort, dstPort, interceptFlag, publisher, splitAFFlag, bmpRaw)
 	if err != nil {
 		glog.Errorf("failed to setup new gobmp server with error: %+v", err)
 		os.Exit(1)

--- a/pkg/bmp/consts.go
+++ b/pkg/bmp/consts.go
@@ -6,6 +6,8 @@ const (
 	// PerPeerHeaderLength defines the length of BMP's Per Peer Header
 	PerPeerHeaderLength = 42
 
+	BMPRawMsg = -1
+
 	// RouteMonitorMsg defines BMP Route Monitor message type
 	RouteMonitorMsg = 0
 	// StatsReportMsg defines BMP Statistics Report message

--- a/pkg/bmp/raw.go
+++ b/pkg/bmp/raw.go
@@ -1,0 +1,21 @@
+package bmp
+
+import (
+	"github.com/golang/glog"
+	"github.com/sbezverk/tools"
+)
+
+type RawMessage struct {
+	Msg []byte
+}
+
+func UnmarshalBMPRawMessage(b []byte) (*RawMessage, error) {
+	if glog.V(6) {
+		glog.Infof("BMP Raw Message Raw: %s", tools.MessageHex(b))
+	}
+	m := RawMessage{}
+	m.Msg = make([]byte, len(b))
+	copy(m.Msg, b)
+
+	return &m, nil
+}

--- a/pkg/gobmpsrv/gobmpsrv.go
+++ b/pkg/gobmpsrv/gobmpsrv.go
@@ -21,6 +21,7 @@ type BMPServer interface {
 type bmpServer struct {
 	splitAF         bool
 	intercept       bool
+	bmpRaw          bool
 	publisher       pub.Publisher
 	sourcePort      int
 	destinationPort int
@@ -117,7 +118,7 @@ func (srv *bmpServer) bmpWorker(client net.Conn) {
 }
 
 // NewBMPServer instantiates a new instance of BMP Server
-func NewBMPServer(sPort, dPort int, intercept bool, p pub.Publisher, splitAF bool) (BMPServer, error) {
+func NewBMPServer(sPort, dPort int, intercept bool, p pub.Publisher, splitAF bool, bmpRaw bool) (BMPServer, error) {
 	incoming, err := net.Listen("tcp", fmt.Sprintf(":%d", sPort))
 	if err != nil {
 		glog.Errorf("fail to setup listener on port %d with error: %+v", sPort, err)
@@ -131,6 +132,7 @@ func NewBMPServer(sPort, dPort int, intercept bool, p pub.Publisher, splitAF boo
 		publisher:       p,
 		incoming:        incoming,
 		splitAF:         splitAF,
+		bmpRaw:          bmpRaw,
 	}
 
 	return &bmp, nil

--- a/pkg/gobmpsrv/gobmpsrv.go
+++ b/pkg/gobmpsrv/gobmpsrv.go
@@ -78,7 +78,7 @@ func (srv *bmpServer) bmpWorker(client net.Conn) {
 	parserQueue := make(chan []byte)
 	parsStop := make(chan struct{})
 	// Starting parser per client with dedicated work queue
-	go parser.Parser(parserQueue, producerQueue, parsStop)
+	go parser.Parser(parserQueue, producerQueue, parsStop, srv.bmpRaw)
 	defer func() {
 		glog.V(5).Infof("all done with client %+v", client.RemoteAddr())
 		close(parsStop)

--- a/pkg/gobmpsrv/gobmpsrv.go
+++ b/pkg/gobmpsrv/gobmpsrv.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"os"
 
 	"github.com/golang/glog"
 	"github.com/sbezverk/gobmp/pkg/bmp"
@@ -120,7 +119,7 @@ func (srv *bmpServer) bmpWorker(client net.Conn) {
 }
 
 // NewBMPServer instantiates a new instance of BMP Server
-func NewBMPServer(sPort, dPort int, intercept bool, p pub.Publisher, splitAF bool, bmpRaw bool) (BMPServer, error) {
+func NewBMPServer(sPort, dPort int, intercept bool, p pub.Publisher, splitAF bool, bmpRaw bool, adminId string) (BMPServer, error) {
 	incoming, err := net.Listen("tcp", fmt.Sprintf(":%d", sPort))
 	if err != nil {
 		glog.Errorf("fail to setup listener on port %d with error: %+v", sPort, err)
@@ -135,15 +134,8 @@ func NewBMPServer(sPort, dPort int, intercept bool, p pub.Publisher, splitAF boo
 		incoming:        incoming,
 		splitAF:         splitAF,
 		bmpRaw:          bmpRaw,
+		adminId:         adminId,
 	}
-
-	// XXX need to be able specify admin id via a command line switch
-	// But for now, just use the hostname
-	hostname, err := os.Hostname()
-	if err != nil {
-		hostname = "dummy"
-	}
-	bmp.adminId = hostname
 
 	return &bmp, nil
 }

--- a/pkg/kafka/kafka-publisher.go
+++ b/pkg/kafka/kafka-publisher.go
@@ -16,6 +16,7 @@ import (
 
 // Define constants for each topic name
 const (
+	rawTopic               = "gobmp.bmp_raw"
 	peerTopic              = "gobmp.parsed.peer"
 	unicastMessageTopic    = "gobmp.parsed.unicast_prefix"
 	unicastMessageV4Topic  = "gobmp.parsed.unicast_prefix_v4"
@@ -48,6 +49,7 @@ var (
 	// topics defines a list of topic to initialize and connect,
 	// initialization is done as a part of NewKafkaPublisher func.
 	topicNames = []string{
+		rawTopic,
 		peerTopic,
 		unicastMessageTopic,
 		unicastMessageV4Topic,
@@ -79,6 +81,8 @@ type publisher struct {
 
 func (p *publisher) PublishMessage(t int, key []byte, msg []byte) error {
 	switch t {
+	case bmp.BMPRawMsg:
+		return p.produceMessage(rawTopic, key, msg)
 	case bmp.PeerStateChangeMsg:
 		return p.produceMessage(peerTopic, key, msg)
 	case bmp.UnicastPrefixMsg:

--- a/pkg/message/producer.go
+++ b/pkg/message/producer.go
@@ -1,6 +1,9 @@
 package message
 
 import (
+	"crypto/md5"
+	"fmt"
+
 	"github.com/golang/glog"
 	"github.com/sbezverk/gobmp/pkg/bmp"
 	"github.com/sbezverk/gobmp/pkg/pub"
@@ -21,6 +24,7 @@ type producer struct {
 	speakerIP      string
 	speakerHash    string
 	addPathCapable map[int]bool
+	adminHash      string
 	// If splitAF is set to true, ipv4 and ipv6 messages will go into separate topics
 	splitAF bool
 }
@@ -56,10 +60,14 @@ func (p *producer) producingWorker(msg bmp.Message) {
 }
 
 // NewProducer instantiates a new instance of a producer with Publisher interface
-func NewProducer(publisher pub.Publisher, splitAF bool) Producer {
+func NewProducer(publisher pub.Publisher, adminId string, splitAF bool) Producer {
+	data := []byte{}
+	data = append(data, []byte(adminId)...)
+
 	return &producer{
 		publisher:      publisher,
 		splitAF:        splitAF,
 		addPathCapable: make(map[int]bool),
+		adminHash:      fmt.Sprintf("%x", md5.Sum(data)),
 	}
 }

--- a/pkg/message/producer.go
+++ b/pkg/message/producer.go
@@ -48,6 +48,8 @@ func (p *producer) producingWorker(msg bmp.Message) {
 		p.produceRouteMonitorMessage(msg)
 	case *bmp.StatsReport:
 		p.produceStatsMessage(msg)
+	case *bmp.RawMessage:
+		p.produceRawMessage(msg)
 	default:
 		glog.Warningf("got Unknown message %T to push to the producer, ignoring it...", obj)
 	}

--- a/pkg/message/raw.go
+++ b/pkg/message/raw.go
@@ -21,7 +21,7 @@ func (p *producer) produceRawMessage(msg bmp.Message) {
 	}
 
 	out := []byte(fmt.Sprintf("V: 1.7\nC_HASH_ID: %s\nR_HASH: %s\nR_IP: %s\nL: %d\n\n",
-		p.speakerHash, msg.PeerHeader.GetPeerHash(),
+		p.adminHash, msg.PeerHeader.GetPeerHash(),
 		msg.PeerHeader.GetPeerAddrString(), len(rm.Msg)))
 	out = append(out, rm.Msg...)
 

--- a/pkg/message/raw.go
+++ b/pkg/message/raw.go
@@ -1,0 +1,32 @@
+package message
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/sbezverk/gobmp/pkg/bmp"
+)
+
+// produceStatsMessage proceduces message from BMP Statistic Message
+func (p *producer) produceRawMessage(msg bmp.Message) {
+	if msg.PeerHeader == nil {
+		// XXX
+		glog.Errorf("perPeerHeader is missing, cannot construct proper raw message")
+		return
+	}
+	rm, ok := msg.Payload.(*bmp.RawMessage)
+	if !ok {
+		glog.Errorf("got invalid Payload type in bmp.RawMessage %+v", msg.Payload)
+		return
+	}
+
+	out := []byte(fmt.Sprintf("V: 1.7\nC_HASH_ID: %s\nR_HASH: %s\nR_IP: %s\nL: %d\n\n",
+		p.speakerHash, msg.PeerHeader.GetPeerHash(),
+		msg.PeerHeader.GetPeerAddrString(), len(rm.Msg)))
+	out = append(out, rm.Msg...)
+
+	if err := p.publisher.PublishMessage(bmp.BMPRawMsg, []byte(msg.PeerHeader.GetPeerHash()), out); err != nil {
+		glog.Errorf("failed to publish a raw BMP message to kafka with error: %+v", err)
+		return
+	}
+}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -14,7 +14,7 @@ func TestParsingWorker(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parsingWorker(tt.input, nil)
+			parsingWorker(tt.input, nil, false)
 		})
 	}
 }


### PR DESCRIPTION
This is an implementation of BMP RAW messages that can be found in OpenBMP (as described in https://github.com/SNAS/openbmp/blob/master/docs/MESSAGE_BUS_API.md).

Production of the raw messages can be switched on by specifying --bmp-raw on the command line.
Additionally, a --admin-id=STRING option is added in order to have a control over collector hash ID mentioned in the RAW format specification.

Specifying --bmp-raw only makes sense in case Kafka publishing is in effect.

The implementation is fairly straightforward as the producer needs to do less work than in the case of parsed messages produced by default.

This work is based on an E-mail discussion between goBMP's author Serguei Bezverkhi @sbezverk and David Teach @dteach-rv, and was sponsored by NSRC https://nsrc.org/