### PR TITLE
Prefix sid update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Message updates and major project changes should be documented here.
 
 ## [Unreleased]
 
+### 2023-04-13
+
+#### Changed
+
+- SR value "prefix_sid" was previous configured with "omitempty" json tag option, this option is now removed. A valid
+  SID index of 0 is now explicit in the json output.
+
 ### 2023-03-20
 
 #### Fixed

--- a/pkg/sr/sr-prefixsid.go
+++ b/pkg/sr/sr-prefixsid.go
@@ -20,7 +20,7 @@ type PrefixSIDFlags interface {
 type PrefixSIDTLV struct {
 	Flags     PrefixSIDFlags `json:"flags,omitempty"`
 	Algorithm uint8          `json:"algo"`
-	SID       uint32         `json:"prefix_sid,omitempty"`
+	SID       uint32         `json:"prefix_sid"`
 }
 
 func (p *PrefixSIDTLV) MarshalJSON() ([]byte, error) {
@@ -30,7 +30,7 @@ func (p *PrefixSIDTLV) MarshalJSON() ([]byte, error) {
 		return json.Marshal(struct {
 			Flags     *ISISFlags `json:"flags,omitempty"`
 			Algorithm uint8      `json:"algo"`
-			SID       uint32     `json:"prefix_sid,omitempty"`
+			SID       uint32     `json:"prefix_sid"`
 		}{
 			Flags:     f,
 			Algorithm: p.Algorithm,
@@ -41,7 +41,7 @@ func (p *PrefixSIDTLV) MarshalJSON() ([]byte, error) {
 		return json.Marshal(struct {
 			Flags     *OSPFFlags `json:"flags,omitempty"`
 			Algorithm uint8      `json:"algo"`
-			SID       uint32     `json:"prefix_sid,omitempty"`
+			SID       uint32     `json:"prefix_sid"`
 		}{
 			Flags:     f,
 			Algorithm: p.Algorithm,
@@ -52,7 +52,7 @@ func (p *PrefixSIDTLV) MarshalJSON() ([]byte, error) {
 		return json.Marshal(struct {
 			Flags     *UnknownProtoFlags `json:"flags,omitempty"`
 			Algorithm uint8              `json:"algo"`
-			SID       uint32             `json:"prefix_sid,omitempty"`
+			SID       uint32             `json:"prefix_sid"`
 		}{
 			Flags:     f,
 			Algorithm: p.Algorithm,
@@ -101,7 +101,7 @@ func (p *PrefixSIDTLV) UnmarshalJSON(b []byte) error {
 			return err
 		}
 	}
-	// SID       uint32         `json:"prefix_sid,omitempty"`
+	// SID       uint32         `json:"prefix_sid"`
 	if v, ok := objVal["prefix_sid"]; ok {
 		if err := json.Unmarshal(v, &result.SID); err != nil {
 			return err


### PR DESCRIPTION
@sbezverk I have prefix SID index '0' as a valid configuration. I was hitting issues where the json data was omitting prefix_sid: 0 due to the default json marshalling. Simlary to 'algo: 0' I require this field to not be omitted but have an explicit 0 present in json data. Let me know if this raises any flags, thanks!