### PR TITLE
Add timeout to create topic request in Kafka publisher

### DIFF
--- a/pkg/kafka/kafka-publisher.go
+++ b/pkg/kafka/kafka-publisher.go
@@ -244,6 +244,7 @@ func ensureTopic(br *sarama.Broker, timeout time.Duration, topicName string, kCo
 				},
 			},
 		},
+		Timeout: timeout,
 	}
 	ticker := time.NewTicker(100 * time.Millisecond)
 	tout := time.NewTimer(timeout)


### PR DESCRIPTION
This fixes issues with some Kafka environments and closes #210.