### PR TITLE
Initial passive BMP support

### DIFF
--- a/cmd/gobmp/gobmp.go
+++ b/cmd/gobmp/gobmp.go
@@ -22,15 +22,16 @@ import (
 )
 
 var (
-	dstPort   int
-	srcPort   int
-	perfPort  int
-	kafkaSrv  string
-	natsSrv   string
-	intercept string
-	splitAF   string
-	dump      string
-	file      string
+	dstPort    int
+	srcPort    int
+	perfPort   int
+	kafkaSrv   string
+	natsSrv    string
+	passiveRtr string
+	intercept  string
+	splitAF    string
+	dump       string
+	file       string
 )
 
 func init() {
@@ -39,6 +40,7 @@ func init() {
 	flag.IntVar(&dstPort, "destination-port", 5050, "port openBMP is listening")
 	flag.StringVar(&kafkaSrv, "kafka-server", "", "URL to access Kafka server")
 	flag.StringVar(&natsSrv, "nats-server", "", "URL to access NATS server")
+	flag.StringVar(&passiveRtr, "passive-router", "", "Passive BMP router to connect outbound (<host>:<port>)")
 	flag.StringVar(&intercept, "intercept", "false", "When intercept set \"true\", all incomming BMP messges will be copied to TCP port specified by destination-port, otherwise received BMP messages will be published to Kafka.")
 	flag.StringVar(&splitAF, "split-af", "true", "When set \"true\" (default) ipv4 and ipv6 will be published in separate topics. if set \"false\" the same topic will be used for both address families.")
 	flag.IntVar(&perfPort, "performance-port", 56767, "port used for performance debugging")
@@ -98,7 +100,7 @@ func main() {
 		glog.Errorf("failed to parse to bool the value of the intercept flag with error: %+v", err)
 		os.Exit(1)
 	}
-	bmpSrv, err := gobmpsrv.NewBMPServer(srcPort, dstPort, interceptFlag, publisher, splitAFFlag)
+	bmpSrv, err := gobmpsrv.NewBMPServer(srcPort, dstPort, interceptFlag, publisher, splitAFFlag, passiveRtr)
 	if err != nil {
 		glog.Errorf("failed to setup new gobmp server with error: %+v", err)
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,10 @@ require (
 	github.com/go-test/deep v1.0.8
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/nats-io/nats-server/v2 v2.9.16 // indirect
+	github.com/nats-io/nats-server/v2 v2.9.16
 	github.com/nats-io/nats.go v1.25.0
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sbezverk/tools v0.0.0-20220706091339-17ec2f713538
 	google.golang.org/protobuf v1.30.0 // indirect
+	gotest.tools v2.2.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pierrec/lz4 v2.5.2+incompatible h1:WCjObylUIOlKy/+7Abdn34TLIkXiA4UWUMhxq9m9ZXI=
 github.com/pierrec/lz4 v2.5.2+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
@@ -171,3 +173,5 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200601152816-913338de1bd2/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=

--- a/pkg/gobmpsrv/gobmpsrv.go
+++ b/pkg/gobmpsrv/gobmpsrv.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/sbezverk/gobmp/pkg/bmp"
@@ -44,29 +45,40 @@ func (srv *bmpServer) Stop() {
 }
 
 func (srv *bmpServer) server() {
+	// Create a channel for signaling retries from failed passive connections
+	retryChan := make(chan struct{})
+	retryCount := 0
+
 	// Establish connection to passive router if specified
 	if srv.passiveRouter != "" {
-		conn, err := net.Dial("tcp", srv.passiveRouter)
-		if err != nil {
-			glog.Errorf("failed to connect to passive router with error: %+v", err)
-			return
-		}
-		glog.Infof("connected to passive router %+v, calling bmpWorker", conn.RemoteAddr())
-		go srv.bmpWorker(conn)
+		go srv.passiveConnect(retryChan, retryCount)
 	}
 
-	for {
-		client, err := srv.incoming.Accept()
-		if err != nil {
-			glog.Errorf("fail to accept client connection with error: %+v", err)
-			continue
+	// separate goroutine for handling incoming client connections
+	go func() {
+		for {
+			client, err := srv.incoming.Accept()
+			if err != nil {
+				glog.Errorf("fail to accept client connection with error: %+v", err)
+				continue
+			}
+			glog.V(5).Infof("client %+v accepted, calling bmpWorker", client.RemoteAddr())
+			go srv.bmpWorker(client, nil)
 		}
-		glog.V(5).Infof("client %+v accepted, calling bmpWorker", client.RemoteAddr())
-		go srv.bmpWorker(client)
+	}()
+
+	// main goroutine for handling retrying passive connections
+	for {
+		<-retryChan
+		if srv.passiveRouter != "" {
+			glog.Infof("retrying connection to passive router")
+			retryCount++
+			go srv.passiveConnect(retryChan, retryCount)
+		}
 	}
 }
 
-func (srv *bmpServer) bmpWorker(client net.Conn) {
+func (srv *bmpServer) bmpWorker(client net.Conn, retryChan chan struct{}) {
 	defer client.Close()
 	var server net.Conn
 	var err error
@@ -99,6 +111,10 @@ func (srv *bmpServer) bmpWorker(client net.Conn) {
 		headerMsg := make([]byte, bmp.CommonHeaderLength)
 		if _, err := io.ReadAtLeast(client, headerMsg, bmp.CommonHeaderLength); err != nil {
 			glog.Errorf("fail to read from client %+v with error: %+v", client.RemoteAddr(), err)
+			// Send a retry signal if channel is provided
+			if retryChan != nil {
+				retryChan <- struct{}{}
+			}
 			return
 		}
 		// Recovering common header first
@@ -126,6 +142,29 @@ func (srv *bmpServer) bmpWorker(client net.Conn) {
 		}
 		parserQueue <- fullMsg
 	}
+}
+
+func (srv *bmpServer) passiveConnect(retryChan chan struct{}, retryCount int) {
+	// Stop retrying after 10 attempts
+	if retryCount > 10 {
+		glog.Errorf("failed to connect to passive router after 10 retries")
+		return
+	}
+
+	conn, err := net.DialTimeout("tcp", srv.passiveRouter, 10*time.Second)
+	if err != nil {
+		glog.Errorf("failed to connect to passive router with error: %+v", err)
+
+		// Use a backoff timer to retry (30s * retryCount)
+		time.Sleep(time.Duration(retryCount*30) * time.Second)
+
+		// Signal tat the connection should be retried
+		retryChan <- struct{}{}
+		return
+	}
+
+	glog.Infof("connected to passive router %+v, calling bmpWorker", conn.RemoteAddr())
+	go srv.bmpWorker(conn, retryChan)
 }
 
 // NewBMPServer instantiates a new instance of BMP Server

--- a/pkg/nats/nats-publisher_test.go
+++ b/pkg/nats/nats-publisher_test.go
@@ -1,0 +1,126 @@
+package nats
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	natssrv "github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/sbezverk/gobmp/pkg/gobmpsrv"
+	"github.com/sbezverk/gobmp/pkg/message"
+	"github.com/sbezverk/gobmp/pkg/pub"
+	"gotest.tools/assert"
+)
+
+const (
+	streamName = "gobmp"
+	natsPrefix = "gobmp"
+	bmpPort    = 5000
+)
+
+var (
+	p pub.Publisher
+	s nats.JetStreamContext
+	b gobmpsrv.BMPServer
+)
+
+func TestMain(m *testing.M) {
+	// build in-memory NATS server
+	natsSrv, err := natssrv.NewServer(&natssrv.Options{
+		Host:      "127.0.0.1",
+		Debug:     false,
+		Port:      natssrv.RANDOM_PORT,
+		JetStream: true,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	defer natsSrv.Shutdown()
+
+	// Start NATS server
+	if err := natssrv.Run(natsSrv); err != nil {
+		panic(err)
+	}
+
+	// Create a NATS connection for subscribing
+	nc, err := nats.Connect(natsSrv.ClientURL())
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	s, err = nc.JetStream()
+	if err != nil {
+		panic(err)
+	}
+
+	// Create the stream
+	_, err = s.AddStream(&nats.StreamConfig{
+		Name:     streamName,
+		Subjects: []string{streamName + ".>"},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Create the Publisher
+	p, err = NewPublisher(natsSrv.ClientURL())
+	if err != nil {
+		panic(err)
+	}
+
+	// Start BMP
+	b, err = gobmpsrv.NewBMPServer(bmpPort, 0, false, p, false, "")
+	if err != nil {
+		panic(err)
+	}
+
+	// Starting Interceptor server
+	b.Start()
+
+	m.Run()
+}
+
+// TestNATSProducer tests NATS producer
+func TestNATSProducer(t *testing.T) {
+	input := []byte{3, 0, 0, 0, 32, 4, 0, 1, 0, 10, 32, 55, 46, 50, 46, 49, 46, 50, 51, 73, 0, 2, 0, 8, 120, 114, 118, 57, 107, 45, 114, 49, 3, 0, 0, 0, 234, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 192, 168, 80, 103, 0, 0, 19, 206, 57, 112, 1, 254, 94, 98, 129, 171, 0, 0, 215, 126, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 192, 168, 80, 128, 0, 179, 131, 152, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 91, 1, 4, 19, 206, 0, 90, 192, 168, 8, 8, 62, 2, 6, 1, 4, 0, 1, 0, 1, 2, 6, 1, 4, 0, 1, 0, 4, 2, 6, 1, 4, 0, 1, 0, 128, 2, 2, 128, 0, 2, 2, 2, 0, 2, 6, 65, 4, 0, 0, 19, 206, 2, 20, 5, 18, 0, 1, 0, 1, 0, 2, 0, 1, 0, 2, 0, 2, 0, 1, 0, 128, 0, 2, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 75, 1, 4, 19, 206, 0, 90, 57, 112, 1, 254, 46, 2, 44, 2, 0, 1, 4, 0, 1, 0, 1, 1, 4, 0, 2, 0, 1, 1, 4, 0, 1, 0, 4, 1, 4, 0, 2, 0, 4, 1, 4, 0, 1, 0, 128, 1, 4, 0, 2, 0, 128, 65, 4, 0, 0, 19, 206}
+
+	// Create a connection to the BMP server
+	conn, err := net.Dial("tcp", fmt.Sprintf(":%d", bmpPort))
+	if err != nil {
+		t.Fatalf("failed to connect to gobmp server with error: %+v", err)
+	}
+	defer conn.Close()
+
+	// Send message to the BMP server
+	_, err = conn.Write(input)
+	if err != nil {
+		t.Fatalf("failed to send message to gobmp server with error: %+v", err)
+	}
+
+	// Wait for message to be published
+	sub, err := s.SubscribeSync(streamName + ".>")
+	if err != nil {
+		t.Fatalf("failed to subscribe to stream with error: %+v", err)
+	}
+
+	// Wait to receive the message from the publisher
+	msg, err := sub.NextMsg(time.Second)
+	if err != nil {
+		t.Fatalf("failed to pull message from stream with error: %+v", err)
+	}
+
+	// Unmarshal msg.Data (bytes) to message.PeerStateChange
+	var peerStateChange message.PeerStateChange
+	err = json.Unmarshal(msg.Data, &peerStateChange)
+	if err != nil {
+		t.Fatalf("failed to unmarshal message with error: %+v", err)
+	}
+
+	assert.Equal(t, peerStateChange.Action, "add")
+	assert.Equal(t, peerStateChange.RouterHash, "4371c52d8d4a6a67a4c438964f61700b")
+}


### PR DESCRIPTION
This PR is an initial iteration to support passive outbound BMP connections as a backwards-compatible _option_ when initializing the BMP server (see #220 for reference).  As stated in the issue thread, the RFC defines support for passive connections and is supported by major routing device vendors (e.g. Arista and Juniper).

The initial approach is simplistic, but my plan would be to support for multiple routers to establish multiple connections in parallel or failover schemas.