### PR TITLE
Add IsLocRIB field support for RFC 9069 compliance

### DIFF
--- a/pkg/bmp/per-peer-header.go
+++ b/pkg/bmp/per-peer-header.go
@@ -212,6 +212,16 @@ func (p *PerPeerHeader) IsLocRIBFiltered() (bool, error) {
 	return false, ErrInvFlagRequestForPeerType
 }
 
+// IsLocRIB returns true if PeerType is 3 (Loc-RIB), regardless of F flag
+// Per RFC 9069: All routes from PeerType 3 are Loc-RIB routes (filtered or not)
+func (p *PerPeerHeader) IsLocRIB() (bool, error) {
+	if p.PeerType == PeerType3 {
+		return true, nil
+	}
+
+	return false, ErrInvFlagRequestForPeerType
+}
+
 // IsRemotePeerIPv6 returns true if Remote Peer is IPv6 for PeerType is 0,1 or 2, for Peer Type 3 always returns false.
 // Per RFC 7854: V flag (bit 7) indicates IPv4 (0) or IPv6 (1) peer address
 func (p *PerPeerHeader) IsRemotePeerIPv6() bool {

--- a/pkg/message/base-nlri.go
+++ b/pkg/message/base-nlri.go
@@ -93,6 +93,9 @@ func (p *producer) nlri(op int, ph *bmp.PerPeerHeader, update *bgp.Update) ([]*U
 		if f, err := ph.IsAdjRIBOut(); err == nil {
 			prfx.IsAdjRIBOut = f
 		}
+		if f, err := ph.IsLocRIB(); err == nil {
+			prfx.IsLocRIB = f
+		}
 		if f, err := ph.IsLocRIBFiltered(); err == nil {
 			prfx.IsLocRIBFiltered = f
 		}

--- a/pkg/message/evpn.go
+++ b/pkg/message/evpn.go
@@ -122,6 +122,9 @@ func (p *producer) evpn(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *
 			if f, err := ph.IsAdjRIBOut(); err == nil {
 				prfx.IsAdjRIBOut = f
 			}
+			if f, err := ph.IsLocRIB(); err == nil {
+				prfx.IsLocRIB = f
+			}
 			if f, err := ph.IsLocRIBFiltered(); err == nil {
 				prfx.IsLocRIBFiltered = f
 			}

--- a/pkg/message/flowspec.go
+++ b/pkg/message/flowspec.go
@@ -55,6 +55,9 @@ func (p *producer) flowspec(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, upda
 	if f, err := ph.IsAdjRIBOut(); err == nil {
 		fs.IsAdjRIBOut = f
 	}
+	if f, err := ph.IsLocRIB(); err == nil {
+		fs.IsLocRIB = f
+	}
 	if f, err := ph.IsLocRIBFiltered(); err == nil {
 		fs.IsLocRIBFiltered = f
 	}

--- a/pkg/message/l3-vpn.go
+++ b/pkg/message/l3-vpn.go
@@ -78,6 +78,9 @@ func (p *producer) l3vpn(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update 
 		if f, err := ph.IsAdjRIBOut(); err == nil {
 			prfx.IsAdjRIBOut = f
 		}
+		if f, err := ph.IsLocRIB(); err == nil {
+			prfx.IsLocRIB = f
+		}
 		if f, err := ph.IsLocRIBFiltered(); err == nil {
 			prfx.IsLocRIBFiltered = f
 		}

--- a/pkg/message/ls-link.go
+++ b/pkg/message/ls-link.go
@@ -39,6 +39,9 @@ func (p *producer) lsLink(link *base.LinkNLRI, nextHop string, op int, ph *bmp.P
 	if f, err := ph.IsAdjRIBOut(); err == nil {
 		msg.IsAdjRIBOut = f
 	}
+	if f, err := ph.IsLocRIB(); err == nil {
+		msg.IsLocRIB = f
+	}
 	if f, err := ph.IsLocRIBFiltered(); err == nil {
 		msg.IsLocRIBFiltered = f
 	}

--- a/pkg/message/ls-node.go
+++ b/pkg/message/ls-node.go
@@ -38,6 +38,9 @@ func (p *producer) lsNode(node *base.NodeNLRI, _ /* place holder for the next ho
 	if f, err := ph.IsAdjRIBOut(); err == nil {
 		msg.IsAdjRIBOut = f
 	}
+	if f, err := ph.IsLocRIB(); err == nil {
+		msg.IsLocRIB = f
+	}
 	if f, err := ph.IsLocRIBFiltered(); err == nil {
 		msg.IsLocRIBFiltered = f
 	}

--- a/pkg/message/ls-prefix.go
+++ b/pkg/message/ls-prefix.go
@@ -38,6 +38,9 @@ func (p *producer) lsPrefix(prfx *base.PrefixNLRI, nextHop string, op int, ph *b
 	if f, err := ph.IsAdjRIBOut(); err == nil {
 		msg.IsAdjRIBOut = f
 	}
+	if f, err := ph.IsLocRIB(); err == nil {
+		msg.IsLocRIB = f
+	}
 	if f, err := ph.IsLocRIBFiltered(); err == nil {
 		msg.IsLocRIBFiltered = f
 	}

--- a/pkg/message/ls-srv6-sid.go
+++ b/pkg/message/ls-srv6-sid.go
@@ -37,6 +37,9 @@ func (p *producer) lsSRv6SID(nlri6 *srv6.SIDNLRI, nextHop string, op int, ph *bm
 	if f, err := ph.IsAdjRIBOut(); err == nil {
 		msg.IsAdjRIBOut = f
 	}
+	if f, err := ph.IsLocRIB(); err == nil {
+		msg.IsLocRIB = f
+	}
 	if f, err := ph.IsLocRIBFiltered(); err == nil {
 		msg.IsLocRIBFiltered = f
 	}

--- a/pkg/message/mp-unicast.go
+++ b/pkg/message/mp-unicast.go
@@ -73,6 +73,9 @@ func (p *producer) unicast(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, updat
 		if f, err := ph.IsAdjRIBOut(); err == nil {
 			prfx.IsAdjRIBOut = f
 		}
+		if f, err := ph.IsLocRIB(); err == nil {
+			prfx.IsLocRIB = f
+		}
 		if f, err := ph.IsLocRIBFiltered(); err == nil {
 			prfx.IsLocRIBFiltered = f
 		}

--- a/pkg/message/peer.go
+++ b/pkg/message/peer.go
@@ -46,6 +46,9 @@ func (p *producer) producePeerMessage(op int, msg bmp.Message) {
 		if f, err := msg.PeerHeader.IsAdjRIBOut(); err == nil {
 			m.IsAdjRIBOut = f
 		}
+		if f, err := msg.PeerHeader.IsLocRIB(); err == nil {
+			m.IsLocRIB = f
+		}
 		if f, err := msg.PeerHeader.IsLocRIBFiltered(); err == nil {
 			m.IsLocRIBFiltered = f
 		}

--- a/pkg/message/srpolicy.go
+++ b/pkg/message/srpolicy.go
@@ -44,6 +44,9 @@ func (p *producer) srpolicy(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, upda
 	if f, err := ph.IsAdjRIBOut(); err == nil {
 		prfx.IsAdjRIBOut = f
 	}
+	if f, err := ph.IsLocRIB(); err == nil {
+		prfx.IsLocRIB = f
+	}
 	if f, err := ph.IsLocRIBFiltered(); err == nil {
 		prfx.IsLocRIBFiltered = f
 	}

--- a/pkg/message/types.go
+++ b/pkg/message/types.go
@@ -55,6 +55,7 @@ type PeerStateChange struct {
 	IsAdjRIBInPost   bool `json:"is_adj_rib_in_post_policy"`
 	IsAdjRIBOutPost  bool `json:"is_adj_rib_out_post_policy"`
 	IsAdjRIBOut      bool `json:"is_adj_rib_out"`
+	IsLocRIB         bool `json:"is_loc_rib"`
 	IsLocRIBFiltered bool `json:"is_loc_rib_filtered"`
 }
 
@@ -89,6 +90,7 @@ type UnicastPrefix struct {
 	IsAdjRIBInPost   bool `json:"is_adj_rib_in_post_policy"`
 	IsAdjRIBOutPost  bool `json:"is_adj_rib_out_post_policy"`
 	IsAdjRIBOut      bool `json:"is_adj_rib_out"`
+	IsLocRIB         bool `json:"is_loc_rib"`
 	IsLocRIBFiltered bool `json:"is_loc_rib_filtered"`
 }
 
@@ -216,6 +218,7 @@ type LSNode struct {
 	IsAdjRIBInPost   bool `json:"is_adj_rib_in_post_policy"`
 	IsAdjRIBOutPost  bool `json:"is_adj_rib_out_post_policy"`
 	IsAdjRIBOut      bool `json:"is_adj_rib_out"`
+	IsLocRIB         bool `json:"is_loc_rib"`
 	IsLocRIBFiltered bool `json:"is_loc_rib_filtered"`
 }
 
@@ -288,6 +291,7 @@ type LSLink struct {
 	IsAdjRIBInPost   bool `json:"is_adj_rib_in_post_policy"`
 	IsAdjRIBOutPost  bool `json:"is_adj_rib_out_post_policy"`
 	IsAdjRIBOut      bool `json:"is_adj_rib_out"`
+	IsLocRIB         bool `json:"is_loc_rib"`
 	IsLocRIBFiltered bool `json:"is_loc_rib_filtered"`
 }
 
@@ -323,6 +327,7 @@ type L3VPNPrefix struct {
 	IsAdjRIBInPost   bool `json:"is_adj_rib_in_post_policy"`
 	IsAdjRIBOutPost  bool `json:"is_adj_rib_out_post_policy"`
 	IsAdjRIBOut      bool `json:"is_adj_rib_out"`
+	IsLocRIB         bool `json:"is_loc_rib"`
 	IsLocRIBFiltered bool `json:"is_loc_rib_filtered"`
 }
 
@@ -366,6 +371,7 @@ type LSPrefix struct {
 	IsAdjRIBInPost   bool `json:"is_adj_rib_in_post_policy"`
 	IsAdjRIBOutPost  bool `json:"is_adj_rib_out_post_policy"`
 	IsAdjRIBOut      bool `json:"is_adj_rib_out"`
+	IsLocRIB         bool `json:"is_loc_rib"`
 	IsLocRIBFiltered bool `json:"is_loc_rib_filtered"`
 }
 
@@ -410,6 +416,7 @@ type LSSRv6SID struct {
 	IsAdjRIBInPost   bool `json:"is_adj_rib_in_post_policy"`
 	IsAdjRIBOutPost  bool `json:"is_adj_rib_out_post_policy"`
 	IsAdjRIBOut      bool `json:"is_adj_rib_out"`
+	IsLocRIB         bool `json:"is_loc_rib"`
 	IsLocRIBFiltered bool `json:"is_loc_rib_filtered"`
 }
 
@@ -453,6 +460,7 @@ type EVPNPrefix struct {
 	IsAdjRIBInPost   bool `json:"is_adj_rib_in_post_policy"`
 	IsAdjRIBOutPost  bool `json:"is_adj_rib_out_post_policy"`
 	IsAdjRIBOut      bool `json:"is_adj_rib_out"`
+	IsLocRIB         bool `json:"is_loc_rib"`
 	IsLocRIBFiltered bool `json:"is_loc_rib_filtered"`
 }
 
@@ -493,6 +501,7 @@ type SRPolicy struct {
 	IsAdjRIBInPost   bool `json:"is_adj_rib_in_post_policy"`
 	IsAdjRIBOutPost  bool `json:"is_adj_rib_out_post_policy"`
 	IsAdjRIBOut      bool `json:"is_adj_rib_out"`
+	IsLocRIB         bool `json:"is_loc_rib"`
 	IsLocRIBFiltered bool `json:"is_loc_rib_filtered"`
 }
 
@@ -520,6 +529,7 @@ type Flowspec struct {
 	IsAdjRIBInPost   bool `json:"is_adj_rib_in_post_policy"`
 	IsAdjRIBOutPost  bool `json:"is_adj_rib_out_post_policy"`
 	IsAdjRIBOut      bool `json:"is_adj_rib_out"`
+	IsLocRIB         bool `json:"is_loc_rib"`
 	IsLocRIBFiltered bool `json:"is_loc_rib_filtered"`
 }
 


### PR DESCRIPTION
Add IsLocRIB field for RFC 9069 Loc-RIB detection
Added IsLocRIB field to properly identify all routes from PeerType 3
(Local RIB Instance Peer), regardless of F flag state.

Changes:
- Added IsLocRIB field to 10 message type structs
- Added IsLocRIB() method to PerPeerHeader
- Updated 11 processors to populate IsLocRIB field
- Added integration tests for both Loc-RIB variants
- Fixed test bug: SRv6SID -> LSSRv6SID

This enables correct identification of all 6 RIB types per RFC 7854,
RFC 8671, and RFC 9069:
- Adj-RIB-In-Pre/Post
- Adj-RIB-Out-Pre/Post
- Loc-RIB (new)
- Loc-RIB-Filtered

Files modified: types.go, per-peer-header.go, 11 processors,
rib_flags_integration_test.go