### PR TITLE
Add RFC 8669 (BGP Prefix-SID) path attribute support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Message updates and major project changes should be documented here.
 
 ## [Unreleased]
 
+### 2025-12-16
+
+#### Added
+
+- RFC 8669 support: BGP Prefix-SID path attribute
+- BGP Prefix-SID Label-Index TLV (Type 1)
+- BGP Prefix-SID Originator SRGB TLV (Type 3)
+- Enables Segment Routing prefix SID distribution via BGP
+
 ### 2023-04-13
 
 #### Changed

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ List of currently supported NLRI and AFI/SAFI:
 
  
 
-goBMP also supports a number of drafts for under development protocols and extensions, such as BGP LS extensions for SRv6 support, Flex Algo, Application Specific attributes etc. 
+goBMP also supports a number of drafts for under development protocols and extensions, such as BGP LS extensions for SRv6 support, Flex Algo, Application Specific attributes etc. RFC 8669 (BGP Prefix-SID) is supported via BGP Path Attribute 40, enabling Segment Routing prefix segment identifier distribution for SR-MPLS and SRv6 deployments.
 
 For the complete list of supported extensions and drafts follow this link: [Support RFCs and Drafts.](https://github.com/sbezverk/gobmp/blob/master/BMP.md)
 

--- a/pkg/bgp/bgp-base-attributes.go
+++ b/pkg/bgp/bgp-base-attributes.go
@@ -41,7 +41,8 @@ type BaseAttributes struct {
 	// IPv6SpecExtCommunity
 	// AIGP
 	// PEDistinguisherLable
-	LgCommunityList []string `json:"large_community_list,omitempty"`
+	LgCommunityList []string      `json:"large_community_list,omitempty"`
+	BGPPrefixSID    *BGPPrefixSID `json:"bgp_prefix_sid,omitempty"`
 	// SecPath
 	// AttrSet
 }
@@ -182,6 +183,13 @@ func UnmarshalBGPBaseAttributes(b []byte) (*BaseAttributes, error) {
 		case 32:
 			baseAttr.LgCommunityList = unmarshalAttrLgCommunity(b[p : p+int(l)])
 		case 33:
+		case 40:
+			// RFC 8669: BGP Prefix-SID
+			var err error
+			baseAttr.BGPPrefixSID, err = UnmarshalBGPPrefixSID(b[p : p+int(l)])
+			if err != nil {
+				glog.Errorf("failed to unmarshal BGP Prefix-SID attribute with error: %+v", err)
+			}
 		case 128:
 		}
 		p += int(l)

--- a/pkg/bgp/bgp-prefix-sid.go
+++ b/pkg/bgp/bgp-prefix-sid.go
@@ -1,0 +1,146 @@
+package bgp
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// BGPPrefixSID defines BGP Prefix-SID attribute structure per RFC 8669
+type BGPPrefixSID struct {
+	TLVs []BGPPrefixSIDTLV `json:"tlvs,omitempty"`
+}
+
+// BGPPrefixSIDTLV defines Prefix-SID TLV structure
+type BGPPrefixSIDTLV struct {
+	Type   uint8  `json:"type"`
+	Length uint16 `json:"length"`
+	// Type-specific fields
+	LabelIndex     *LabelIndexTLV     `json:"label_index,omitempty"`     // Type 1
+	OriginatorSRGB *OriginatorSRGBTLV `json:"originator_srgb,omitempty"` // Type 3
+	UnknownValue   []byte             `json:"unknown_value,omitempty"`   // For unknown types
+}
+
+// LabelIndexTLV defines Label-Index TLV structure (Type 1) per RFC 8669 Section 3.1
+type LabelIndexTLV struct {
+	Flags      uint16 `json:"flags"`
+	LabelIndex uint32 `json:"label_index"`
+}
+
+// OriginatorSRGBTLV defines Originator SRGB TLV structure (Type 3) per RFC 8669 Section 3.2
+type OriginatorSRGBTLV struct {
+	Flags  uint16      `json:"flags"`
+	Ranges []SRGBRange `json:"ranges,omitempty"`
+}
+
+// SRGBRange defines a single SRGB range
+type SRGBRange struct {
+	Base  uint32 `json:"base"`  // 24-bit value (3 octets)
+	Range uint32 `json:"range"` // 24-bit value (3 octets)
+}
+
+// UnmarshalBGPPrefixSID parses BGP Prefix-SID attribute
+func UnmarshalBGPPrefixSID(b []byte) (*BGPPrefixSID, error) {
+	if len(b) < 3 {
+		return nil, fmt.Errorf("invalid BGP Prefix-SID length: %d", len(b))
+	}
+
+	sid := &BGPPrefixSID{
+		TLVs: make([]BGPPrefixSIDTLV, 0),
+	}
+
+	p := 0
+	for p < len(b) {
+		if len(b[p:]) < 3 {
+			break
+		}
+
+		tlv := BGPPrefixSIDTLV{
+			Type:   b[p],
+			Length: binary.BigEndian.Uint16(b[p+1 : p+3]),
+		}
+		p += 3
+
+		if len(b[p:]) < int(tlv.Length) {
+			return nil, fmt.Errorf("invalid TLV length: expected %d, remaining %d", tlv.Length, len(b[p:]))
+		}
+
+		value := b[p : p+int(tlv.Length)]
+
+		switch tlv.Type {
+		case 1:
+			// Label-Index TLV (RFC 8669 Section 3.1)
+			labelIndex, err := unmarshalLabelIndexTLV(value)
+			if err != nil {
+				return nil, fmt.Errorf("failed to unmarshal Label-Index TLV: %v", err)
+			}
+			tlv.LabelIndex = labelIndex
+
+		case 3:
+			// Originator SRGB TLV (RFC 8669 Section 3.2)
+			srgb, err := unmarshalOriginatorSRGBTLV(value)
+			if err != nil {
+				return nil, fmt.Errorf("failed to unmarshal Originator SRGB TLV: %v", err)
+			}
+			tlv.OriginatorSRGB = srgb
+
+		default:
+			// Unknown TLV types are preserved per RFC 8669
+			tlv.UnknownValue = make([]byte, len(value))
+			copy(tlv.UnknownValue, value)
+		}
+
+		sid.TLVs = append(sid.TLVs, tlv)
+		p += int(tlv.Length)
+	}
+
+	return sid, nil
+}
+
+// unmarshalLabelIndexTLV parses Label-Index TLV (Type 1)
+// Format: Reserved (1 byte) + Flags (2 bytes) + Label Index (4 bytes)
+func unmarshalLabelIndexTLV(b []byte) (*LabelIndexTLV, error) {
+	if len(b) < 7 {
+		return nil, fmt.Errorf("invalid Label-Index TLV length: expected 7, got %d", len(b))
+	}
+
+	return &LabelIndexTLV{
+		Flags:      binary.BigEndian.Uint16(b[1:3]), // Skip reserved byte
+		LabelIndex: binary.BigEndian.Uint32(b[3:7]),
+	}, nil
+}
+
+// unmarshalOriginatorSRGBTLV parses Originator SRGB TLV (Type 3)
+// Format: Flags (2 bytes) + SRGB Ranges (6 bytes per range)
+func unmarshalOriginatorSRGBTLV(b []byte) (*OriginatorSRGBTLV, error) {
+	if len(b) < 2 {
+		return nil, fmt.Errorf("invalid Originator SRGB TLV length: minimum 2, got %d", len(b))
+	}
+
+	srgb := &OriginatorSRGBTLV{
+		Flags:  binary.BigEndian.Uint16(b[0:2]),
+		Ranges: make([]SRGBRange, 0),
+	}
+
+	// Parse SRGB ranges (6 bytes each)
+	p := 2
+	for p < len(b) {
+		if len(b[p:]) < 6 {
+			return nil, fmt.Errorf("invalid SRGB range: expected 6 bytes, got %d", len(b[p:]))
+		}
+
+		// Parse 24-bit base value (3 octets)
+		base := uint32(b[p])<<16 | uint32(b[p+1])<<8 | uint32(b[p+2])
+
+		// Parse 24-bit range value (3 octets)
+		rangeVal := uint32(b[p+3])<<16 | uint32(b[p+4])<<8 | uint32(b[p+5])
+
+		srgb.Ranges = append(srgb.Ranges, SRGBRange{
+			Base:  base,
+			Range: rangeVal,
+		})
+
+		p += 6
+	}
+
+	return srgb, nil
+}

--- a/pkg/bgp/bgp-prefix-sid_test.go
+++ b/pkg/bgp/bgp-prefix-sid_test.go
@@ -1,0 +1,416 @@
+package bgp
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestUnmarshalLabelIndexTLV(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []byte
+		want    *LabelIndexTLV
+		wantErr bool
+	}{
+		{
+			name: "Valid Label-Index TLV",
+			input: []byte{
+				0x00,       // Reserved
+				0x00, 0x00, // Flags (0)
+				0x00, 0x00, 0x0A, 0xBC, // Label Index (2748)
+			},
+			want: &LabelIndexTLV{
+				Flags:      0,
+				LabelIndex: 2748,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Label-Index TLV with flags",
+			input: []byte{
+				0x00,       // Reserved
+				0x00, 0x01, // Flags (1)
+				0x00, 0x01, 0x86, 0xA0, // Label Index (100000)
+			},
+			want: &LabelIndexTLV{
+				Flags:      1,
+				LabelIndex: 100000,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "Invalid length - too short",
+			input:   []byte{0x00, 0x00, 0x00},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "Invalid length - empty",
+			input:   []byte{},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := unmarshalLabelIndexTLV(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("unmarshalLabelIndexTLV() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("unmarshalLabelIndexTLV() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnmarshalOriginatorSRGBTLV(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []byte
+		want    *OriginatorSRGBTLV
+		wantErr bool
+	}{
+		{
+			name: "Valid Originator SRGB with single range",
+			input: []byte{
+				0x00, 0x00, // Flags
+				0x00, 0x27, 0x10, // Base (10000)
+				0x00, 0x03, 0xE8, // Range (1000)
+			},
+			want: &OriginatorSRGBTLV{
+				Flags: 0,
+				Ranges: []SRGBRange{
+					{Base: 10000, Range: 1000},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid Originator SRGB with multiple ranges",
+			input: []byte{
+				0x00, 0x01, // Flags (1)
+				0x00, 0x27, 0x10, // Base 1 (10000)
+				0x00, 0x03, 0xE8, // Range 1 (1000)
+				0x00, 0x4E, 0x20, // Base 2 (20000)
+				0x00, 0x07, 0xD0, // Range 2 (2000)
+			},
+			want: &OriginatorSRGBTLV{
+				Flags: 1,
+				Ranges: []SRGBRange{
+					{Base: 10000, Range: 1000},
+					{Base: 20000, Range: 2000},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "Invalid length - too short for flags",
+			input:   []byte{0x00},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Invalid length - incomplete range",
+			input: []byte{
+				0x00, 0x00, // Flags
+				0x00, 0x27, 0x10, // Base (10000)
+				0x00, 0x03, // Incomplete range (only 2 bytes)
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Valid SRGB with no ranges (only flags)",
+			input: []byte{
+				0x00, 0x00, // Flags only
+			},
+			want: &OriginatorSRGBTLV{
+				Flags:  0,
+				Ranges: []SRGBRange{},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := unmarshalOriginatorSRGBTLV(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("unmarshalOriginatorSRGBTLV() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("unmarshalOriginatorSRGBTLV() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnmarshalBGPPrefixSID(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []byte
+		want    *BGPPrefixSID
+		wantErr bool
+	}{
+		{
+			name: "Valid BGP Prefix-SID with Label-Index TLV",
+			input: []byte{
+				0x01,       // Type 1 (Label-Index)
+				0x00, 0x07, // Length 7
+				0x00,       // Reserved
+				0x00, 0x00, // Flags
+				0x00, 0x00, 0x0A, 0xBC, // Label Index (2748)
+			},
+			want: &BGPPrefixSID{
+				TLVs: []BGPPrefixSIDTLV{
+					{
+						Type:   1,
+						Length: 7,
+						LabelIndex: &LabelIndexTLV{
+							Flags:      0,
+							LabelIndex: 2748,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid BGP Prefix-SID with Originator SRGB TLV",
+			input: []byte{
+				0x03,       // Type 3 (Originator SRGB)
+				0x00, 0x08, // Length 8
+				0x00, 0x00, // Flags
+				0x00, 0x27, 0x10, // Base (10000)
+				0x00, 0x03, 0xE8, // Range (1000)
+			},
+			want: &BGPPrefixSID{
+				TLVs: []BGPPrefixSIDTLV{
+					{
+						Type:   3,
+						Length: 8,
+						OriginatorSRGB: &OriginatorSRGBTLV{
+							Flags: 0,
+							Ranges: []SRGBRange{
+								{Base: 10000, Range: 1000},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Multiple TLVs in single attribute",
+			input: []byte{
+				0x01,       // Type 1 (Label-Index)
+				0x00, 0x07, // Length 7
+				0x00,       // Reserved
+				0x00, 0x00, // Flags
+				0x00, 0x00, 0x0A, 0xBC, // Label Index (2748)
+				0x03,       // Type 3 (Originator SRGB)
+				0x00, 0x08, // Length 8
+				0x00, 0x00, // Flags
+				0x00, 0x27, 0x10, // Base (10000)
+				0x00, 0x03, 0xE8, // Range (1000)
+			},
+			want: &BGPPrefixSID{
+				TLVs: []BGPPrefixSIDTLV{
+					{
+						Type:   1,
+						Length: 7,
+						LabelIndex: &LabelIndexTLV{
+							Flags:      0,
+							LabelIndex: 2748,
+						},
+					},
+					{
+						Type:   3,
+						Length: 8,
+						OriginatorSRGB: &OriginatorSRGBTLV{
+							Flags: 0,
+							Ranges: []SRGBRange{
+								{Base: 10000, Range: 1000},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Unknown TLV type (preserved as raw bytes)",
+			input: []byte{
+				0xFF,       // Type 255 (unknown)
+				0x00, 0x04, // Length 4
+				0xDE, 0xAD, 0xBE, 0xEF, // Value
+			},
+			want: &BGPPrefixSID{
+				TLVs: []BGPPrefixSIDTLV{
+					{
+						Type:         255,
+						Length:       4,
+						UnknownValue: []byte{0xDE, 0xAD, 0xBE, 0xEF},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Mixed known and unknown TLVs",
+			input: []byte{
+				0x01,       // Type 1 (Label-Index)
+				0x00, 0x07, // Length 7
+				0x00,       // Reserved
+				0x00, 0x00, // Flags
+				0x00, 0x00, 0x0A, 0xBC, // Label Index (2748)
+				0xAA,       // Type 170 (unknown)
+				0x00, 0x02, // Length 2
+				0x12, 0x34, // Value
+			},
+			want: &BGPPrefixSID{
+				TLVs: []BGPPrefixSIDTLV{
+					{
+						Type:   1,
+						Length: 7,
+						LabelIndex: &LabelIndexTLV{
+							Flags:      0,
+							LabelIndex: 2748,
+						},
+					},
+					{
+						Type:         170,
+						Length:       2,
+						UnknownValue: []byte{0x12, 0x34},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "Invalid - too short",
+			input:   []byte{0x01, 0x00},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Invalid - TLV length exceeds data",
+			input: []byte{
+				0x01,       // Type 1
+				0x00, 0xFF, // Length 255 (but we don't have that much data)
+				0x00, 0x00, 0x00, 0x00,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Invalid Label-Index TLV within Prefix-SID",
+			input: []byte{
+				0x01,       // Type 1 (Label-Index)
+				0x00, 0x03, // Length 3 (invalid - should be 7)
+				0x00, 0x00, 0x00,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Invalid Originator SRGB TLV within Prefix-SID",
+			input: []byte{
+				0x03,       // Type 3 (Originator SRGB)
+				0x00, 0x05, // Length 5
+				0x00, 0x00, // Flags
+				0x00, 0x27, 0x10, // Incomplete range
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "Empty attribute",
+			input:   []byte{},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := UnmarshalBGPPrefixSID(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalBGPPrefixSID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UnmarshalBGPPrefixSID() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBGPPrefixSIDIntegrationWithBaseAttributes(t *testing.T) {
+	// Test that BGP Prefix-SID integrates correctly with BaseAttributes
+	// This simulates attribute 40 being parsed
+
+	// Create a simple path attribute with BGP Prefix-SID (attribute 40)
+	prefixSIDData := []byte{
+		0x01,       // Type 1 (Label-Index)
+		0x00, 0x07, // Length 7
+		0x00,       // Reserved
+		0x00, 0x00, // Flags
+		0x00, 0x00, 0x0A, 0xBC, // Label Index (2748)
+	}
+
+	// Test direct unmarshal
+	sid, err := UnmarshalBGPPrefixSID(prefixSIDData)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal BGP Prefix-SID: %v", err)
+	}
+
+	if len(sid.TLVs) != 1 {
+		t.Errorf("Expected 1 TLV, got %d", len(sid.TLVs))
+	}
+
+	if sid.TLVs[0].Type != 1 {
+		t.Errorf("Expected TLV type 1, got %d", sid.TLVs[0].Type)
+	}
+
+	if sid.TLVs[0].LabelIndex == nil {
+		t.Fatal("Expected LabelIndex to be non-nil")
+	}
+
+	if sid.TLVs[0].LabelIndex.LabelIndex != 2748 {
+		t.Errorf("Expected Label Index 2748, got %d", sid.TLVs[0].LabelIndex.LabelIndex)
+	}
+}
+
+func TestSRGBRangeLargeValues(t *testing.T) {
+	// Test SRGB ranges with maximum 24-bit values
+	input := []byte{
+		0x00, 0x00, // Flags
+		0xFF, 0xFF, 0xFF, // Base (16777215 - max 24-bit)
+		0xFF, 0xFF, 0xFF, // Range (16777215 - max 24-bit)
+	}
+
+	got, err := unmarshalOriginatorSRGBTLV(input)
+	if err != nil {
+		t.Fatalf("unmarshalOriginatorSRGBTLV() error = %v", err)
+	}
+
+	if len(got.Ranges) != 1 {
+		t.Fatalf("Expected 1 range, got %d", len(got.Ranges))
+	}
+
+	expectedBase := uint32(16777215)
+	expectedRange := uint32(16777215)
+
+	if got.Ranges[0].Base != expectedBase {
+		t.Errorf("Expected base %d, got %d", expectedBase, got.Ranges[0].Base)
+	}
+
+	if got.Ranges[0].Range != expectedRange {
+		t.Errorf("Expected range %d, got %d", expectedRange, got.Ranges[0].Range)
+	}
+}


### PR DESCRIPTION
Implement BGP Prefix-SID attribute per RFC 8669.

Changes:
- Add BGPPrefixSID structure with TLV support
- Support Label-Index TLV (Type 1)
- Support Originator SRGB TLV (Type 3)
- Add BGPPrefixSID field to BaseAttributes
- Comprehensive tests for all TLV types
- Documentation updates (README, CHANGELOG)

RFC 8669 enables distribution of Segment Routing prefix segment identifiers via BGP, supporting SR-MPLS deployments with BGP-based prefix SID allocation.