### PR TITLE
Rfc 8955 flowspec extcomm

### DIFF
--- a/pkg/bgp/extended-community.go
+++ b/pkg/bgp/extended-community.go
@@ -334,11 +334,17 @@ func type80(subType uint8, value []byte) string {
 			s = fmt.Sprintf("AS: %d Rate: %d bps", binary.BigEndian.Uint16(value[:2]), uint32(math.Float32frombits(binary.BigEndian.Uint32(value[2:])))*8)
 		case 0x08:
 			s = fmt.Sprintf("%d:%d", binary.BigEndian.Uint16(value[0:2]), binary.BigEndian.Uint32(value[2:]))
-		case 0x09:
-			fallthrough
 		case 0x07:
-			// TODO (sbezverk) add corresponding transformation actions
-			fallthrough
+			// Traffic-Action Extended Community (RFC 8955 Section 7.3)
+			// Bit 47 (T): Terminal Action, Bit 46 (S): Sample
+			terminalAction := value[5]&0x01 != 0
+			sampleBit := value[5]&0x02 != 0
+			s = fmt.Sprintf("T=%t S=%t", terminalAction, sampleBit)
+		case 0x09:
+			// Traffic Marking Extended Community (RFC 8955 Section 7.5)
+			// Lower 6 bits of last byte contain DSCP value
+			dscp := value[5] & 0x3F
+			s = fmt.Sprintf("DSCP=%d", dscp)
 		default:
 			s = tools.MessageHex(value)
 		}

--- a/pkg/bgp/extended-community_test.go
+++ b/pkg/bgp/extended-community_test.go
@@ -1,0 +1,89 @@
+package bgp
+
+import (
+	"testing"
+)
+
+func TestFlowspecTrafficAction(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []byte
+		expect string
+	}{
+		{
+			name:   "terminal action set, sample clear",
+			input:  []byte{0x80, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+			expect: "flowspec-traffic-action=T=true S=false",
+		},
+		{
+			name:   "terminal action clear, sample set",
+			input:  []byte{0x80, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02},
+			expect: "flowspec-traffic-action=T=false S=true",
+		},
+		{
+			name:   "both bits set",
+			input:  []byte{0x80, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03},
+			expect: "flowspec-traffic-action=T=true S=true",
+		},
+		{
+			name:   "both bits clear",
+			input:  []byte{0x80, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			expect: "flowspec-traffic-action=T=false S=false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ext, err := makeExtCommunity(tt.input)
+			if err != nil {
+				t.Fatalf("makeExtCommunity() error = %v", err)
+			}
+			result := ext.String()
+			if result != tt.expect {
+				t.Errorf("got %s, want %s", result, tt.expect)
+			}
+		})
+	}
+}
+
+func TestFlowspecTrafficRemarking(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []byte
+		expect string
+	}{
+		{
+			name:   "DSCP 0 (default)",
+			input:  []byte{0x80, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			expect: "flowspec-traffic-remarking=DSCP=0",
+		},
+		{
+			name:   "DSCP 46 (EF - Expedited Forwarding)",
+			input:  []byte{0x80, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2E},
+			expect: "flowspec-traffic-remarking=DSCP=46",
+		},
+		{
+			name:   "DSCP 26 (AF31)",
+			input:  []byte{0x80, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1A},
+			expect: "flowspec-traffic-remarking=DSCP=26",
+		},
+		{
+			name:   "DSCP 63 (maximum)",
+			input:  []byte{0x80, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x3F},
+			expect: "flowspec-traffic-remarking=DSCP=63",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ext, err := makeExtCommunity(tt.input)
+			if err != nil {
+				t.Fatalf("makeExtCommunity() error = %v", err)
+			}
+			result := ext.String()
+			if result != tt.expect {
+				t.Errorf("got %s, want %s", result, tt.expect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary
Implements proper parsing for FlowSpec traffic-action and traffic-remarking extended communities per RFC 8955, replacing raw hex output with human-readable structured values.

### Changes

**Traffic-Action Extended Community (Type 0x80, Subtype 0x07) - RFC 8955 Section 7.3:**
- Parse bit 47 (T-bit): Terminal Action flag - controls whether evaluation continues
- Parse bit 46 (S-bit): Sample flag - enables traffic sampling/logging
- Output format: `flowspec-traffic-action=T={true|false} S={true|false}`

**Traffic Marking Extended Community (Type 0x80, Subtype 0x09) - RFC 8955 Section 7.5:**
- Extract 6-bit DSCP value from bits 5-0 of last octet
- Output format: `flowspec-traffic-remarking=DSCP={0-63}`
- Supports standard DSCP values (EF=46, AF classes, etc.)

### Testing
- **4 test cases** for traffic-action covering all bit combinations (T/S set/clear)
- **4 test cases** for traffic-remarking with DSCP values: 0 (default), 26 (AF31), 46 (EF), 63 (max)
- All existing BGP extended community tests passing
- Tested on both production and local repositories

### Files Modified
- `pkg/bgp/extended-community.go` - Updated `type80()` function

### Files Added
- `pkg/bgp/extended-community_test.go` - Comprehensive test suite

### Impact
- **Production Value:** Enables proper DDoS mitigation, traffic engineering, and QoS policy visibility
- **Backward Compatible:** Only affects display formatting, no protocol changes
- **RFC Compliance:** Full compliance with RFC 8955 Sections 7.3 and 7.5

### References
- Fixes #260
- RFC 8955: Dissemination of Flow Specification Rules
  - Section 7.3: Traffic-Action Extended Community
  - Section 7.5: Traffic Marking Extended Community