### PR TITLE
ci: upgrade Go version from 1.23.x to 1.24.x

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -12,7 +12,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        go-version: [1.23.x]
+        go-version: [1.24.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -109,7 +109,7 @@ jobs:
     strategy:
         matrix:
           os: [ubuntu-latest]
-          go-version: [1.23.x]
+          go-version: [1.24.x]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo
@@ -196,7 +196,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
 
       - name: Run BGP-LS RFC 7752 compliance tests
         run: |
@@ -248,7 +248,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
 
       - name: Verify VPLS test data exists
         run: |


### PR DESCRIPTION
## Summary
- Upgrade Go version in CI/CD workflow from 1.23.x to 1.24.x
- Aligns with `go.mod` requirement (`go 1.24.0`)

## Problem
PR #311 (`actions/setup-go` v5→v6) fails because v6 sets `GOTOOLCHAIN=local`,
which prevents auto-downloading Go 1.24 when the workflow specifies 1.23.x.

## Solution
Update all `go-version` references in `.github/workflows/cicd.yml` to 1.24.x.

## Changes
- `tests` job: 1.23.x → 1.24.x
- `integration_tests` job: 1.23.x → 1.24.x
- `rfc_compliance_bgpls` job: 1.23.x → 1.24.x
- `rfc_compliance_vpls` job: 1.23.x → 1.24.x