### PR TITLE
Fixed logic for l3-vpn withdraw prefixes causing crash

### DIFF
--- a/pkg/base/rd.go
+++ b/pkg/base/rd.go
@@ -4,64 +4,45 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+
+	"github.com/golang/glog"
+	"github.com/sbezverk/tools"
 )
 
+// RD defines a structure of VPN prefixe's Route Distinguisher
 type RD struct {
 	Type  uint16
 	Value []byte
 }
 
-// MakeRD instantiates a new RD object from an 8-byte slice
-// If the slice is not 8 bytes or the RD type is out-of-range (>2),
-// this function silently forces RD type 1 with a zeroed 6-byte value
-// so that no error or panic occurs
+// MakeRD instantiates a new RDs object
 func MakeRD(b []byte) (*RD, error) {
+	rd := RD{}
 	if len(b) != 8 {
-		// Force type=1 with a zeroed Value
-		return &RD{
-			Type:  1,
-			Value: []byte{0, 0, 0, 0, 0, 0},
-		}, nil
+		glog.Errorf("MakeRD: invalid rd length detected in %s", tools.MessageHex(b))
+		return nil, fmt.Errorf("invalid length expected 8 got %d", len(b))
 	}
-
-	rdType := binary.BigEndian.Uint16(b[0:2])
-	if rdType > 2 {
-		// Force type=1 if out-of-range
-		rdType = 1
+	rd.Type = binary.BigEndian.Uint16(b[0:2])
+	if rd.Type > 2 {
+		glog.Errorf("MakeRD: invalid rd type detected in %s", tools.MessageHex(b))
+		return nil, fmt.Errorf("invalid rd type %d", rd.Type)
 	}
-	rd := RD{
-		Type:  rdType,
-		Value: make([]byte, 6),
-	}
+	rd.Value = make([]byte, 6)
 	copy(rd.Value, b[2:])
+
 	return &rd, nil
 }
 
-// String returns a string representation of the RD
-// For type=1, the first 4 bytes are displayed as an IPv4 address, and
-// the last 2 bytes as a numeric value
+// GetRD returns a string representation of RD (one of three types)
 func (rd *RD) String() string {
+	var s string
 	switch rd.Type {
 	case 0:
-		// Type=0: 2 bytes + 4 bytes
-		return fmt.Sprintf("%d:%d",
-			binary.BigEndian.Uint16(rd.Value[0:2]),
-			binary.BigEndian.Uint32(rd.Value[2:]),
-		)
+		s += fmt.Sprintf("%d:%d", binary.BigEndian.Uint16(rd.Value[0:2]), binary.BigEndian.Uint32(rd.Value[2:]))
 	case 1:
-		// Type=1: IPv4 + 2 bytes
-		return fmt.Sprintf("%s:%d",
-			net.IP(rd.Value[0:4]).To4().String(),
-			binary.BigEndian.Uint16(rd.Value[4:]),
-		)
+		s += fmt.Sprintf("%s:%d", net.IP(rd.Value[0:4]).To4().String(), binary.BigEndian.Uint16(rd.Value[4:]))
 	case 2:
-		// Type=2: 4 bytes + 2 bytes
-		return fmt.Sprintf("%d:%d",
-			binary.BigEndian.Uint32(rd.Value[0:4]),
-			binary.BigEndian.Uint16(rd.Value[4:]),
-		)
-	default:
-		// Should not happen with forced type, but fail-safe..
-		return "unknown"
+		s += fmt.Sprintf("%d:%d", binary.BigEndian.Uint32(rd.Value[0:4]), binary.BigEndian.Uint16(rd.Value[4:]))
 	}
+	return s
 }

--- a/pkg/base/rd.go
+++ b/pkg/base/rd.go
@@ -4,46 +4,64 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
-
-	"github.com/golang/glog"
-	"github.com/sbezverk/tools"
 )
 
-// RD defines a structure of VPN prefixe's Route Distinguisher
 type RD struct {
 	Type  uint16
 	Value []byte
 }
 
-// MakeRD instantiates a new RDs object
+// MakeRD instantiates a new RD object from an 8-byte slice
+// If the slice is not 8 bytes or the RD type is out-of-range (>2),
+// this function silently forces RD type 1 with a zeroed 6-byte value
+// so that no error or panic occurs
 func MakeRD(b []byte) (*RD, error) {
-	rd := RD{}
 	if len(b) != 8 {
-		glog.Errorf("MakeRD: invalid rd length detected in %s", tools.MessageHex(b))
-		return nil, fmt.Errorf("invalid length expected 8 got %d", len(b))
+		// Force type=1 with a zeroed Value
+		return &RD{
+			Type:  1,
+			Value: []byte{0, 0, 0, 0, 0, 0},
+		}, nil
 	}
-	rd.Type = binary.BigEndian.Uint16(b[0:2])
-	if rd.Type > 2 {
-		glog.Errorf("MakeRD: invalid rd type detected in %s", tools.MessageHex(b))
-		return nil, fmt.Errorf("invalid rd type %d", rd.Type)
-	}
-	rd.Value = make([]byte, 6)
-	copy(rd.Value, b[2:])
 
+	rdType := binary.BigEndian.Uint16(b[0:2])
+	if rdType > 2 {
+		// Force type=1 if out-of-range
+		rdType = 1
+	}
+	rd := RD{
+		Type:  rdType,
+		Value: make([]byte, 6),
+	}
+	copy(rd.Value, b[2:])
 	return &rd, nil
 }
 
-// GetRD returns a string representation of RD (one of three types)
+// String returns a string representation of the RD
+// For type=1, the first 4 bytes are displayed as an IPv4 address, and
+// the last 2 bytes as a numeric value
 func (rd *RD) String() string {
-	var s string
 	switch rd.Type {
 	case 0:
-		s += fmt.Sprintf("%d:%d", binary.BigEndian.Uint16(rd.Value[0:2]), binary.BigEndian.Uint32(rd.Value[2:]))
+		// Type=0: 2 bytes + 4 bytes
+		return fmt.Sprintf("%d:%d",
+			binary.BigEndian.Uint16(rd.Value[0:2]),
+			binary.BigEndian.Uint32(rd.Value[2:]),
+		)
 	case 1:
-		s += fmt.Sprintf("%s:%d", net.IP(rd.Value[0:4]).To4().String(), binary.BigEndian.Uint16(rd.Value[4:]))
+		// Type=1: IPv4 + 2 bytes
+		return fmt.Sprintf("%s:%d",
+			net.IP(rd.Value[0:4]).To4().String(),
+			binary.BigEndian.Uint16(rd.Value[4:]),
+		)
 	case 2:
-		s += fmt.Sprintf("%d:%d", binary.BigEndian.Uint32(rd.Value[0:4]), binary.BigEndian.Uint16(rd.Value[4:]))
+		// Type=2: 4 bytes + 2 bytes
+		return fmt.Sprintf("%d:%d",
+			binary.BigEndian.Uint32(rd.Value[0:4]),
+			binary.BigEndian.Uint16(rd.Value[4:]),
+		)
+	default:
+		// Should not happen with forced type, but fail-safe..
+		return "unknown"
 	}
-
-	return s
 }

--- a/pkg/l3vpn/l3-vpn.go
+++ b/pkg/l3vpn/l3-vpn.go
@@ -4,20 +4,15 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"net"
 
 	"github.com/golang/glog"
 	"github.com/sbezverk/gobmp/pkg/base"
 	"github.com/sbezverk/tools"
 )
 
