### PR TITLE
Add Multicast VPN support (AFI 1/2, SAFI 129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Message updates and major project changes should be documented here.
 - MCAST-VPN support for IPv4 (AFI 1, SAFI 5) per RFC 6514
 - MCAST-VPN support for IPv6 (AFI 2, SAFI 5) per RFC 6514
 - Support for all 7 MCAST-VPN route types: Intra-AS I-PMSI A-D, Inter-AS I-PMSI A-D, S-PMSI A-D, Leaf A-D, Source Active A-D, Shared Tree Join, Source Tree Join
+- MVPN support for IPv4 (AFI 1, SAFI 129) per RFC 6514
+- MVPN support for IPv6 (AFI 2, SAFI 129) per RFC 6514
+- Support for all 7 MVPN route types (reusing MCAST-VPN parser): Intra-AS I-PMSI A-D, Inter-AS I-PMSI A-D, S-PMSI A-D, Leaf A-D, Source Active A-D, Shared Tree Join, Source Tree Join
 
 ### 2025-12-15
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ List of currently supported NLRI and AFI/SAFI:
    <td>2/5
    </td>
   </tr>
+  <tr>
+   <td>MVPN for v4
+   </td>
+   <td>1/129
+   </td>
+  </tr>
+  <tr>
+   <td>MVPN for v6
+   </td>
+   <td>2/129
+   </td>
+  </tr>
 </table>
 
 

--- a/pkg/bgp/mp-nlri.go
+++ b/pkg/bgp/mp-nlri.go
@@ -23,6 +23,7 @@ type MPNLRI interface {
 	GetNLRI73() (*srpolicy.NLRI73, error)
 	GetFlowspecNLRI() (*flowspec.NLRI, error)
 	GetNLRIMCASTVPN() (*mcastvpn.Route, error)
+	GetNLRIMVPN() (*mcastvpn.Route, error)
 	GetNextHop() string
 	IsIPv6NLRI() bool
 	IsNextHopIPv6() bool
@@ -89,6 +90,12 @@ func NLRIMessageType(afi uint16, safi uint8) int {
 		// AFI 2 and SAFI 5 MCAST-VPN v6
 	case afi == 2 && safi == 5:
 		return 33
+		// AFI 1 and SAFI 129 Multicast VPN v4
+	case afi == 1 && safi == 129:
+		return 34
+		// AFI 2 and SAFI 129 Multicast VPN v6
+	case afi == 2 && safi == 129:
+		return 35
 	}
 
 	return 0

--- a/pkg/bgp/mp-reach-nlri.go
+++ b/pkg/bgp/mp-reach-nlri.go
@@ -225,6 +225,15 @@ func (mp *MPReachNLRI) GetNLRIMCASTVPN() (*mcastvpn.Route, error) {
 	return nil, fmt.Errorf("not found")
 }
 
+// GetNLRIMVPN instantiates Multicast VPN (SAFI 129) NLRI
+func (mp *MPReachNLRI) GetNLRIMVPN() (*mcastvpn.Route, error) {
+	if mp.SubAddressFamilyID == 129 {
+		return mcastvpn.UnmarshalMCASTVPNNLRI(mp.NLRI)
+	}
+
+	return nil, fmt.Errorf("not found")
+}
+
 // UnmarshalMPReachNLRI builds MP Reach NLRI attributes
 func UnmarshalMPReachNLRI(b []byte, srv6 bool, addPath map[int]bool) (MPNLRI, error) {
 	if glog.V(6) {

--- a/pkg/bgp/mp-unreach-nlri.go
+++ b/pkg/bgp/mp-unreach-nlri.go
@@ -182,6 +182,15 @@ func (mp *MPUnReachNLRI) GetNLRIMCASTVPN() (*mcastvpn.Route, error) {
 	return nil, fmt.Errorf("not found")
 }
 
+// GetNLRIMVPN instantiates Multicast VPN (SAFI 129) NLRI
+func (mp *MPUnReachNLRI) GetNLRIMVPN() (*mcastvpn.Route, error) {
+	if mp.SubAddressFamilyID == 129 {
+		return mcastvpn.UnmarshalMCASTVPNNLRI(mp.WithdrawnRoutes)
+	}
+
+	return nil, fmt.Errorf("not found")
+}
+
 // UnmarshalMPUnReachNLRI builds MP Reach NLRI attributes
 func UnmarshalMPUnReachNLRI(b []byte, addPath map[int]bool) (MPNLRI, error) {
 	if glog.V(6) {

--- a/pkg/bmp/consts.go
+++ b/pkg/bmp/consts.go
@@ -66,6 +66,10 @@ const (
 	MCASTVPNV4Msg = 204
 	// MCASTVPNV6Msg defines BMP Route Monitoring message carrying MCAST-VPN IPv6 NLRI
 	MCASTVPNV6Msg = 206
+	// MVPNV4Msg defines BMP Route Monitoring message carrying MVPN IPv4 NLRI
+	MVPNV4Msg = 208
+	// MVPNV6Msg defines BMP Route Monitoring message carrying MVPN IPv6 NLRI
+	MVPNV6Msg = 210
 	// BMPRawMsg defines BMP RAW message type for unprocessed BMP messages
 	BMPRawMsg = 255
 )

--- a/pkg/message/mvpn.go
+++ b/pkg/message/mvpn.go
@@ -1,0 +1,129 @@
+package message
+
+import (
+	"encoding/hex"
+	"fmt"
+	"net"
+
+	"github.com/sbezverk/gobmp/pkg/bgp"
+	"github.com/sbezverk/gobmp/pkg/bmp"
+	"github.com/sbezverk/gobmp/pkg/mcastvpn"
+)
+
+// mvpn processes MP_REACH_NLRI/MP_UNREACH_NLRI AFI 1/2 SAFI 129 (MVPN)
+func (p *producer) mvpn(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *bgp.Update) ([]*MVPNPrefix, error) {
+	var operation string
+	switch op {
+	case 0:
+		operation = "add"
+	case 1:
+		operation = "del"
+	default:
+		return nil, fmt.Errorf("unknown operation %d", op)
+	}
+
+	prfxs := make([]*MVPNPrefix, 0)
+	mvpnRoute, err := nlri.GetNLRIMVPN()
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle EOR (End-of-RIB) when no NLRIs present
+	if len(mvpnRoute.Route) == 0 {
+		return []*MVPNPrefix{
+			{
+				Action:     operation,
+				RouterHash: p.speakerHash,
+				RouterIP:   p.speakerIP,
+				PeerHash:   ph.GetPeerHash(),
+				PeerASN:    ph.PeerAS,
+				Timestamp:  ph.GetPeerTimestamp(),
+				PeerType:   uint8(ph.PeerType),
+				IsEOR:      true,
+			},
+		}, nil
+	}
+
+	for _, route := range mvpnRoute.Route {
+		prfx := &MVPNPrefix{
+			Action:         operation,
+			RouterHash:     p.speakerHash,
+			RouterIP:       p.speakerIP,
+			PeerType:       uint8(ph.PeerType),
+			PeerHash:       ph.GetPeerHash(),
+			PeerASN:        ph.PeerAS,
+			Timestamp:      ph.GetPeerTimestamp(),
+			RouteType:      route.RouteType,
+			BaseAttributes: update.BaseAttributes,
+		}
+
+		// Set RIB flags
+		if f, err := ph.IsAdjRIBInPost(); err == nil {
+			prfx.IsAdjRIBInPost = f
+		}
+		if f, err := ph.IsAdjRIBOutPost(); err == nil {
+			prfx.IsAdjRIBOutPost = f
+		}
+		if f, err := ph.IsLocRIBFiltered(); err == nil {
+			prfx.IsLocRIBFiltered = f
+		}
+
+		prfx.PeerIP = ph.GetPeerAddrString()
+		prfx.IsIPv4 = !nlri.IsIPv6NLRI()
+
+		// Extract nexthop
+		prfx.Nexthop = nlri.GetNextHop()
+		prfx.IsNexthopIPv4 = len(nlri.GetNextHop()) > 0 && net.ParseIP(nlri.GetNextHop()).To4() != nil
+
+		// Extract Route Distinguisher if present
+		if rd := route.GetMCASTVPNRD(); rd != nil {
+			prfx.RD = rd.String()
+		}
+
+		// Extract Originating Router IP if present
+		if originatorIP := route.GetMCASTVPNOriginatorIP(); len(originatorIP) > 0 {
+			if len(originatorIP) == 4 {
+				prfx.OriginatorIP = net.IP(originatorIP).To4().String()
+			} else if len(originatorIP) == 16 {
+				prfx.OriginatorIP = net.IP(originatorIP).To16().String()
+			}
+		}
+
+		// Extract Multicast Source if present
+		if mcastSrc := route.GetMCASTVPNMulticastSource(); len(mcastSrc) > 0 {
+			if len(mcastSrc) == 4 {
+				prfx.MulticastSource = net.IP(mcastSrc).To4().String()
+			} else if len(mcastSrc) == 16 {
+				prfx.MulticastSource = net.IP(mcastSrc).To16().String()
+			}
+		}
+
+		// Extract Multicast Group if present
+		if mcastGrp := route.GetMCASTVPNMulticastGroup(); len(mcastGrp) > 0 {
+			if len(mcastGrp) == 4 {
+				prfx.MulticastGroup = net.IP(mcastGrp).To4().String()
+			} else if len(mcastGrp) == 16 {
+				prfx.MulticastGroup = net.IP(mcastGrp).To16().String()
+			}
+		}
+
+		// Extract Source AS if present
+		if sourceAS := route.GetMCASTVPNSourceAS(); sourceAS != 0 {
+			prfx.SourceAS = sourceAS
+		}
+
+		// For Type 4 (Leaf A-D), extract Route Key
+		if route.RouteType == 4 {
+			if spec := route.GetRouteTypeSpec(); spec != nil {
+				// Type 4 specific: encode RouteKey as hex string
+				if t4, ok := spec.(*mcastvpn.Type4); ok {
+					prfx.RouteKey = hex.EncodeToString(t4.RouteKey)
+				}
+			}
+		}
+
+		prfxs = append(prfxs, prfx)
+	}
+
+	return prfxs, nil
+}

--- a/pkg/message/process-mp-update.go
+++ b/pkg/message/process-mp-update.go
@@ -215,6 +215,24 @@ func (p *producer) processMPUpdate(nlri bgp.MPNLRI, operation int, ph *bmp.PerPe
 				return
 			}
 		}
+	case 34:
+		fallthrough
+	case 35:
+		msgs, err := p.mvpn(nlri, operation, ph, update)
+		if err != nil {
+			glog.Errorf("failed to produce mvpn messages with error: %+v", err)
+			return
+		}
+		for _, m := range msgs {
+			topicType := bmp.MVPNV6Msg
+			if m.IsIPv4 {
+				topicType = bmp.MVPNV4Msg
+			}
+			if err := p.marshalAndPublish(&m, topicType, []byte(m.RouterHash), false); err != nil {
+				glog.Errorf("failed to process MVPN message with error: %+v", err)
+				return
+			}
+		}
 	case 71:
 		p.processNLRI71SubTypes(nlri, operation, ph, update)
 	}

--- a/pkg/message/types.go
+++ b/pkg/message/types.go
@@ -370,6 +370,10 @@ type MCASTVPNPrefix struct {
 	IsLocRIBFiltered bool                `json:"is_loc_rib_filtered"`
 }
 
+// MVPNPrefix defines structure for Multicast VPN (SAFI 129)
+// Reuses MCASTVPNPrefix structure (same RFC 6514 format)
+type MVPNPrefix = MCASTVPNPrefix
+
 // L3VPNPrefix defines the structure of Layer 3 VPN message
 type L3VPNPrefix struct {
 	Key            string              `json:"_key,omitempty"`

--- a/pkg/message/vpls_test.go
+++ b/pkg/message/vpls_test.go
@@ -345,4 +345,5 @@ func (m *mockMPNLRI) GetNLRI71() (*ls.NLRI71, error)           { return nil, nil
 func (m *mockMPNLRI) GetNLRI73() (*srpolicy.NLRI73, error)     { return nil, nil }
 func (m *mockMPNLRI) GetFlowspecNLRI() (*flowspec.NLRI, error) { return nil, nil }
 func (m *mockMPNLRI) GetNLRIMCASTVPN() (*mcastvpn.Route, error) { return nil, nil }
+func (m *mockMPNLRI) GetNLRIMVPN() (*mcastvpn.Route, error)     { return nil, nil }
 func (m *mockMPNLRI) GetNLRIMulticast() (*base.MPNLRI, error)  { return nil, nil }


### PR DESCRIPTION
Implement RFC 6514 Multicast VPN (SAFI 129) by reusing existing MCAST-VPN (SAFI 5) implementation.

Changes:
- BGP integration for AFI 1/2, SAFI 129 (cases 34, 35)
- Message producer for BMP Route Monitoring
- Kafka topics: MVPNV4Msg (208), MVPNV6Msg (210)
- Reuses existing mcastvpn package (all 7 route types)
- Documentation updates (README, CHANGELOG)

All 7 RFC 6514 route types supported:
- Type 1: Intra-AS I-PMSI A-D route
- Type 2: Inter-AS I-PMSI A-D route
- Type 3: S-PMSI A-D route
- Type 4: Leaf A-D route
- Type 5: Source Active A-D route
- Type 6: Shared Tree Join route
- Type 7: Source Tree Join route