### PR TITLE
pin kafka and zookeeper to specific cicd versions

### DIFF
--- a/build/unicastv4-bgp/test_bed_single_kafka.yml
+++ b/build/unicastv4-bgp/test_bed_single_kafka.yml
@@ -20,7 +20,7 @@ networks:
 
 services:
   zoo:
-    image: bitnami/zookeeper:latest
+    image: sbezverk/zookeeper:cicd
     hostname: zoo
     container_name: zoo
     ports:
@@ -35,7 +35,7 @@ services:
         ipv4_address: 10.1.1.5
 
   kafka:
-    image: bitnami/kafka:latest
+    image: sbezverk/kafka:cicd
     hostname: kafka
     container_name: kafka
     ports:


### PR DESCRIPTION
something happened with bitnami's latest zookeeper, pining a single node test to use cicd tag for zookeeper and kafka instead.