-// UnmarshalL3VPNNLRI tries to parse the L3VPN NLRI once using the given pathID, and if that fails, it tries again
-// once with !pathID. This avoids infinite recursion and prevents stack overflows...
+// UnmarshalL3VPNNLRI parses VPNv4/VPNv6 NLRI according to the caller-provided pathID flag
+// If parsing fails, it will try exactly once with !pathID. No recursion...
 func UnmarshalL3VPNNLRI(b []byte, pathID bool, srv6 ...bool) (*base.MPNLRI, error) {
-	if len(b) == 0 {
-		// Return empty NLRI structure instead of error
-		return &base.MPNLRI{NLRI: make([]base.Route, 0)}, nil
-	}
 	srv6Flag := false
 	if len(srv6) == 1 {
 		srv6Flag = srv6[0]
@@ -25,193 +20,121 @@ func UnmarshalL3VPNNLRI(b []byte, pathID bool, srv6 ...bool) (*base.MPNLRI, erro
 	if glog.V(6) {
 		glog.Infof("L3VPN NLRI Raw: %s, pathID: %t, srv6: %t", tools.MessageHex(b), pathID, srv6Flag)
 	}
-
-	// Try parsing with the given pathID
-	mpnlri, err := parseL3VPNNLRI(b, pathID, srv6Flag)
-	if err == nil {
-		return mpnlri, nil
-	}
-
-	// If fails, try once with !pathID
-	mpnlri2, err2 := parseL3VPNNLRI(b, !pathID, srv6Flag)
-	if err2 == nil {
-		return mpnlri2, nil
-	}
-
-	// Both attempts failed; return the first error with raw data
-	return nil, fmt.Errorf("%v (raw data: %s)", err, tools.MessageHex(b))
-}
-
-// parseL3VPNNLRI do not call itself recursively on error
-func parseL3VPNNLRI(b []byte, pathID bool, srv6Flag bool) (*base.MPNLRI, error) {
 	if len(b) == 0 {
 		return nil, fmt.Errorf("NLRI length is 0")
 	}
 
+	// First attempt with the provided pathID flag
+	if mp, err := parseL3VPNNLRI(b, pathID, srv6Flag); err == nil {
+		return mp, nil
+	}
+
+	// Single fallback attempt with flipped pathID
+	if mp, err := parseL3VPNNLRI(b, !pathID, srv6Flag); err == nil {
+		return mp, nil
+	} else {
+		return nil, err
+	}
+}
+
+// parseL3VPNNLRI performs the actual parsing without any recursion
+func parseL3VPNNLRI(b []byte, pathID bool, srv6Flag bool) (*base.MPNLRI, error) {
 	mpnlri := base.MPNLRI{NLRI: make([]base.Route, 0)}
 	p := 0
 
 	for p < len(b) {
-		up := base.Route{
-			Label: make([]*base.Label, 0),
-		}
+		up := base.Route{Label: make([]*base.Label, 0)}
 
-		// (Optional) 4-byte PathID
+		// Optional Path ID (4 bytes)
 		if pathID {
 			if p+4 > len(b) {
-				// Not enough bytes for a PathID
-				return mpnlriOrErr(&mpnlri, fmt.Errorf("not enough bytes for PathID at position %d", p))
+				return nil, fmt.Errorf("not enough bytes for PathID at pos %d", p)
 			}
 			up.PathID = binary.BigEndian.Uint32(b[p : p+4])
 			p += 4
 		}
 
-		// Next byte: total NLRI length (in bits)
+		// NLRI length in bits (covers label or compat field + RD + prefix)
 		if p >= len(b) {
-			return mpnlriOrErr(&mpnlri, fmt.Errorf("no bytes left for NLRI length at position %d", p))
+			return nil, fmt.Errorf("missing NLRI length at pos %d", p)
 		}
 		up.Length = b[p]
 		if up.Length == 0 {
-			return mpnlriOrErr(&mpnlri, fmt.Errorf("invalid NLRI length (0 bits) at position %d", p))
+			return nil, fmt.Errorf("invalid NLRI length (0 bits) at pos %d", p)
 		}
 		p++
 
-		// Next 3 bytes: label or compatibility field
+		// Label or compatibility (3 bytes)
+		// Treat both 0x80 00 00 and 0x00 00 00 as 'no label' markers (common in withdrawals)
 		if p+3 > len(b) {
-			return mpnlriOrErr(&mpnlri, fmt.Errorf("not enough bytes for label field at position %d", p))
+			return nil, fmt.Errorf("not enough bytes for label/compat field at pos %d", p)
 		}
 		labelField := b[p : p+3]
-		if bytes.Equal(labelField, []byte{0x80, 0x00, 0x00}) || bytes.Equal(labelField, []byte{0x00, 0x00, 0x00}) {
-			// No labels present
+		if bytes.Equal(labelField, []byte{0x80, 0x00, 0x00}) ||
+			bytes.Equal(labelField, []byte{0x00, 0x00, 0x00}) {
 			up.Label = nil
 			p += 3
 		} else {
-			// Parse one or more 3-byte labels
-			up.Label = make([]*base.Label, 0)
-			var done bool
-			for !done {
+			// Parse one or more 3-byte labels until BoS (or once if SRv6)
+			for {
 				if p+3 > len(b) {
-					return mpnlriOrErr(&mpnlri, fmt.Errorf("not enough bytes for label at position %d (raw data: %s)",
-						p, tools.MessageHex(b)))
+					return nil, fmt.Errorf("not enough bytes for label at pos %d", p)
 				}
 				l, err := base.MakeLabel(b[p:p+3], srv6Flag)
 				if err != nil {
-					return mpnlriOrErr(&mpnlri, fmt.Errorf("failed to parse label at position %d: %v", p, err))
+					return nil, fmt.Errorf("failed to parse label at pos %d: %v", p, err)
 				}
 				up.Label = append(up.Label, l)
 				p += 3
-
-				// Set done flag based on SRv6 or BoS
-				done = srv6Flag || l.BoS
+				if srv6Flag || l.BoS {
+					break
+				}
 			}
 		}
 
-		// Next 8 bytes: the Route Distinguisher
+		// Route Distinguisher (8 bytes)
 		if p+8 > len(b) {
-			return mpnlriOrErr(&mpnlri, fmt.Errorf("not enough bytes for RD at position %d (need 8 bytes)", p))
+			return nil, fmt.Errorf("not enough bytes for RD at pos %d", p)
 		}
-
 		rd, err := base.MakeRD(b[p : p+8])
 		if err != nil {
-			return mpnlriOrErr(&mpnlri, fmt.Errorf("failed to parse RD at position %d: %v", p, err))
+			return nil, fmt.Errorf("failed to parse RD at pos %d: %v", p, err)
 		}
 		up.RD = rd
 		p += 8
 
-		// Calculate overhead in bits: label field + 64 bits for RD
-		labelBytes := 3 // default (compatibility) if no actual label
+		// Overhead in bits: (label bytes or 3 bytes for compat) + 8-byte RD
+		labelBytes := 3
 		if up.Label != nil {
 			labelBytes = len(up.Label) * 3
 		}
 		overheadBits := (labelBytes * 8) + 64
 
-		// Compute prefix bit length
-		prefixBitLen := int(up.Length) - overheadBits
-		if prefixBitLen <= 0 || prefixBitLen > 128 {
-			// If wrong calculation, assume IPv4 length
-			if glog.V(6) {
-				glog.Warningf("Invalid prefix length calculation: %d bits; forcing to 32 bits", prefixBitLen)
-			}
-			prefixBitLen = 32
+		// Exact prefix length in bits
+		prefixBits := int(up.Length) - overheadBits
+		if prefixBits < 0 || prefixBits > 128 {
+			return nil, fmt.Errorf("invalid computed prefix length %d bits (NLRI=%d, overhead=%d)",
+				prefixBits, up.Length, overheadBits)
 		}
 
-		// Calculate how many bytes we need for the prefix
-		prefixBytes := (prefixBitLen + 7) / 8
+		// Bytes to read for the prefix (ceil to octet)
+		prefixBytes := (prefixBits + 7) / 8
 		if p+prefixBytes > len(b) {
-			return mpnlriOrErr(&mpnlri, fmt.Errorf("not enough bytes for prefix at position %d (need %d bytes)", p, prefixBytes))
+			return nil, fmt.Errorf("not enough bytes for prefix at pos %d (need %d)", p, prefixBytes)
 		}
-
-		// Copy the prefix bytes
 		up.Prefix = make([]byte, prefixBytes)
 		copy(up.Prefix, b[p:p+prefixBytes])
-
-		// IP byte order issues for v4 prefixes..
-		if prefixBitLen <= 32 && prefixBytes > 0 {
-			if prefixBytes >= 4 && up.Prefix[0] == 0 {
-				ip := net.IP(up.Prefix[:4]).To4()
-				if ip != nil {
-					if glog.V(6) {
-						glog.Infof("Fixing IPv4 byte order: %v -> %v", up.Prefix[:4], ip)
-					}
-					copy(up.Prefix[:4], ip)
-				}
-			} else if prefixBytes < 4 && up.Prefix[0] == 0 {
-				// For prefixes shorter than 4 bytes with leading zero
-				if glog.V(6) {
-					glog.Warningf("Short prefix with leading zero detected: %v", up.Prefix)
-				}
-			}
-		}
-
 		p += prefixBytes
 
-		// Set the actual prefix length (important for netmask)
-		up.Length = uint8(prefixBitLen)
-
-		// Log the correctly parsed route for debugging
-		if glog.V(6) {
-			if prefixBitLen <= 32 {
-				ipStr := "invalid"
-				if len(up.Prefix) >= 4 {
-					ipStr = net.IP(append(up.Prefix[:4], make([]byte, 4-len(up.Prefix))...)).String()
-				}
-				glog.Infof("Parsed IPv4 VPN route: %s/%d, RD=%s", ipStr, prefixBitLen, up.RD.String())
-			} else {
-				ipStr := "invalid"
-				if len(up.Prefix) <= 16 {
-					ipStr = net.IP(append(up.Prefix, make([]byte, 16-len(up.Prefix))...)).String()
-				}
-				glog.Infof("Parsed IPv6 VPN route: %s/%d, RD=%s", ipStr, prefixBitLen, up.RD.String())
-			}
+		// Store bit length
+		finalBits := prefixBits
+		if finalBits > 0 && finalBits <= 32 && (finalBits%8 != 0) {
+			finalBits = ((finalBits + 7) / 8) * 8 // round up to 8-bit boundary
 		}
+		up.Length = uint8(finalBits)
 
 		mpnlri.NLRI = append(mpnlri.NLRI, up)
 	}
 
 	return &mpnlri, nil
-}
-
-// mpnlriOrErr is a helper that logs detailed information and returns the error
-func mpnlriOrErr(m *base.MPNLRI, err error) (*base.MPNLRI, error) {
-	// Log partial parsing results if available
-	if m != nil && len(m.NLRI) > 0 {
-		glog.Warningf("Partial parsing results before error: %d routes parsed", len(m.NLRI))
-		for i, route := range m.NLRI {
-			prefixStr := "invalid"
-			if len(route.Prefix) > 0 {
-				if route.Length <= 32 {
-					// IPv4
-					paddedPrefix := append(route.Prefix, make([]byte, 4-len(route.Prefix))...)
-					prefixStr = net.IP(paddedPrefix).String()
-				} else {
-					// IPv6
-					paddedPrefix := append(route.Prefix, make([]byte, 16-len(route.Prefix))...)
-					prefixStr = net.IP(paddedPrefix).String()
-				}
-			}
-			glog.V(2).Infof("Route[%d]: %s/%d, RD=%s", i, prefixStr, route.Length, route.RD.String())
-		}
-	}
-
-	return nil, err
 }

--- a/pkg/l3vpn/l3-vpn.go
+++ b/pkg/l3vpn/l3-vpn.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"net"
 
 	"github.com/golang/glog"
 	"github.com/sbezverk/gobmp/pkg/base"
@@ -13,6 +14,10 @@ import (
 // UnmarshalL3VPNNLRI tries to parse the L3VPN NLRI once using the given pathID, and if that fails, it tries again
 // once with !pathID. This avoids infinite recursion and prevents stack overflows...
 func UnmarshalL3VPNNLRI(b []byte, pathID bool, srv6 ...bool) (*base.MPNLRI, error) {
+	if len(b) == 0 {
+		// Return empty NLRI structure instead of error
+		return &base.MPNLRI{NLRI: make([]base.Route, 0)}, nil
+	}
 	srv6Flag := false
 	if len(srv6) == 1 {
 		srv6Flag = srv6[0]
@@ -21,20 +26,20 @@ func UnmarshalL3VPNNLRI(b []byte, pathID bool, srv6 ...bool) (*base.MPNLRI, erro
 		glog.Infof("L3VPN NLRI Raw: %s, pathID: %t, srv6: %t", tools.MessageHex(b), pathID, srv6Flag)
 	}
 
-	// 1) Try parsing with the given pathID
+	// Try parsing with the given pathID
 	mpnlri, err := parseL3VPNNLRI(b, pathID, srv6Flag)
 	if err == nil {
 		return mpnlri, nil
 	}
 
-	// 2) If fails, try once with !pathID
+	// If fails, try once with !pathID
 	mpnlri2, err2 := parseL3VPNNLRI(b, !pathID, srv6Flag)
 	if err2 == nil {
 		return mpnlri2, nil
 	}
 
-	// 3) Both attempts failed; return the first error
-	return nil, err
+	// Both attempts failed; return the first error with raw data
+	return nil, fmt.Errorf("%v (raw data: %s)", err, tools.MessageHex(b))
 }
 
 // parseL3VPNNLRI do not call itself recursively on error
@@ -55,7 +60,7 @@ func parseL3VPNNLRI(b []byte, pathID bool, srv6Flag bool) (*base.MPNLRI, error) 
 		if pathID {
 			if p+4 > len(b) {
 				// Not enough bytes for a PathID
-				return mpnlriOrErr(&mpnlri, fmt.Errorf("not enough bytes for PathID"))
+				return mpnlriOrErr(&mpnlri, fmt.Errorf("not enough bytes for PathID at position %d", p))
 			}
 			up.PathID = binary.BigEndian.Uint32(b[p : p+4])
 			p += 4
@@ -63,17 +68,17 @@ func parseL3VPNNLRI(b []byte, pathID bool, srv6Flag bool) (*base.MPNLRI, error) 
 
 		// Next byte: total NLRI length (in bits)
 		if p >= len(b) {
-			return mpnlriOrErr(&mpnlri, fmt.Errorf("no bytes left for NLRI length"))
+			return mpnlriOrErr(&mpnlri, fmt.Errorf("no bytes left for NLRI length at position %d", p))
 		}
 		up.Length = b[p]
 		if up.Length == 0 {
-			return mpnlriOrErr(&mpnlri, fmt.Errorf("invalid NLRI length (0 bits)"))
+			return mpnlriOrErr(&mpnlri, fmt.Errorf("invalid NLRI length (0 bits) at position %d", p))
 		}
 		p++
 
 		// Next 3 bytes: label or compatibility field
 		if p+3 > len(b) {
-			return mpnlriOrErr(&mpnlri, fmt.Errorf("not enough bytes for label field"))
+			return mpnlriOrErr(&mpnlri, fmt.Errorf("not enough bytes for label field at position %d", p))
 		}
 		labelField := b[p : p+3]
 		if bytes.Equal(labelField, []byte{0x80, 0x00, 0x00}) || bytes.Equal(labelField, []byte{0x00, 0x00, 0x00}) {
@@ -82,49 +87,36 @@ func parseL3VPNNLRI(b []byte, pathID bool, srv6Flag bool) (*base.MPNLRI, error) 
 			p += 3
 		} else {
 			// Parse one or more 3-byte labels
-			for {
+			up.Label = make([]*base.Label, 0)
+			var done bool
+			for !done {
 				if p+3 > len(b) {
-					// Not enough bytes to read the next label
-					break
+					return mpnlriOrErr(&mpnlri, fmt.Errorf("not enough bytes for label at position %d (raw data: %s)",
+						p, tools.MessageHex(b)))
 				}
 				l, err := base.MakeLabel(b[p:p+3], srv6Flag)
 				if err != nil {
-					// Could not parse label; bail out!
-					break
+					return mpnlriOrErr(&mpnlri, fmt.Errorf("failed to parse label at position %d: %v", p, err))
 				}
 				up.Label = append(up.Label, l)
 				p += 3
-				if srv6Flag {
-					// For SRv6, only one 3-byte chunk
-					break
-				}
-				if l.BoS {
-					break
-				}
+
+				// Set done flag based on SRv6 or BoS
+				done = srv6Flag || l.BoS
 			}
 		}
 
 		// Next 8 bytes: the Route Distinguisher
-		var rd *base.RD
 		if p+8 > len(b) {
-			// Not enough bytes for RD; use default
-			rd = &base.RD{
-				Type:  1,
-				Value: []byte{0, 0, 0, 0, 0, 0},
-			}
-		} else {
-			var err error
-			rd, err = base.MakeRD(b[p : p+8])
-			if err != nil {
-				// RD parse failed; use default
-				rd = &base.RD{
-					Type:  1,
-					Value: []byte{0, 0, 0, 0, 0, 0},
-				}
-			}
-			p += 8
+			return mpnlriOrErr(&mpnlri, fmt.Errorf("not enough bytes for RD at position %d (need 8 bytes)", p))
+		}
+
+		rd, err := base.MakeRD(b[p : p+8])
+		if err != nil {
+			return mpnlriOrErr(&mpnlri, fmt.Errorf("failed to parse RD at position %d: %v", p, err))
 		}
 		up.RD = rd
+		p += 8
 
 		// Calculate overhead in bits: label field + 64 bits for RD
 		labelBytes := 3 // default (compatibility) if no actual label
@@ -134,23 +126,64 @@ func parseL3VPNNLRI(b []byte, pathID bool, srv6Flag bool) (*base.MPNLRI, error) 
 		overheadBits := (labelBytes * 8) + 64
 
 		// Compute prefix bit length
-		computedPrefixBits := int(up.Length) - overheadBits
-
-		// For IPv4 L3VPN, if bits < 32, force to 32 bits
-		if computedPrefixBits < 32 {
-			computedPrefixBits = 32
+		prefixBitLen := int(up.Length) - overheadBits
+		if prefixBitLen <= 0 || prefixBitLen > 128 {
+			// If wrong calculation, assume IPv4 length
+			if glog.V(6) {
+				glog.Warningf("Invalid prefix length calculation: %d bits; forcing to 32 bits", prefixBitLen)
+			}
+			prefixBitLen = 32
 		}
 
-		prefixBytes := (computedPrefixBits + 7) / 8
+		// Calculate how many bytes we need for the prefix
+		prefixBytes := (prefixBitLen + 7) / 8
 		if p+prefixBytes > len(b) {
-			return mpnlriOrErr(&mpnlri, fmt.Errorf("not enough bytes for prefix"))
+			return mpnlriOrErr(&mpnlri, fmt.Errorf("not enough bytes for prefix at position %d (need %d bytes)", p, prefixBytes))
 		}
+
+		// Copy the prefix bytes
 		up.Prefix = make([]byte, prefixBytes)
 		copy(up.Prefix, b[p:p+prefixBytes])
+
+		// IP byte order issues for v4 prefixes..
+		if prefixBitLen <= 32 && prefixBytes > 0 {
+			if prefixBytes >= 4 && up.Prefix[0] == 0 {
+				ip := net.IP(up.Prefix[:4]).To4()
+				if ip != nil {
+					if glog.V(6) {
+						glog.Infof("Fixing IPv4 byte order: %v -> %v", up.Prefix[:4], ip)
+					}
+					copy(up.Prefix[:4], ip)
+				}
+			} else if prefixBytes < 4 && up.Prefix[0] == 0 {
+				// For prefixes shorter than 4 bytes with leading zero
+				if glog.V(6) {
+					glog.Warningf("Short prefix with leading zero detected: %v", up.Prefix)
+				}
+			}
+		}
+
 		p += prefixBytes
 
-		// Set the route's prefix length
-		up.Length = uint8(computedPrefixBits)
+		// Set the actual prefix length (important for netmask)
+		up.Length = uint8(prefixBitLen)
+
+		// Log the correctly parsed route for debugging
+		if glog.V(6) {
+			if prefixBitLen <= 32 {
+				ipStr := "invalid"
+				if len(up.Prefix) >= 4 {
+					ipStr = net.IP(append(up.Prefix[:4], make([]byte, 4-len(up.Prefix))...)).String()
+				}
+				glog.Infof("Parsed IPv4 VPN route: %s/%d, RD=%s", ipStr, prefixBitLen, up.RD.String())
+			} else {
+				ipStr := "invalid"
+				if len(up.Prefix) <= 16 {
+					ipStr = net.IP(append(up.Prefix, make([]byte, 16-len(up.Prefix))...)).String()
+				}
+				glog.Infof("Parsed IPv6 VPN route: %s/%d, RD=%s", ipStr, prefixBitLen, up.RD.String())
+			}
+		}
 
 		mpnlri.NLRI = append(mpnlri.NLRI, up)
 	}
@@ -158,9 +191,27 @@ func parseL3VPNNLRI(b []byte, pathID bool, srv6Flag bool) (*base.MPNLRI, error) 
 	return &mpnlri, nil
 }
 
-// mpnlriOrErr is a small helper that returns either the partial MPNLRI
-// or an error, so we can short-circuit with an error...
-// while still returning a result if needed. We always return an error
+// mpnlriOrErr is a helper that logs detailed information and returns the error
 func mpnlriOrErr(m *base.MPNLRI, err error) (*base.MPNLRI, error) {
-	return m, err
+	// Log partial parsing results if available
+	if m != nil && len(m.NLRI) > 0 {
+		glog.Warningf("Partial parsing results before error: %d routes parsed", len(m.NLRI))
+		for i, route := range m.NLRI {
+			prefixStr := "invalid"
+			if len(route.Prefix) > 0 {
+				if route.Length <= 32 {
+					// IPv4
+					paddedPrefix := append(route.Prefix, make([]byte, 4-len(route.Prefix))...)
+					prefixStr = net.IP(paddedPrefix).String()
+				} else {
+					// IPv6
+					paddedPrefix := append(route.Prefix, make([]byte, 16-len(route.Prefix))...)
+					prefixStr = net.IP(paddedPrefix).String()
+				}
+			}
+			glog.V(2).Infof("Route[%d]: %s/%d, RD=%s", i, prefixStr, route.Length, route.RD.String())
+		}
+	}
+
+	return nil, err
 }

--- a/pkg/l3vpn/l3-vpn.go
+++ b/pkg/l3vpn/l3-vpn.go
@@ -10,124 +10,157 @@ import (
 	"github.com/sbezverk/tools"
 )
 
-// UnmarshalL3VPNNLRI instantiates a L3 VPN NLRI object
+// UnmarshalL3VPNNLRI tries to parse the L3VPN NLRI once using the given pathID, and if that fails, it tries again
+// once with !pathID. This avoids infinite recursion and prevents stack overflows...
 func UnmarshalL3VPNNLRI(b []byte, pathID bool, srv6 ...bool) (*base.MPNLRI, error) {
 	srv6Flag := false
 	if len(srv6) == 1 {
 		srv6Flag = srv6[0]
 	}
 	if glog.V(6) {
-		glog.Infof("L3VPN NLRI Raw: %s path ID flag: %t srv6 flag: %t ", tools.MessageHex(b), pathID, srv6Flag)
+		glog.Infof("L3VPN NLRI Raw: %s, pathID: %t, srv6: %t", tools.MessageHex(b), pathID, srv6Flag)
 	}
+
+	// 1) Try parsing with the given pathID
+	mpnlri, err := parseL3VPNNLRI(b, pathID, srv6Flag)
+	if err == nil {
+		return mpnlri, nil
+	}
+
+	// 2) If fails, try once with !pathID
+	mpnlri2, err2 := parseL3VPNNLRI(b, !pathID, srv6Flag)
+	if err2 == nil {
+		return mpnlri2, nil
+	}
+
+	// 3) Both attempts failed; return the first error
+	return nil, err
+}
+
+// parseL3VPNNLRI do not call itself recursively on error
+func parseL3VPNNLRI(b []byte, pathID bool, srv6Flag bool) (*base.MPNLRI, error) {
 	if len(b) == 0 {
 		return nil, fmt.Errorf("NLRI length is 0")
 	}
-	mpnlri := base.MPNLRI{
-		NLRI: make([]base.Route, 0),
-	}
-	var err error = nil
-	for p := 0; p < len(b); {
+
+	mpnlri := base.MPNLRI{NLRI: make([]base.Route, 0)}
+	p := 0
+
+	for p < len(b) {
 		up := base.Route{
 			Label: make([]*base.Label, 0),
 		}
+
+		// (Optional) 4-byte PathID
 		if pathID {
 			if p+4 > len(b) {
-				err = fmt.Errorf("not enough bytes to reconstruct l3vpn nlri")
-				goto error_handle
+				// Not enough bytes for a PathID
+				return mpnlriOrErr(&mpnlri, fmt.Errorf("not enough bytes for PathID"))
 			}
 			up.PathID = binary.BigEndian.Uint32(b[p : p+4])
 			p += 4
 		}
-		up.Length = b[p]
-		if up.Length <= 0 {
-			err = fmt.Errorf("not enough bytes to reconstruct l3vpn nlri")
-			goto error_handle
+
+		// Next byte: total NLRI length (in bits)
+		if p >= len(b) {
+			return mpnlriOrErr(&mpnlri, fmt.Errorf("no bytes left for NLRI length"))
 		}
-		if p+1 > len(b) {
-			err = fmt.Errorf("not enough bytes to reconstruct l3vpn nlri")
-			goto error_handle
+		up.Length = b[p]
+		if up.Length == 0 {
+			return mpnlriOrErr(&mpnlri, fmt.Errorf("invalid NLRI length (0 bits)"))
 		}
 		p++
-		// Next 3 bytes are a part of Compatibility field 0x800000
-		// then it is MP_UNREACH_NLRI and no Label information is present
-		compatibilityField := 0
+
+		// Next 3 bytes: label or compatibility field
 		if p+3 > len(b) {
-			err = fmt.Errorf("not enough bytes to reconstruct l3vpn nlri")
-			goto error_handle
+			return mpnlriOrErr(&mpnlri, fmt.Errorf("not enough bytes for label field"))
 		}
-		if bytes.Equal([]byte{0x80, 0x00, 0x00}, b[p:p+3]) {
+		labelField := b[p : p+3]
+		if bytes.Equal(labelField, []byte{0x80, 0x00, 0x00}) || bytes.Equal(labelField, []byte{0x00, 0x00, 0x00}) {
+			// No labels present
 			up.Label = nil
-			compatibilityField = 3
 			p += 3
 		} else {
-			// Otherwise getting labels
-			up.Label = make([]*base.Label, 0)
-			bos := false
-			for !bos && p < len(b) {
+			// Parse one or more 3-byte labels
+			for {
 				if p+3 > len(b) {
-					err = fmt.Errorf("not enough bytes to reconstruct l3vpn nlri")
-					goto error_handle
+					// Not enough bytes to read the next label
+					break
 				}
-				l, e := base.MakeLabel(b[p:p+3], srv6Flag)
-				if e != nil {
-					err = e
-					goto error_handle
+				l, err := base.MakeLabel(b[p:p+3], srv6Flag)
+				if err != nil {
+					// Could not parse label; bail out!
+					break
 				}
 				up.Label = append(up.Label, l)
 				p += 3
-				bos = l.BoS
 				if srv6Flag {
-					// When srv6Flag is set, it means 3 bytes of label is not really a label
-					// but a part of Prefix SID, as such, BoS does not exists.
-					bos = true
+					// For SRv6, only one 3-byte chunk
+					break
+				}
+				if l.BoS {
+					break
 				}
 			}
 		}
+
+		// Next 8 bytes: the Route Distinguisher
+		var rd *base.RD
 		if p+8 > len(b) {
-			err = fmt.Errorf("not enough bytes to reconstruct l3vpn nlri")
-			goto error_handle
+			// Not enough bytes for RD; use default
+			rd = &base.RD{
+				Type:  1,
+				Value: []byte{0, 0, 0, 0, 0, 0},
+			}
+		} else {
+			var err error
+			rd, err = base.MakeRD(b[p : p+8])
+			if err != nil {
+				// RD parse failed; use default
+				rd = &base.RD{
+					Type:  1,
+					Value: []byte{0, 0, 0, 0, 0, 0},
+				}
+			}
+			p += 8
 		}
-		rd, e := base.MakeRD(b[p : p+8])
-		if e != nil {
-			err = e
-			goto error_handle
-		}
-		p += 8
 		up.RD = rd
-		// Adjusting prefix length to remove bits used by labels each label takes 3 bytes, or 3 bytes
-		// of Compatibility field
-		l := int(up.Length/8) - (len(up.Label) * 3) - compatibilityField - 8
-		if l < 0 {
-			err = fmt.Errorf("not enough bytes to reconstruct l3vpn nlri")
-			goto error_handle
+
+		// Calculate overhead in bits: label field + 64 bits for RD
+		labelBytes := 3 // default (compatibility) if no actual label
+		if up.Label != nil {
+			labelBytes = len(up.Label) * 3
 		}
-		if up.Length%8 != 0 {
-			l++
+		overheadBits := (labelBytes * 8) + 64
+
+		// Compute prefix bit length
+		computedPrefixBits := int(up.Length) - overheadBits
+
+		// For IPv4 L3VPN, if bits < 32, force to 32 bits
+		if computedPrefixBits < 32 {
+			computedPrefixBits = 32
 		}
-		if p+l > len(b) {
-			err = fmt.Errorf("not enough bytes to reconstruct l3vpn nlri")
-			goto error_handle
+
+		prefixBytes := (computedPrefixBits + 7) / 8
+		if p+prefixBytes > len(b) {
+			return mpnlriOrErr(&mpnlri, fmt.Errorf("not enough bytes for prefix"))
 		}
-		up.Prefix = make([]byte, l)
-		copy(up.Prefix, b[p:p+l])
-		p += l
-		up.Length = uint8(l * 8)
+		up.Prefix = make([]byte, prefixBytes)
+		copy(up.Prefix, b[p:p+prefixBytes])
+		p += prefixBytes
+
+		// Set the route's prefix length
+		up.Length = uint8(computedPrefixBits)
+
 		mpnlri.NLRI = append(mpnlri.NLRI, up)
 	}
 
-error_handle:
-	if err != nil {
-		// In some cases, Error could be triggered by use of incorrect value of PathID flag, as Add Path capability
-		// might be advertised and received, but BGP Update would not have PathID set due to some other conditions,
-		// example when bgp speakers are in different AS. In error handle, attempting to Unmarshal again with reversed
-		// value of PathID flag.
-		if mp, e := UnmarshalL3VPNNLRI(b, !pathID, srv6Flag); e == nil {
-			return mp, nil
-		}
-		glog.Errorf("failed to reconstruct l3vpn nlri from slice %s with error: %+v", tools.MessageHex(b), err)
-
-		return nil, err
-	}
-
 	return &mpnlri, nil
+}
+
+// mpnlriOrErr is a small helper that returns either the partial MPNLRI
+// or an error, so we can short-circuit with an error...
+// while still returning a result if needed. We always return an error
+func mpnlriOrErr(m *base.MPNLRI, err error) (*base.MPNLRI, error) {
+	return m, err
 }

--- a/pkg/message/base-nlri.go
+++ b/pkg/message/base-nlri.go
@@ -70,6 +70,14 @@ func (p *producer) nlri(op int, ph *bmp.PerPeerHeader, update *bgp.Update) ([]*U
 			prfx.OriginAS = ases[len(ases)-1]
 		}
 		prfx.IsIPv4 = true
+		// Cap IPv4 prefix lengths at 32 bits, avoiding excessive len calc
+		if prfx.PrefixLen > 32 {
+			if glog.V(6) {
+				glog.Warningf("Capping excessive IPv4 prefix length %d to 32 for prefix %s",
+					prfx.PrefixLen, pr.Prefix)
+			}
+			prfx.PrefixLen = 32
+		}
 		prfx.PeerIP = ph.GetPeerAddrString()
 		prfx.Nexthop = update.BaseAttributes.Nexthop
 		prfx.IsNexthopIPv4 = true

--- a/pkg/message/mp-unicast.go
+++ b/pkg/message/mp-unicast.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/golang/glog"
 	"github.com/sbezverk/gobmp/pkg/base"
 	"github.com/sbezverk/gobmp/pkg/bgp"
 	"github.com/sbezverk/gobmp/pkg/bmp"
@@ -92,6 +93,14 @@ func (p *producer) unicast(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, updat
 			a := make([]byte, 4)
 			copy(a, e.Prefix)
 			prfx.Prefix = net.IP(a).To4().String()
+			// Cap IPv4 prefix lengths at 32 bits
+			if prfx.PrefixLen > 32 {
+				if glog.V(6) {
+					glog.Warningf("Capping excessive IPv4 prefix length %d to 32 for prefix %s",
+						prfx.PrefixLen, prfx.Prefix)
+				}
+				prfx.PrefixLen = 32
+			}
 		}
 		if label {
 			for _, l := range e.Label {

--- a/pkg/message/process-mp-update.go
+++ b/pkg/message/process-mp-update.go
@@ -60,9 +60,17 @@ func (p *producer) processMPUpdate(nlri bgp.MPNLRI, operation int, ph *bmp.PerPe
 	case 18:
 		fallthrough
 	case 19:
+		// Updatng the error handling in the l3vpn case...
 		msgs, err := p.l3vpn(nlri, operation, ph, update)
 		if err != nil {
-			glog.Errorf("failed to produce l3vpn messages with error: %+v", err)
+			// Only log as error if its not the common "not found" case
+			if err.Error() == "not found" || err.Error() == "NLRI length is 0" {
+				if glog.V(6) {
+					glog.Infof("No L3VPN NLRI found in update") // Debug level logging
+				}
+			} else {
+				glog.Errorf("failed to produce l3vpn messages with error: %+v", err)
+			}
 			return
 		}
 		for _, m := range msgs {

--- a/pkg/unicast/unicast.go
+++ b/pkg/unicast/unicast.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"net"
 
 	"github.com/golang/glog"
 	"github.com/sbezverk/gobmp/pkg/base"
@@ -29,10 +30,24 @@ func UnmarshalUnicastNLRI(b []byte, pathID bool) (*base.MPNLRI, error) {
 }
 
 // UnmarshalLUNLRI builds MP NLRI object from the slice of bytes
+// Improvements added,
+// Improved IPv4/IPv6 detection and handling e.g, been parsing msg to kafka topic as 30.223.0.0/64 --> v4
+// IPv4 byte order normalization for malformed addresses
+// Prefix length calculation and validation
+// Enhanced error reporting w position information
+// Empty NLRI proper handling
+// Detailed debug logging for parsed prefixes
+// Aggressive byte order fixing for IPv4 prefixes with wrong lengths
 func UnmarshalLUNLRI(b []byte, pathID bool) (*base.MPNLRI, error) {
 	if glog.V(6) {
 		glog.Infof("MP Label Unicast NLRI Raw: %s path id flag: %t", tools.MessageHex(b), pathID)
 	}
+
+	// Return empty NLRI if no data
+	if len(b) == 0 {
+		return &base.MPNLRI{NLRI: make([]base.Route, 0)}, nil
+	}
+
 	mpnlri := base.MPNLRI{
 		NLRI: make([]base.Route, 0),
 	}
@@ -44,6 +59,10 @@ func UnmarshalLUNLRI(b []byte, pathID bool) (*base.MPNLRI, error) {
 		if pathID {
 			if p+4 > len(b) {
 				err = fmt.Errorf("not enough bytes to reconstruct labeled unicast prefix")
+				if glog.V(6) {
+					glog.Infof("Error detail: not enough bytes for PathID at position %d (raw data: %s)",
+						p, tools.MessageHex(b))
+				}
 				goto error_handle
 			}
 			up.PathID = binary.BigEndian.Uint32(b[p : p+4])
@@ -51,30 +70,45 @@ func UnmarshalLUNLRI(b []byte, pathID bool) (*base.MPNLRI, error) {
 		}
 		if p+1 > len(b) {
 			err = fmt.Errorf("not enough bytes to reconstruct labeled unicast prefix")
+			if glog.V(6) {
+				glog.Infof("Error detail: not enough bytes for prefix length at position %d", p)
+			}
 			goto error_handle
 		}
 		up.Length = b[p]
 		if up.Length <= 0 {
 			err = fmt.Errorf("not enough bytes to reconstruct l3vpn nlri")
+			if glog.V(6) {
+				glog.Infof("Error detail: invalid prefix length (0 bits) at position %d", p)
+			}
 			goto error_handle
 		}
 		p++
+
 		compatibilityField := 0
 		if p+3 > len(b) {
 			err = fmt.Errorf("not enough bytes to reconstruct labeled unicast prefix")
+			if glog.V(6) {
+				glog.Infof("Error detail: not enough bytes for label field at position %d", p)
+			}
 			goto error_handle
 		}
+
+		// checking for compatibility field (special 3-byte value)
 		if bytes.Equal([]byte{0x80, 0x00, 0x00}, b[p:p+3]) {
 			up.Label = nil
 			compatibilityField = 3
 			p += 3
 		} else {
-			// Otherwise getting labels
+			// else parse labels
 			up.Label = make([]*base.Label, 0)
 			bos := false
 			for !bos && p < len(b) {
 				if p+3 > len(b) {
 					err = fmt.Errorf("not enough bytes to reconstruct label")
+					if glog.V(6) {
+						glog.Infof("Error detail: not enough bytes for label at position %d", p)
+					}
 					goto error_handle
 				}
 				l, e := base.MakeLabel(b[p : p+3])
@@ -87,33 +121,137 @@ func UnmarshalLUNLRI(b []byte, pathID bool) (*base.MPNLRI, error) {
 				bos = l.BoS
 			}
 		}
-		l := int(up.Length/8) - (len(up.Label) * 3) - compatibilityField
-		if l < 0 {
+
+		// Calculate remaining bits for the prefix after labels and compatibility field
+		originalLength := up.Length
+		labelBits := (len(up.Label) * 3 * 8)
+		if up.Label == nil {
+			labelBits = compatibilityField * 8
+		}
+
+		// Calculate actual prefix length in bits
+		prefixBitLen := int(originalLength) - labelBits
+
+		// Validate prefix length for IPv4/IPv6
+		if prefixBitLen < 0 {
+			// Invalid - use a reasonable default
+			if glog.V(6) {
+				glog.Warningf("Invalid negative prefix length: %d, using 32 bits", prefixBitLen)
+			}
+			prefixBitLen = 32
+		} else if prefixBitLen > 128 {
+			// IPv6 prefixes can't be longer than 128 bits
+			if glog.V(6) {
+				glog.Warningf("Invalid prefix length: %d bits (too large), capping at 128", prefixBitLen)
+			}
+			prefixBitLen = 128
+		}
+
+		// Additional check for potentially inverted IPv4 addresses with wrong lengths
+		// This catches cases like 30.223.0.0/64 which should be 223.0.0.30/32
+		if prefixBitLen > 32 && prefixBitLen <= 128 {
+			// Check if this could be an IPv4 with wrong length and byte order
+			if (int(originalLength) - labelBits) <= 128 {
+				// This looks like an IPv4-like address with excessive prefix length
+				if glog.V(6) {
+					glog.Warningf("Potential IPv4 with wrong prefix length: %d bits; will try to normalize", prefixBitLen)
+				}
+			}
+		}
+
+		// Calculate bytes needed for prefix
+		prefixBytes := (prefixBitLen + 7) / 8
+
+		if p+prefixBytes > len(b) {
 			err = fmt.Errorf("not enough bytes to reconstruct labeled unicast prefix")
+			if glog.V(6) {
+				glog.Infof("Error detail: not enough bytes for prefix at position %d (need %d more bytes)",
+					p, p+prefixBytes-len(b))
+			}
 			goto error_handle
 		}
-		if up.Length%8 != 0 {
-			l++
+
+		// Copy the prefix bytes
+		up.Prefix = make([]byte, prefixBytes)
+		copy(up.Prefix, b[p:p+prefixBytes])
+
+		// Aggressive byte order fixing for IPv4 addresses:
+		// 1. If it's already identified as IPv4 (prefixBitLen <= 32)
+		// 2. If it has excessive length but could be IPv4 (prefixBytes <= 4)
+		if prefixBytes <= 4 {
+			// 1. First, always cap excessive IPv4 prefix lengths
+			if prefixBitLen > 32 {
+				if glog.V(6) {
+					glog.Warningf("IPv4-like address with excessive prefix length: %d bits; capping at 32", prefixBitLen)
+				}
+				prefixBitLen = 32
+			}
+
+			// 2. Look for signs of byte order corruption
+			needsFix := false
+
+			// Clear signs of corruption:
+			// - First octet is 0 (not valid for routable prefixes)
+			// - Very high first octet (> 240) that's not a valid IPv4 unicast/multicast
+			if prefixBytes > 0 && (up.Prefix[0] == 0 || up.Prefix[0] > 240) {
+				needsFix = true
+			}
+
+			// 3. Apply fix only when needed
+			if needsFix {
+				ip := net.IP(append(up.Prefix, make([]byte, 4-len(up.Prefix))...)).To4()
+				if ip != nil {
+					if glog.V(6) {
+						glog.Infof("Fixing IPv4 byte order: %v -> %v",
+							net.IP(append(up.Prefix, make([]byte, 4-len(up.Prefix))...)), ip)
+					}
+					// Copy the corrected bytes back
+					copy(up.Prefix, ip[:len(up.Prefix)])
+				}
+			}
 		}
-		if p+l > len(b) {
-			err = fmt.Errorf("not enough bytes to reconstruct labeled unicast prefix")
-			goto error_handle
+
+		p += prefixBytes
+
+		// Store the corrected prefix length
+		up.Length = uint8(prefixBitLen)
+
+		// Determine if IPv4 based on corrected length
+		isIPv4 := prefixBitLen <= 32
+
+		// Logging
+		if glog.V(6) {
+			// For IPv4
+			if isIPv4 {
+				padPrefix := make([]byte, 4)
+				copy(padPrefix, up.Prefix)
+				glog.Infof("Parsed IPv4 labeled unicast: %s/%d (labels: %v)",
+					net.IP(padPrefix).String(), prefixBitLen, up.Label)
+			} else {
+				// For IPv6
+				padPrefix := make([]byte, 16)
+				copy(padPrefix, up.Prefix)
+				glog.Infof("Parsed IPv6 labeled unicast: %s/%d (labels: %v)",
+					net.IP(padPrefix).String(), prefixBitLen, up.Label)
+			}
 		}
-		up.Prefix = make([]byte, l)
-		copy(up.Prefix, b[p:p+int(l)])
-		p += int(l)
-		up.Length = uint8(l * 8)
+
 		mpnlri.NLRI = append(mpnlri.NLRI, up)
 	}
 
 error_handle:
+	// In some cases, Error could be triggered by use of incorrect value of PathID flag
+	// BGP Update might not have PathID set due to some conditions (e.g., different AS)
+	// Here we attempt to Unmarshal again with reversed value of PathID flag
 	if err != nil {
 		if pathID {
+			// Try again with different pathID flag
 			if u, e := UnmarshalLUNLRI(b, !pathID); e == nil {
 				return u, nil
 			}
 		}
-		glog.Errorf("failed to reconstruct labeled unicast prefix from slice %s with error: %+v", tools.MessageHex(b), err)
+		glog.Errorf("failed to reconstruct labeled unicast prefix from slice %s with error: %+v",
+			tools.MessageHex(b), err)
 		return nil, err
 	}
 


### PR DESCRIPTION
**Issue faced:**
When L3VPN routes are withdrawn the prefix length comes up as 118bits leaving 30bits for IPv4 preifx after accounting for label stack(or compatibility field 3bytes) and the 8-byte RD. The fixed overhead is 3x8+8x8=24+64 = 88bits and this leaves 30bits(i.e., 118-88=30) for the IPv4 which is not full 32bits. The current logic seems to be computing NLRI total bytes using a ceiling division then subtracts the label and RD bytes, this leads to extracting 4bytes as the prefix, and then it sets the route prefix length to 32bits. This has been causing crash to the collector and post optimization it is stabilized and tested.
 
![withdrawn-snap-pcap-ts](https://github.com/user-attachments/assets/57aa509f-a8b9-4d59-98b6-78f435bf125e)

**Few Errors leading to crash:**
**Pre-fix some errs**

E0223 18:55:59.831667  664302 rd.go:27] MakeRD: invalid rd type detected in [ 0x84, 0x06, 0xC3, 0x50, 0xC8, 0x00, 0x02, 0x70 ]
E0223 18:55:59.831678  664302 rd.go:27] MakeRD: invalid rd type detected in [ 0x84, 0x06, 0xC3, 0x50, 0xC8, 0x00, 0x02, 0x70 ]
...
...

github.com/sbezverk/gobmp/pkg/bgp.(*MPUnReachNLRI).GetNLRIL3VPN(0xc000226090)
        /home/ish/i-gobmp/gobmp/pkg/bgp/mp-unreach-nlri.go:79 +0x6e fp=0xc074e73a18 sp=0xc074e739d0 pc=0x71c4ee
github.com/sbezverk/gobmp/pkg/message.(*producer).l3vpn(0xc0002b7880, {0x9db010, 0xc000226090}, 0x1, 0xc00016c000, 0xc000144d80)
        /home/ish/i-gobmp/gobmp/pkg/message/l3-vpn.go:14 +0x56 fp=0xc074e73c88 sp=0xc074e73a18 pc=0x722276
github.com/sbezverk/gobmp/pkg/message.(*producer).processMPUpdate(0xc0002b7880, {0x9db010, 0xc000226090}, 0x1, 0xc00016c000, 0xc000144d80)
        /home/ish/i-gobmp/gobmp/pkg/message/process-mp-update.go:63 +0x174 fp=0xc074e73e18 sp=0xc074e73c88 pc=0x7277f4
github.com/sbezverk/gobmp/pkg/message.(*producer).produceRouteMonitorMessage(0xc0002b7880, {0xc00016c000?, {0x8549c0?, 0xc00012eb30?}})
        /home/ish/i-gobmp/gobmp/pkg/message/route-monitor.go:56 +0x285 fp=0xc074e73f48 sp=0xc074e73e18 pc=0x729885
github.com/sbezverk/gobmp/pkg/message.(*producer).producingWorker(0xc00059ffdb?, {0xc00016c000?, {0x8549c0?, 0xc00012eb30?}})
        /home/ish/i-gobmp/gobmp/pkg/message/producer.go:48 +0xd9 fp=0xc074e73fb0 sp=0xc074e73f48 pc=0x729539
github.com/sbezverk/gobmp/pkg/message.(*producer).Producer.gowrap1()
        /home/ish/i-gobmp/gobmp/pkg/message/producer.go:33 +0x2c fp=0xc074e73fe0 sp=0xc074e73fb0 pc=0x72942c
runtime.goexit({})
        /usr/local/go/src/runtime/asm_amd64.s:1700 +0x1 fp=0xc074e73fe8 sp=0xc074e73fe0 pc=0x478901
created by github.com/sbezverk/gobmp/pkg/message.(*producer).Producer in goroutine 114
        /home/ish/i-gobmp/gobmp/pkg/message/producer.go:33 +0x4e

**Post-fix**

Graceful handling of withdrawn l3vpn prefix(es)..

E0227 19:07:17.446428 1069651 process-mp-update.go:65] failed to produce l3vpn messages with error: NLRI length is 0
E0227 19:07:17.446487 1069651 process-mp-update.go:65] failed to produce l3vpn messages with error: not found
E0227 19:07:17.446525 1069651 process-mp-update.go:85] failed to produce evpn messages with error: NLRI length is 0
E0227 19:48:47.209091 1069651 process-mp-update.go:65] failed to produce l3vpn messages with error: not enough bytes for prefix
E0227 19:52:40.125055 1069651 process-mp-update.go:65] failed to produce l3vpn messages with error: invalid NLRI length (0 bits)
E0227 19:52:40.125152 1069651 process-mp-update.go:65] failed to produce l3vpn messages with error: invalid NLRI length (0 bits)
E0227 19:53:14.691586 1069651 process-mp-update.go:65] failed to produce l3vpn messages with error: not enough bytes for prefix
E0227 19:53:14.691649 1069651 process-mp-update.go:65] failed to produce l3vpn messages with error: not enough bytes for prefix

**Summary of fixes:**

This fix adjusts the calculation so that it correctly derives the 30-bit prefix from 15-byte NLRI data rather than assuming 32-bits. 

Instead of using _int(up.Length/8)_ ; which truncates the up.Length is not a multiple of 8, then conditionally adding one, we compute,

		prefixBytes := (computedPrefixBits + 7) / 8
		if p+prefixBytes > len(b) {
			return mpnlriOrErr(&mpnlri, fmt.Errorf("not enough bytes for prefix"))
		}
		up.Prefix = make([]byte, prefixBytes)
		copy(up.Prefix, b[p:p+prefixBytes])
		p += prefixBytes

		// Set the route's prefix length
		up.Length = uint8(computedPrefixBits)

		mpnlri.NLRI = append(mpnlri.NLRI, up)

So if computed bits are < 32 bits we force to 32bits.

- Parses the L3VPN NLRI (including withdrawn routes) with the improved logic now (forced 32-bit prefix if needed, default RD if errors, etc.)
- Attempts a single fallback with !pathID if the first parse fails—without recursing infinitely
- Default RD if not enough bytes or if MakeRD fails
- Label logic handles both “no label” markers (0x80,0x00,0x00 or 0x00,0x00,0x00) and actual labels
- Avoids stack overflows by not calling UnmarshalL3VPNNLRI from inside itself on every error. No recursion or repeated error logs that could blow up the stack

