### PR TITLE
Remove Codecov bot integration

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -87,15 +87,6 @@ jobs:
             coverage.txt
             benchmark.txt
           retention-days: 30
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          file: ./coverage.txt
-          flags: unittests
-          name: codecov-gobmp
-          fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       # --- Build ---
       - name: Build binary


### PR DESCRIPTION
Remove codecov/codecov-action from CI workflow to reduce external dependencies and PR comment noise. Coverage generation still enabled via `go test -coverprofile=coverage.txt` and uploaded as artifacts.

Coverage can be viewed locally with: go tool cover -html=coverage.txt