### PR TITLE
Add RFC 8097 (RPKI Origin Validation State) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Message updates and major project changes should be documented here.
 - IPv6-based Route Target and Route Origin extended communities
 - Type 0x05 Extended Community parsing
 - Enables IPv6 VPN route target filtering
+- RFC 8097 support: BGP Prefix Origin Validation State Extended Community
+- RPKI origin validation state extraction in Unicast and L3VPN prefixes
+- Origin validation state field in UnicastPrefix and L3VPNPrefix message types
+- Enables RPKI route validation monitoring and security analysis
 - MCAST-VPN support for IPv4 (AFI 1, SAFI 5) per RFC 6514
 - MCAST-VPN support for IPv6 (AFI 2, SAFI 5) per RFC 6514
 - Support for all 7 MCAST-VPN route types: Intra-AS I-PMSI A-D, Inter-AS I-PMSI A-D, S-PMSI A-D, Leaf A-D, Source Active A-D, Shared Tree Join, Source Tree Join

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ RFC 9723 (BGP Colored Prefix Routing for SRv6) is supported via Color Extended C
 
 RFC 5701 (IPv6 Address Specific Extended Community) is supported for IPv6 VPN deployments, enabling IPv6-based route targets and route origin extended communities.
 
+RFC 8097 (BGP Prefix Origin Validation State) is supported via Origin Validation State Extended Community extraction in IPv4 and IPv6 Unicast and L3VPN prefixes, enabling RPKI validation state propagation within autonomous systems.
+
 For the complete list of supported extensions and drafts follow this link: [Support RFCs and Drafts.](https://github.com/sbezverk/gobmp/blob/master/BMP.md)
 
  

--- a/pkg/bgp/extended-community-const.go
+++ b/pkg/bgp/extended-community-const.go
@@ -54,6 +54,8 @@ const (
 	ECPContextLabelSpaceID = "cls="
 	// ECPColor extended community prefix for Color Extended Community	[RFC5512]
 	ECPColor = "color="
+	// ECPOriginValidation extended community prefix for Origin Validation State [RFC8097]
+	ECPOriginValidation = "ov-state="
 	// ECPEncapsulation extended community prefix for Encapsulation Extended Community	[RFC5512]
 	ECPEncapsulation = "encap="
 	// ECPDefaultGateway extended community prefix for Default Gateway	[Yakov_Rekhter]

--- a/pkg/bgp/extended-community_rpki_test.go
+++ b/pkg/bgp/extended-community_rpki_test.go
@@ -1,0 +1,158 @@
+package bgp
+
+import (
+	"testing"
+)
+
+func TestType43_OriginValidationStates(t *testing.T) {
+	tests := []struct {
+		name     string
+		subType  uint8
+		value    []byte
+		expected string
+	}{
+		{
+			name:     "Valid State (0)",
+			subType:  0x00,
+			value:    []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, // Last byte = 0
+			expected: "ov-state=valid",
+		},
+		{
+			name:     "Not Found State (1)",
+			subType:  0x00,
+			value:    []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x01}, // Last byte = 1
+			expected: "ov-state=not-found",
+		},
+		{
+			name:     "Invalid State (2)",
+			subType:  0x00,
+			value:    []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x02}, // Last byte = 2
+			expected: "ov-state=invalid",
+		},
+		{
+			name:     "Unknown State (3)",
+			subType:  0x00,
+			value:    []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x03}, // Last byte = 3
+			expected: "ov-state=unknown=3",
+		},
+		{
+			name:     "Unknown State (255)",
+			subType:  0x00,
+			value:    []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0xff}, // Last byte = 255
+			expected: "ov-state=unknown=255",
+		},
+		{
+			name:     "Invalid Length",
+			subType:  0x00,
+			value:    []byte{0x00, 0x00, 0x00}, // Too short
+			expected: "ov-state=invalid-length",
+		},
+		{
+			name:     "Unknown Subtype",
+			subType:  0x01,
+			value:    []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			expected: "Subtype unknown=unknown-subtype=1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := type43(tt.subType, tt.value)
+			if result != tt.expected {
+				t.Errorf("type43() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestType43_RFC8097_Compliance(t *testing.T) {
+	// RFC 8097 specifies exact byte structure
+	// Byte 0-1: Type/Subtype (0x43, 0x00)
+	// Byte 2-3: Reserved (0x00, 0x00)
+	// Byte 4-6: Reserved (0x00, 0x00, 0x00)
+	// Byte 7: Validation State
+
+	tests := []struct {
+		name          string
+		fullEC        []byte // Full 8-byte EC
+		expectedState string
+	}{
+		{
+			name:          "RFC 8097 Valid State",
+			fullEC:        []byte{0x43, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			expectedState: "valid",
+		},
+		{
+			name:          "RFC 8097 Not Found State",
+			fullEC:        []byte{0x43, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+			expectedState: "not-found",
+		},
+		{
+			name:          "RFC 8097 Invalid State",
+			fullEC:        []byte{0x43, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02},
+			expectedState: "invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Extract value portion (last 6 bytes) as type43 receives
+			value := tt.fullEC[2:]
+			result := type43(0x00, value)
+			expected := "ov-state=" + tt.expectedState
+			if result != expected {
+				t.Errorf("type43() = %q, want %q", result, expected)
+			}
+		})
+	}
+}
+
+func TestExtCommunity_String_Type43(t *testing.T) {
+	tests := []struct {
+		name     string
+		ec       *ExtCommunity
+		expected string
+	}{
+		{
+			name: "Type 0x43 Valid State",
+			ec: &ExtCommunity{
+				Type:    0x43,
+				SubType: uint8Ptr(0x00),
+				Value:   []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, // Valid
+			},
+			expected: "ov-state=valid",
+		},
+		{
+			name: "Type 0x43 Not Found State",
+			ec: &ExtCommunity{
+				Type:    0x43,
+				SubType: uint8Ptr(0x00),
+				Value:   []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x01}, // Not found
+			},
+			expected: "ov-state=not-found",
+		},
+		{
+			name: "Type 0x43 Invalid State",
+			ec: &ExtCommunity{
+				Type:    0x43,
+				SubType: uint8Ptr(0x00),
+				Value:   []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x02}, // Invalid
+			},
+			expected: "ov-state=invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.ec.String()
+			if result != tt.expected {
+				t.Errorf("ExtCommunity.String() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+// uint8Ptr is a helper function to create a pointer to a uint8 value
+func uint8Ptr(v uint8) *uint8 {
+	return &v
+}

--- a/pkg/message/types.go
+++ b/pkg/message/types.go
@@ -62,31 +62,32 @@ type PeerStateChange struct {
 // UnicastPrefix defines a message format sent as a result of BMP Route Monitor message
 // which carries BGP Update with original NLRI information.
 type UnicastPrefix struct {
-	Key            string              `json:"_key,omitempty"`
-	ID             string              `json:"_id,omitempty"`
-	Rev            string              `json:"_rev,omitempty"`
-	Action         string              `json:"action,omitempty"` // Action can be "add" or "del"
-	Sequence       int                 `json:"sequence,omitempty"`
-	Hash           string              `json:"hash,omitempty"`
-	RouterHash     string              `json:"router_hash,omitempty"`
-	RouterIP       string              `json:"router_ip,omitempty"`
-	BaseAttributes *bgp.BaseAttributes `json:"base_attrs,omitempty"`
-	PeerHash       string              `json:"peer_hash,omitempty"`
-	PeerIP         string              `json:"peer_ip,omitempty"`
-	PeerType       uint8               `json:"peer_type"`
-	PeerASN        uint32              `json:"peer_asn,omitempty"`
-	Timestamp      string              `json:"timestamp,omitempty"`
-	Prefix         string              `json:"prefix,omitempty"`
-	PrefixLen      int32               `json:"prefix_len,omitempty"`
-	IsIPv4         bool                `json:"is_ipv4"`
-	OriginAS       uint32              `json:"origin_as,omitempty"`
-	Nexthop        string              `json:"nexthop,omitempty"`
-	IsNexthopIPv4  bool                `json:"is_nexthop_ipv4"`
-	PathID         int32               `json:"path_id,omitempty"`
-	Labels         []uint32            `json:"labels,omitempty"`
-	Color          *uint32             `json:"color,omitempty"` // RFC 9723 BGP Colored Prefix Routing (CPR) for SRv6
-	PrefixSID      *prefixsid.PSid     `json:"prefix_sid,omitempty"`
-	IsEOR          bool                `json:"is_eor,omitempty"`
+	Key              string              `json:"_key,omitempty"`
+	ID               string              `json:"_id,omitempty"`
+	Rev              string              `json:"_rev,omitempty"`
+	Action           string              `json:"action,omitempty"` // Action can be "add" or "del"
+	Sequence         int                 `json:"sequence,omitempty"`
+	Hash             string              `json:"hash,omitempty"`
+	RouterHash       string              `json:"router_hash,omitempty"`
+	RouterIP         string              `json:"router_ip,omitempty"`
+	BaseAttributes   *bgp.BaseAttributes `json:"base_attrs,omitempty"`
+	PeerHash         string              `json:"peer_hash,omitempty"`
+	PeerIP           string              `json:"peer_ip,omitempty"`
+	PeerType         uint8               `json:"peer_type"`
+	PeerASN          uint32              `json:"peer_asn,omitempty"`
+	Timestamp        string              `json:"timestamp,omitempty"`
+	Prefix           string              `json:"prefix,omitempty"`
+	PrefixLen        int32               `json:"prefix_len,omitempty"`
+	IsIPv4           bool                `json:"is_ipv4"`
+	OriginAS         uint32              `json:"origin_as,omitempty"`
+	Nexthop          string              `json:"nexthop,omitempty"`
+	IsNexthopIPv4    bool                `json:"is_nexthop_ipv4"`
+	PathID           int32               `json:"path_id,omitempty"`
+	Labels           []uint32            `json:"labels,omitempty"`
+	Color            *uint32             `json:"color,omitempty"`             // RFC 9723 BGP Colored Prefix Routing (CPR) for SRv6
+	OriginValidation *string             `json:"origin_validation,omitempty"` // RFC 8097 RPKI Origin Validation State
+	PrefixSID        *prefixsid.PSid     `json:"prefix_sid,omitempty"`
+	IsEOR            bool                `json:"is_eor,omitempty"`
 	// Values are assigned based on PerPeerHeader flags
 	IsAdjRIBInPost   bool `json:"is_adj_rib_in_post_policy"`
 	IsAdjRIBOutPost  bool `json:"is_adj_rib_out_post_policy"`
@@ -171,6 +172,11 @@ func (u *UnicastPrefix) Equal(ou *UnicastPrefix) (bool, []string) {
 	} else if u.Color != nil && *u.Color != *ou.Color {
 		equal = false
 		diffs = append(diffs, "color mismatch")
+	}
+	if (u.OriginValidation == nil) != (ou.OriginValidation == nil) ||
+		(u.OriginValidation != nil && *u.OriginValidation != *ou.OriginValidation) {
+		equal = false
+		diffs = append(diffs, "origin_validation mismatch")
 	}
 	if u.PrefixSID != nil || ou.PrefixSID != nil {
 		if eq, df := u.PrefixSID.Equal(ou.PrefixSID); !eq {
@@ -341,32 +347,33 @@ type MCASTVPNPrefix struct {
 }
 // L3VPNPrefix defines the structure of Layer 3 VPN message
 type L3VPNPrefix struct {
-	Key            string              `json:"_key,omitempty"`
-	ID             string              `json:"_id,omitempty"`
-	Rev            string              `json:"_rev,omitempty"`
-	Action         string              `json:"action,omitempty"` // Action can be "add" or "del"
-	Sequence       int                 `json:"sequence,omitempty"`
-	Hash           string              `json:"hash,omitempty"`
-	RouterHash     string              `json:"router_hash,omitempty"`
-	RouterIP       string              `json:"router_ip,omitempty"`
-	BaseAttributes *bgp.BaseAttributes `json:"base_attrs,omitempty"`
-	PeerHash       string              `json:"peer_hash,omitempty"`
-	PeerIP         string              `json:"peer_ip,omitempty"`
-	PeerType       uint8               `json:"peer_type"`
-	PeerASN        uint32              `json:"peer_asn,omitempty"`
-	Timestamp      string              `json:"timestamp,omitempty"`
-	Prefix         string              `json:"prefix,omitempty"`
-	PrefixLen      int32               `json:"prefix_len,omitempty"`
-	IsIPv4         bool                `json:"is_ipv4"`
-	OriginAS       uint32              `json:"origin_as,omitempty"`
-	Nexthop        string              `json:"nexthop,omitempty"`
-	ClusterList    string              `json:"cluster_list,omitempty"`
-	IsNexthopIPv4  bool                `json:"is_nexthop_ipv4"`
-	PathID         int32               `json:"path_id,omitempty"`
-	Labels         []uint32            `json:"labels,omitempty"`
-	VPNRD          string              `json:"vpn_rd,omitempty"`
-	VPNRDType      uint16              `json:"vpn_rd_type"`
-	PrefixSID      *prefixsid.PSid     `json:"prefix_sid,omitempty"`
+	Key              string              `json:"_key,omitempty"`
+	ID               string              `json:"_id,omitempty"`
+	Rev              string              `json:"_rev,omitempty"`
+	Action           string              `json:"action,omitempty"` // Action can be "add" or "del"
+	Sequence         int                 `json:"sequence,omitempty"`
+	Hash             string              `json:"hash,omitempty"`
+	RouterHash       string              `json:"router_hash,omitempty"`
+	RouterIP         string              `json:"router_ip,omitempty"`
+	BaseAttributes   *bgp.BaseAttributes `json:"base_attrs,omitempty"`
+	PeerHash         string              `json:"peer_hash,omitempty"`
+	PeerIP           string              `json:"peer_ip,omitempty"`
+	PeerType         uint8               `json:"peer_type"`
+	PeerASN          uint32              `json:"peer_asn,omitempty"`
+	Timestamp        string              `json:"timestamp,omitempty"`
+	Prefix           string              `json:"prefix,omitempty"`
+	PrefixLen        int32               `json:"prefix_len,omitempty"`
+	IsIPv4           bool                `json:"is_ipv4"`
+	OriginAS         uint32              `json:"origin_as,omitempty"`
+	Nexthop          string              `json:"nexthop,omitempty"`
+	ClusterList      string              `json:"cluster_list,omitempty"`
+	IsNexthopIPv4    bool                `json:"is_nexthop_ipv4"`
+	PathID           int32               `json:"path_id,omitempty"`
+	Labels           []uint32            `json:"labels,omitempty"`
+	OriginValidation *string             `json:"origin_validation,omitempty"` // RFC 8097 RPKI Origin Validation State
+	VPNRD            string              `json:"vpn_rd,omitempty"`
+	VPNRDType        uint16              `json:"vpn_rd_type"`
+	PrefixSID        *prefixsid.PSid     `json:"prefix_sid,omitempty"`
 	// Values are assigned based on PerPeerHeader flags
 	IsAdjRIBInPost   bool `json:"is_adj_rib_in_post_policy"`
 	IsAdjRIBOutPost  bool `json:"is_adj_rib_out_post_policy"`

--- a/pkg/message/unicast_rpki_test.go
+++ b/pkg/message/unicast_rpki_test.go
@@ -1,0 +1,340 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/sbezverk/gobmp/pkg/bgp"
+)
+
+// stringPtr is a helper function to create a pointer to a string value
+func stringPtr(s string) *string {
+	return &s
+}
+
+// equalStringPtr compares two string pointers for equality
+func equalStringPtr(a, b *string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+func TestExtractOriginValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		attrs    *bgp.BaseAttributes
+		expected *string
+	}{
+		{
+			name: "Valid State",
+			attrs: &bgp.BaseAttributes{
+				ExtCommunityList: []string{"ov-state=valid"},
+			},
+			expected: stringPtr("valid"),
+		},
+		{
+			name: "Not Found State",
+			attrs: &bgp.BaseAttributes{
+				ExtCommunityList: []string{"ov-state=not-found"},
+			},
+			expected: stringPtr("not-found"),
+		},
+		{
+			name: "Invalid State",
+			attrs: &bgp.BaseAttributes{
+				ExtCommunityList: []string{"ov-state=invalid"},
+			},
+			expected: stringPtr("invalid"),
+		},
+		{
+			name: "No OV State EC",
+			attrs: &bgp.BaseAttributes{
+				ExtCommunityList: []string{"rt=65000:100"},
+			},
+			expected: nil,
+		},
+		{
+			name: "Multiple ECs with OV State",
+			attrs: &bgp.BaseAttributes{
+				ExtCommunityList: []string{"rt=65000:100", "ov-state=valid", "ro=65000:200"},
+			},
+			expected: stringPtr("valid"),
+		},
+		{
+			name: "Multiple ECs without OV State",
+			attrs: &bgp.BaseAttributes{
+				ExtCommunityList: []string{"rt=65000:100", "color=100", "ro=65000:200"},
+			},
+			expected: nil,
+		},
+		{
+			name:     "Nil BaseAttributes",
+			attrs:    nil,
+			expected: nil,
+		},
+		{
+			name: "Nil ExtCommunityList",
+			attrs: &bgp.BaseAttributes{
+				ExtCommunityList: nil,
+			},
+			expected: nil,
+		},
+		{
+			name: "Empty ExtCommunityList",
+			attrs: &bgp.BaseAttributes{
+				ExtCommunityList: []string{},
+			},
+			expected: nil,
+		},
+		{
+			name: "Unknown State Value",
+			attrs: &bgp.BaseAttributes{
+				ExtCommunityList: []string{"ov-state=unknown=3"},
+			},
+			expected: nil, // Only valid, not-found, invalid accepted
+		},
+		{
+			name: "Malformed State",
+			attrs: &bgp.BaseAttributes{
+				ExtCommunityList: []string{"ov-state=malformed"},
+			},
+			expected: nil,
+		},
+		{
+			name: "First Valid State Used",
+			attrs: &bgp.BaseAttributes{
+				ExtCommunityList: []string{"ov-state=valid", "ov-state=invalid"},
+			},
+			expected: stringPtr("valid"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractOriginValidation(tt.attrs)
+			if !equalStringPtr(result, tt.expected) {
+				var resultVal, expectedVal string
+				if result == nil {
+					resultVal = "nil"
+				} else {
+					resultVal = *result
+				}
+				if tt.expected == nil {
+					expectedVal = "nil"
+				} else {
+					expectedVal = *tt.expected
+				}
+				t.Errorf("extractOriginValidation() = %q, want %q", resultVal, expectedVal)
+			}
+		})
+	}
+}
+
+func TestExtractOriginValidation_Integration(t *testing.T) {
+	// Test with realistic BGP BaseAttributes structure
+	attrs := &bgp.BaseAttributes{
+		Origin:           "igp",
+		ASPath:           []uint32{65000, 65001},
+		Nexthop:          "2001:db8::1",
+		ExtCommunityList: []string{"rt=65000:100", "ov-state=valid", "color=500"},
+	}
+
+	ovState := extractOriginValidation(attrs)
+	if ovState == nil {
+		t.Fatalf("expected Origin Validation state to be extracted, got nil")
+	}
+	if *ovState != "valid" {
+		t.Errorf("expected Origin Validation state 'valid', got %q", *ovState)
+	}
+}
+
+func TestUnicastPrefix_OriginValidationField(t *testing.T) {
+	// Test UnicastPrefix struct with OriginValidation field
+	prefix := &UnicastPrefix{
+		Prefix:           "2001:db8::/32",
+		PrefixLen:        32,
+		OriginValidation: stringPtr("valid"),
+	}
+
+	if prefix.OriginValidation == nil {
+		t.Fatal("expected OriginValidation field to be set")
+	}
+	if *prefix.OriginValidation != "valid" {
+		t.Errorf("expected OriginValidation 'valid', got %q", *prefix.OriginValidation)
+	}
+
+	// Test with nil OriginValidation
+	prefix2 := &UnicastPrefix{
+		Prefix:           "2001:db8:1::/48",
+		PrefixLen:        48,
+		OriginValidation: nil,
+	}
+
+	if prefix2.OriginValidation != nil {
+		t.Errorf("expected OriginValidation field to be nil, got %q", *prefix2.OriginValidation)
+	}
+}
+
+func TestUnicastPrefix_Equal_WithOriginValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix1  *UnicastPrefix
+		prefix2  *UnicastPrefix
+		expected bool
+	}{
+		{
+			name: "Equal prefixes with same OV state",
+			prefix1: &UnicastPrefix{
+				Prefix:           "2001:db8::/32",
+				PrefixLen:        32,
+				OriginValidation: stringPtr("valid"),
+			},
+			prefix2: &UnicastPrefix{
+				Prefix:           "2001:db8::/32",
+				PrefixLen:        32,
+				OriginValidation: stringPtr("valid"),
+			},
+			expected: true,
+		},
+		{
+			name: "Different OV states",
+			prefix1: &UnicastPrefix{
+				Prefix:           "2001:db8::/32",
+				PrefixLen:        32,
+				OriginValidation: stringPtr("valid"),
+			},
+			prefix2: &UnicastPrefix{
+				Prefix:           "2001:db8::/32",
+				PrefixLen:        32,
+				OriginValidation: stringPtr("invalid"),
+			},
+			expected: false,
+		},
+		{
+			name: "One OV state nil, other set",
+			prefix1: &UnicastPrefix{
+				Prefix:           "2001:db8::/32",
+				PrefixLen:        32,
+				OriginValidation: stringPtr("valid"),
+			},
+			prefix2: &UnicastPrefix{
+				Prefix:           "2001:db8::/32",
+				PrefixLen:        32,
+				OriginValidation: nil,
+			},
+			expected: false,
+		},
+		{
+			name: "Both OV states nil",
+			prefix1: &UnicastPrefix{
+				Prefix:           "2001:db8::/32",
+				PrefixLen:        32,
+				OriginValidation: nil,
+			},
+			prefix2: &UnicastPrefix{
+				Prefix:           "2001:db8::/32",
+				PrefixLen:        32,
+				OriginValidation: nil,
+			},
+			expected: true,
+		},
+		{
+			name: "All three states tested",
+			prefix1: &UnicastPrefix{
+				Prefix:           "2001:db8::/32",
+				PrefixLen:        32,
+				OriginValidation: stringPtr("not-found"),
+			},
+			prefix2: &UnicastPrefix{
+				Prefix:           "2001:db8::/32",
+				PrefixLen:        32,
+				OriginValidation: stringPtr("not-found"),
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			equal, diffs := tt.prefix1.Equal(tt.prefix2)
+			if equal != tt.expected {
+				t.Errorf("Equal() = %v, want %v. Diffs: %v", equal, tt.expected, diffs)
+			}
+		})
+	}
+}
+
+func TestL3VPNPrefix_OriginValidationField(t *testing.T) {
+	// Test L3VPNPrefix struct with OriginValidation field
+	prefix := &L3VPNPrefix{
+		Prefix:           "10.1.1.0",
+		PrefixLen:        24,
+		OriginValidation: stringPtr("invalid"),
+		VPNRD:            "65000:100",
+	}
+
+	if prefix.OriginValidation == nil {
+		t.Fatal("expected OriginValidation field to be set")
+	}
+	if *prefix.OriginValidation != "invalid" {
+		t.Errorf("expected OriginValidation 'invalid', got %q", *prefix.OriginValidation)
+	}
+
+	// Test with nil OriginValidation
+	prefix2 := &L3VPNPrefix{
+		Prefix:           "10.2.2.0",
+		PrefixLen:        24,
+		OriginValidation: nil,
+		VPNRD:            "65000:200",
+	}
+
+	if prefix2.OriginValidation != nil {
+		t.Errorf("expected OriginValidation field to be nil, got %q", *prefix2.OriginValidation)
+	}
+}
+
+func TestOriginValidation_AllStates(t *testing.T) {
+	// Ensure all three valid states are tested
+	states := []string{"valid", "not-found", "invalid"}
+
+	for _, state := range states {
+		t.Run("State_"+state, func(t *testing.T) {
+			attrs := &bgp.BaseAttributes{
+				ExtCommunityList: []string{"ov-state=" + state},
+			}
+
+			result := extractOriginValidation(attrs)
+			if result == nil {
+				t.Fatalf("expected state %q to be extracted, got nil", state)
+			}
+			if *result != state {
+				t.Errorf("expected state %q, got %q", state, *result)
+			}
+		})
+	}
+}
+
+func TestOriginValidation_WithColorEC(t *testing.T) {
+	// Test that both Color and OriginValidation can coexist
+	attrs := &bgp.BaseAttributes{
+		ExtCommunityList: []string{"color=100", "ov-state=valid", "rt=65000:100"},
+	}
+
+	ovState := extractOriginValidation(attrs)
+	color := extractColorEC(attrs)
+
+	if ovState == nil {
+		t.Error("expected Origin Validation state to be extracted")
+	} else if *ovState != "valid" {
+		t.Errorf("expected OriginValidation 'valid', got %q", *ovState)
+	}
+
+	if color == nil {
+		t.Error("expected Color to be extracted")
+	} else if *color != 100 {
+		t.Errorf("expected Color 100, got %d", *color)
+	}
+}


### PR DESCRIPTION
Implement BGP Prefix Origin Validation State Extended Community per RFC 8097.

Changes:
- Add OriginValidation field to UnicastPrefix and L3VPNPrefix message types
- Parse Non-Transitive Opaque Extended Community (Type 0x43)
- Extract RPKI origin validation state from BGP Updates
- Support validation states: valid, not-found, invalid
- Comprehensive tests for EC parsing and state extraction
- Documentation updates (README, CHANGELOG)

RFC 8097 enables RPKI validation state propagation within an AS using BGP Extended Communities. Adds security monitoring capabilities to BMP collection by exposing route origin validation status.