### PR TITLE
Add RFC 9069 TableName support to all NLRI parsers

### DIFF
--- a/pkg/message/evpn.go
+++ b/pkg/message/evpn.go
@@ -128,6 +128,10 @@ func (p *producer) evpn(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *
 			if f, err := ph.IsLocRIBFiltered(); err == nil {
 				prfx.IsLocRIBFiltered = f
 			}
+			// RFC 9069: Set TableName for LocRIB peers
+			if prfx.IsLocRIB {
+				prfx.TableName = p.GetTableName(ph.GetPeerBGPIDString(), ph.GetPeerDistinguisherString())
+			}
 		}
 		prfxs = append(prfxs, prfx)
 	}

--- a/pkg/message/flowspec.go
+++ b/pkg/message/flowspec.go
@@ -61,6 +61,10 @@ func (p *producer) flowspec(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, upda
 	if f, err := ph.IsLocRIBFiltered(); err == nil {
 		fs.IsLocRIBFiltered = f
 	}
+	// RFC 9069: Set TableName for LocRIB peers
+	if fs.IsLocRIB {
+		fs.TableName = p.GetTableName(ph.GetPeerBGPIDString(), ph.GetPeerDistinguisherString())
+	}
 
 	return []*Flowspec{fs}, nil
 }

--- a/pkg/message/ls-link.go
+++ b/pkg/message/ls-link.go
@@ -45,6 +45,10 @@ func (p *producer) lsLink(link *base.LinkNLRI, nextHop string, op int, ph *bmp.P
 	if f, err := ph.IsLocRIBFiltered(); err == nil {
 		msg.IsLocRIBFiltered = f
 	}
+	// RFC 9069: Set TableName for LocRIB peers
+	if msg.IsLocRIB {
+		msg.TableName = p.GetTableName(ph.GetPeerBGPIDString(), ph.GetPeerDistinguisherString())
+	}
 	msg.Nexthop = nextHop
 	msg.PeerIP = ph.GetPeerAddrString()
 	msg.Protocol = link.GetLinkProtocolID()

--- a/pkg/message/ls-node.go
+++ b/pkg/message/ls-node.go
@@ -44,6 +44,10 @@ func (p *producer) lsNode(node *base.NodeNLRI, _ /* place holder for the next ho
 	if f, err := ph.IsLocRIBFiltered(); err == nil {
 		msg.IsLocRIBFiltered = f
 	}
+	// RFC 9069: Set TableName for LocRIB peers
+	if msg.IsLocRIB {
+		msg.TableName = p.GetTableName(ph.GetPeerBGPIDString(), ph.GetPeerDistinguisherString())
+	}
 	msg.PeerIP = ph.GetPeerAddrString()
 	msg.Protocol = node.GetNodeProtocolID()
 	msg.ProtocolID = node.ProtocolID

--- a/pkg/message/ls-prefix.go
+++ b/pkg/message/ls-prefix.go
@@ -44,6 +44,10 @@ func (p *producer) lsPrefix(prfx *base.PrefixNLRI, nextHop string, op int, ph *b
 	if f, err := ph.IsLocRIBFiltered(); err == nil {
 		msg.IsLocRIBFiltered = f
 	}
+	// RFC 9069: Set TableName for LocRIB peers
+	if msg.IsLocRIB {
+		msg.TableName = p.GetTableName(ph.GetPeerBGPIDString(), ph.GetPeerDistinguisherString())
+	}
 	msg.Nexthop = nextHop
 	msg.PeerIP = ph.GetPeerAddrString()
 	msg.ProtocolID = prfx.ProtocolID

--- a/pkg/message/ls-srv6-sid.go
+++ b/pkg/message/ls-srv6-sid.go
@@ -43,6 +43,10 @@ func (p *producer) lsSRv6SID(nlri6 *srv6.SIDNLRI, nextHop string, op int, ph *bm
 	if f, err := ph.IsLocRIBFiltered(); err == nil {
 		msg.IsLocRIBFiltered = f
 	}
+	// RFC 9069: Set TableName for LocRIB peers
+	if msg.IsLocRIB {
+		msg.TableName = p.GetTableName(ph.GetPeerBGPIDString(), ph.GetPeerDistinguisherString())
+	}
 	msg.Nexthop = nextHop
 	msg.PeerIP = ph.GetPeerAddrString()
 	msg.ProtocolID = nlri6.ProtocolID

--- a/pkg/message/mcastvpn.go
+++ b/pkg/message/mcastvpn.go
@@ -64,8 +64,18 @@ func (p *producer) mcastvpn(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, upda
 		if f, err := ph.IsAdjRIBOutPost(); err == nil {
 			prfx.IsAdjRIBOutPost = f
 		}
+		if f, err := ph.IsAdjRIBOut(); err == nil {
+			prfx.IsAdjRIBOut = f
+		}
+		if f, err := ph.IsLocRIB(); err == nil {
+			prfx.IsLocRIB = f
+		}
 		if f, err := ph.IsLocRIBFiltered(); err == nil {
 			prfx.IsLocRIBFiltered = f
+		}
+		// RFC 9069: Set TableName for LocRIB peers
+		if prfx.IsLocRIB {
+			prfx.TableName = p.GetTableName(ph.GetPeerBGPIDString(), ph.GetPeerDistinguisherString())
 		}
 
 		prfx.PeerIP = ph.GetPeerAddrString()

--- a/pkg/message/mp-multicast.go
+++ b/pkg/message/mp-multicast.go
@@ -60,8 +60,18 @@ func (p *producer) multicast(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, upd
 		if f, err := ph.IsAdjRIBOutPost(); err == nil {
 			prfx.IsAdjRIBOutPost = f
 		}
+		if f, err := ph.IsAdjRIBOut(); err == nil {
+			prfx.IsAdjRIBOut = f
+		}
+		if f, err := ph.IsLocRIB(); err == nil {
+			prfx.IsLocRIB = f
+		}
 		if f, err := ph.IsLocRIBFiltered(); err == nil {
 			prfx.IsLocRIBFiltered = f
+		}
+		// RFC 9069: Set TableName for LocRIB peers
+		if prfx.IsLocRIB {
+			prfx.TableName = p.GetTableName(ph.GetPeerBGPIDString(), ph.GetPeerDistinguisherString())
 		}
 		if ases := update.BaseAttributes.ASPath; len(ases) != 0 {
 			prfx.OriginAS = ases[len(ases)-1]

--- a/pkg/message/rtc.go
+++ b/pkg/message/rtc.go
@@ -63,8 +63,18 @@ func (p *producer) rtc(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *b
 		if f, err := ph.IsAdjRIBOutPost(); err == nil {
 			prfx.IsAdjRIBOutPost = f
 		}
+		if f, err := ph.IsAdjRIBOut(); err == nil {
+			prfx.IsAdjRIBOut = f
+		}
+		if f, err := ph.IsLocRIB(); err == nil {
+			prfx.IsLocRIB = f
+		}
 		if f, err := ph.IsLocRIBFiltered(); err == nil {
 			prfx.IsLocRIBFiltered = f
+		}
+		// RFC 9069: Set TableName for LocRIB peers
+		if prfx.IsLocRIB {
+			prfx.TableName = p.GetTableName(ph.GetPeerBGPIDString(), ph.GetPeerDistinguisherString())
 		}
 
 		prfx.PeerIP = ph.GetPeerAddrString()

--- a/pkg/message/srpolicy.go
+++ b/pkg/message/srpolicy.go
@@ -50,6 +50,10 @@ func (p *producer) srpolicy(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, upda
 	if f, err := ph.IsLocRIBFiltered(); err == nil {
 		prfx.IsLocRIBFiltered = f
 	}
+	// RFC 9069: Set TableName for LocRIB peers
+	if prfx.IsLocRIB {
+		prfx.TableName = p.GetTableName(ph.GetPeerBGPIDString(), ph.GetPeerDistinguisherString())
+	}
 	if ases := update.BaseAttributes.ASPath; len(ases) != 0 {
 		// Last element in AS_PATH would be the AS of the origin
 		prfx.OriginAS = ases[len(ases)-1]

--- a/pkg/message/types.go
+++ b/pkg/message/types.go
@@ -89,11 +89,12 @@ type UnicastPrefix struct {
 	PrefixSID        *prefixsid.PSid     `json:"prefix_sid,omitempty"`
 	IsEOR            bool                `json:"is_eor,omitempty"`
 	// Values are assigned based on PerPeerHeader flags
-	IsAdjRIBInPost   bool `json:"is_adj_rib_in_post_policy"`
-	IsAdjRIBOutPost  bool `json:"is_adj_rib_out_post_policy"`
-	IsAdjRIBOut      bool `json:"is_adj_rib_out"`
-	IsLocRIB         bool `json:"is_loc_rib"`
-	IsLocRIBFiltered bool `json:"is_loc_rib_filtered"`
+	IsAdjRIBInPost   bool   `json:"is_adj_rib_in_post_policy"`
+	IsAdjRIBOutPost  bool   `json:"is_adj_rib_out_post_policy"`
+	IsAdjRIBOut      bool   `json:"is_adj_rib_out"`
+	IsLocRIB         bool   `json:"is_loc_rib"`
+	IsLocRIBFiltered bool   `json:"is_loc_rib_filtered"`
+	TableName        string `json:"table_name,omitempty"` // RFC 9069 Table Name for LocRIB
 }
 
 func (u *UnicastPrefix) Equal(ou *UnicastPrefix) (bool, []string) {
@@ -233,11 +234,12 @@ type LSNode struct {
 	NodeMSD             []*base.MSDTV                   `json:"node_msd,omitempty"`
 	FlexAlgoDefinition  []*bgpls.FlexAlgoDefinition     `json:"flex_algo_definition,omitempty"`
 	// Values are assigned based on PerPeerHeader flags
-	IsAdjRIBInPost   bool `json:"is_adj_rib_in_post_policy"`
-	IsAdjRIBOutPost  bool `json:"is_adj_rib_out_post_policy"`
-	IsAdjRIBOut      bool `json:"is_adj_rib_out"`
-	IsLocRIB         bool `json:"is_loc_rib"`
-	IsLocRIBFiltered bool `json:"is_loc_rib_filtered"`
+	IsAdjRIBInPost   bool   `json:"is_adj_rib_in_post_policy"`
+	IsAdjRIBOutPost  bool   `json:"is_adj_rib_out_post_policy"`
+	IsAdjRIBOut      bool   `json:"is_adj_rib_out"`
+	IsLocRIB         bool   `json:"is_loc_rib"`
+	IsLocRIBFiltered bool   `json:"is_loc_rib_filtered"`
+	TableName        string `json:"table_name,omitempty"` // RFC 9069 Table Name for LocRIB
 }
 
 // LSLink defines a structure of LS link message
@@ -306,11 +308,12 @@ type LSLink struct {
 	UnidirAvailableBW     uint32                        `json:"unidir_available_bw,omitempty"`
 	UnidirBWUtilization   uint32                        `json:"unidir_bw_utilization,omitempty"`
 	// Values are assigned based on PerPeerHeader flags
-	IsAdjRIBInPost   bool `json:"is_adj_rib_in_post_policy"`
-	IsAdjRIBOutPost  bool `json:"is_adj_rib_out_post_policy"`
-	IsAdjRIBOut      bool `json:"is_adj_rib_out"`
-	IsLocRIB         bool `json:"is_loc_rib"`
-	IsLocRIBFiltered bool `json:"is_loc_rib_filtered"`
+	IsAdjRIBInPost   bool   `json:"is_adj_rib_in_post_policy"`
+	IsAdjRIBOutPost  bool   `json:"is_adj_rib_out_post_policy"`
+	IsAdjRIBOut      bool   `json:"is_adj_rib_out"`
+	IsLocRIB         bool   `json:"is_loc_rib"`
+	IsLocRIBFiltered bool   `json:"is_loc_rib_filtered"`
+	TableName        string `json:"table_name,omitempty"` // RFC 9069 Table Name for LocRIB
 }
 
 // MulticastPrefix defines a message format sent as a result of BMP Route Monitor message
@@ -338,9 +341,13 @@ type MulticastPrefix struct {
 	IsNexthopIPv4    bool                `json:"is_nexthop_ipv4"`
 	PathID           int32               `json:"path_id,omitempty"`
 	IsEOR            bool                `json:"is_eor,omitempty"`
-	IsAdjRIBInPost   bool                `json:"is_adj_rib_in_post_policy"`
-	IsAdjRIBOutPost  bool                `json:"is_adj_rib_out_post_policy"`
-	IsLocRIBFiltered bool                `json:"is_loc_rib_filtered"`
+	// Values are assigned based on PerPeerHeader flags
+	IsAdjRIBInPost   bool   `json:"is_adj_rib_in_post_policy"`
+	IsAdjRIBOutPost  bool   `json:"is_adj_rib_out_post_policy"`
+	IsAdjRIBOut      bool   `json:"is_adj_rib_out"`
+	IsLocRIB         bool   `json:"is_loc_rib"`
+	IsLocRIBFiltered bool   `json:"is_loc_rib_filtered"`
+	TableName        string `json:"table_name,omitempty"` // RFC 9069 Table Name for LocRIB
 }
 
 // MCASTVPNPrefix defines the structure of MCAST-VPN message (AFI 1/2, SAFI 5)
@@ -371,9 +378,13 @@ type MCASTVPNPrefix struct {
 	IsIPv4           bool                `json:"is_ipv4"`
 	IsNexthopIPv4    bool                `json:"is_nexthop_ipv4"`
 	IsEOR            bool                `json:"is_eor,omitempty"`
-	IsAdjRIBInPost   bool                `json:"is_adj_rib_in_post_policy"`
-	IsAdjRIBOutPost  bool                `json:"is_adj_rib_out_post_policy"`
-	IsLocRIBFiltered bool                `json:"is_loc_rib_filtered"`
+	// Values are assigned based on PerPeerHeader flags
+	IsAdjRIBInPost   bool   `json:"is_adj_rib_in_post_policy"`
+	IsAdjRIBOutPost  bool   `json:"is_adj_rib_out_post_policy"`
+	IsAdjRIBOut      bool   `json:"is_adj_rib_out"`
+	IsLocRIB         bool   `json:"is_loc_rib"`
+	IsLocRIBFiltered bool   `json:"is_loc_rib_filtered"`
+	TableName        string `json:"table_name,omitempty"` // RFC 9069 Table Name for LocRIB
 }
 
 // MVPNPrefix defines structure for Multicast VPN (SAFI 129)
@@ -401,9 +412,13 @@ type RTCPrefix struct {
 	RouteTarget      string              `json:"route_target,omitempty"`
 	IsIPv4           bool                `json:"is_ipv4"`
 	IsEOR            bool                `json:"is_eor,omitempty"`
-	IsAdjRIBInPost   bool                `json:"is_adj_rib_in_post_policy"`
-	IsAdjRIBOutPost  bool                `json:"is_adj_rib_out_post_policy"`
-	IsLocRIBFiltered bool                `json:"is_loc_rib_filtered"`
+	// Values are assigned based on PerPeerHeader flags
+	IsAdjRIBInPost   bool   `json:"is_adj_rib_in_post_policy"`
+	IsAdjRIBOutPost  bool   `json:"is_adj_rib_out_post_policy"`
+	IsAdjRIBOut      bool   `json:"is_adj_rib_out"`
+	IsLocRIB         bool   `json:"is_loc_rib"`
+	IsLocRIBFiltered bool   `json:"is_loc_rib_filtered"`
+	TableName        string `json:"table_name,omitempty"` // RFC 9069 Table Name for LocRIB
 }
 
 // L3VPNPrefix defines the structure of Layer 3 VPN message
@@ -436,11 +451,12 @@ type L3VPNPrefix struct {
 	VPNRDType        uint16              `json:"vpn_rd_type"`
 	PrefixSID        *prefixsid.PSid     `json:"prefix_sid,omitempty"`
 	// Values are assigned based on PerPeerHeader flags
-	IsAdjRIBInPost   bool `json:"is_adj_rib_in_post_policy"`
-	IsAdjRIBOutPost  bool `json:"is_adj_rib_out_post_policy"`
-	IsAdjRIBOut      bool `json:"is_adj_rib_out"`
-	IsLocRIB         bool `json:"is_loc_rib"`
-	IsLocRIBFiltered bool `json:"is_loc_rib_filtered"`
+	IsAdjRIBInPost   bool   `json:"is_adj_rib_in_post_policy"`
+	IsAdjRIBOutPost  bool   `json:"is_adj_rib_out_post_policy"`
+	IsAdjRIBOut      bool   `json:"is_adj_rib_out"`
+	IsLocRIB         bool   `json:"is_loc_rib"`
+	IsLocRIBFiltered bool   `json:"is_loc_rib_filtered"`
+	TableName        string `json:"table_name,omitempty"` // RFC 9069 Table Name for LocRIB
 }
 
 // LSPrefix defines a structure of LS Prefix message
@@ -480,11 +496,12 @@ type LSPrefix struct {
 	FlexAlgoPrefixMetric []*bgpls.FlexAlgoPrefixMetric `json:"flex_algo_prefix_metric,omitempty"`
 	SRv6Locator          *srv6.LocatorTLV              `json:"srv6_locator,omitempty"`
 	// Values are assigned based on PerPeerHeader flags
-	IsAdjRIBInPost   bool `json:"is_adj_rib_in_post_policy"`
-	IsAdjRIBOutPost  bool `json:"is_adj_rib_out_post_policy"`
-	IsAdjRIBOut      bool `json:"is_adj_rib_out"`
-	IsLocRIB         bool `json:"is_loc_rib"`
-	IsLocRIBFiltered bool `json:"is_loc_rib_filtered"`
+	IsAdjRIBInPost   bool   `json:"is_adj_rib_in_post_policy"`
+	IsAdjRIBOutPost  bool   `json:"is_adj_rib_out_post_policy"`
+	IsAdjRIBOut      bool   `json:"is_adj_rib_out"`
+	IsLocRIB         bool   `json:"is_loc_rib"`
+	IsLocRIBFiltered bool   `json:"is_loc_rib_filtered"`
+	TableName        string `json:"table_name,omitempty"` // RFC 9069 Table Name for LocRIB
 }
 
 // LSSRv6SID defines a structure of LS SRv6 SID message
@@ -525,11 +542,12 @@ type LSSRv6SID struct {
 	SRv6BGPPeerNodeSID   *srv6.BGPPeerNodeSID          `json:"srv6_bgp_peer_node_sid,omitempty"`
 	SRv6SIDStructure     *srv6.SIDStructure            `json:"srv6_sid_structure,omitempty"`
 	// Values are assigned based on PerPeerHeader flags
-	IsAdjRIBInPost   bool `json:"is_adj_rib_in_post_policy"`
-	IsAdjRIBOutPost  bool `json:"is_adj_rib_out_post_policy"`
-	IsAdjRIBOut      bool `json:"is_adj_rib_out"`
-	IsLocRIB         bool `json:"is_loc_rib"`
-	IsLocRIBFiltered bool `json:"is_loc_rib_filtered"`
+	IsAdjRIBInPost   bool   `json:"is_adj_rib_in_post_policy"`
+	IsAdjRIBOutPost  bool   `json:"is_adj_rib_out_post_policy"`
+	IsAdjRIBOut      bool   `json:"is_adj_rib_out"`
+	IsLocRIB         bool   `json:"is_loc_rib"`
+	IsLocRIBFiltered bool   `json:"is_loc_rib_filtered"`
+	TableName        string `json:"table_name,omitempty"` // RFC 9069 Table Name for LocRIB
 }
 
 // EVPNPrefix defines the structure of EVPN message
@@ -569,11 +587,12 @@ type EVPNPrefix struct {
 	RouteType      uint8               `json:"route_type,omitempty"`
 	PMSITunnel     *pmsi.PMSITunnel    `json:"pmsi_tunnel,omitempty"` // RFC 6514 PMSI Tunnel for Type 3 routes
 	// Values are assigned based on PerPeerHeader flags
-	IsAdjRIBInPost   bool `json:"is_adj_rib_in_post_policy"`
-	IsAdjRIBOutPost  bool `json:"is_adj_rib_out_post_policy"`
-	IsAdjRIBOut      bool `json:"is_adj_rib_out"`
-	IsLocRIB         bool `json:"is_loc_rib"`
-	IsLocRIBFiltered bool `json:"is_loc_rib_filtered"`
+	IsAdjRIBInPost   bool   `json:"is_adj_rib_in_post_policy"`
+	IsAdjRIBOutPost  bool   `json:"is_adj_rib_out_post_policy"`
+	IsAdjRIBOut      bool   `json:"is_adj_rib_out"`
+	IsLocRIB         bool   `json:"is_loc_rib"`
+	IsLocRIBFiltered bool   `json:"is_loc_rib_filtered"`
+	TableName        string `json:"table_name,omitempty"` // RFC 9069 Table Name for LocRIB
 }
 
 // VPLSPrefix defines the structure of VPLS message (AFI 25, SAFI 65)
@@ -623,9 +642,12 @@ type VPLSPrefix struct {
 	RouteTargets []string `json:"route_targets,omitempty"` // Array of RT strings (e.g., "RT:65000:100")
 
 	// Values assigned based on PerPeerHeader flags
-	IsAdjRIBInPost   bool `json:"is_adj_rib_in_post_policy"`
-	IsAdjRIBOutPost  bool `json:"is_adj_rib_out_post_policy"`
-	IsLocRIBFiltered bool `json:"is_loc_rib_filtered"`
+	IsAdjRIBInPost   bool   `json:"is_adj_rib_in_post_policy"`
+	IsAdjRIBOutPost  bool   `json:"is_adj_rib_out_post_policy"`
+	IsAdjRIBOut      bool   `json:"is_adj_rib_out"`
+	IsLocRIB         bool   `json:"is_loc_rib"`
+	IsLocRIBFiltered bool   `json:"is_loc_rib_filtered"`
+	TableName        string `json:"table_name,omitempty"` // RFC 9069 Table Name for LocRIB
 }
 
 // SRPolicy defines the structure of SR Policy message
@@ -662,11 +684,12 @@ type SRPolicy struct {
 	ENLP           *srpolicy.ENLP          `json:"enlp_subtlv,omitempty"`
 	SegmentList    []*srpolicy.SegmentList `json:"segment_list_subtlv,omitempty"`
 	// Values are assigned based on PerPeerHeader flags
-	IsAdjRIBInPost   bool `json:"is_adj_rib_in_post_policy"`
-	IsAdjRIBOutPost  bool `json:"is_adj_rib_out_post_policy"`
-	IsAdjRIBOut      bool `json:"is_adj_rib_out"`
-	IsLocRIB         bool `json:"is_loc_rib"`
-	IsLocRIBFiltered bool `json:"is_loc_rib_filtered"`
+	IsAdjRIBInPost   bool   `json:"is_adj_rib_in_post_policy"`
+	IsAdjRIBOutPost  bool   `json:"is_adj_rib_out_post_policy"`
+	IsAdjRIBOut      bool   `json:"is_adj_rib_out"`
+	IsLocRIB         bool   `json:"is_loc_rib"`
+	IsLocRIBFiltered bool   `json:"is_loc_rib_filtered"`
+	TableName        string `json:"table_name,omitempty"` // RFC 9069 Table Name for LocRIB
 }
 
 // Flowspec defines the structure of SR Policy message
@@ -690,11 +713,12 @@ type Flowspec struct {
 	SpecHash       string              `json:"spec_hash,omitempty"`
 	Spec           []flowspec.Spec     `json:"spec,omitempty"`
 	// Values are assigned based on PerPeerHeader flags
-	IsAdjRIBInPost   bool `json:"is_adj_rib_in_post_policy"`
-	IsAdjRIBOutPost  bool `json:"is_adj_rib_out_post_policy"`
-	IsAdjRIBOut      bool `json:"is_adj_rib_out"`
-	IsLocRIB         bool `json:"is_loc_rib"`
-	IsLocRIBFiltered bool `json:"is_loc_rib_filtered"`
+	IsAdjRIBInPost   bool   `json:"is_adj_rib_in_post_policy"`
+	IsAdjRIBOutPost  bool   `json:"is_adj_rib_out_post_policy"`
+	IsAdjRIBOut      bool   `json:"is_adj_rib_out"`
+	IsLocRIB         bool   `json:"is_loc_rib"`
+	IsLocRIBFiltered bool   `json:"is_loc_rib_filtered"`
+	TableName        string `json:"table_name,omitempty"` // RFC 9069 Table Name for LocRIB
 }
 
 // AFISAFIStat represents statistics per Address Family (RFC 7854, RFC 8671)

--- a/pkg/message/vpls.go
+++ b/pkg/message/vpls.go
@@ -150,6 +150,27 @@ func (p *producer) vpls(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *
 			}
 		}
 
+		// Values assigned based on PerPeerHeader flags
+		if f, err := ph.IsAdjRIBInPost(); err == nil {
+			prfx.IsAdjRIBInPost = f
+		}
+		if f, err := ph.IsAdjRIBOutPost(); err == nil {
+			prfx.IsAdjRIBOutPost = f
+		}
+		if f, err := ph.IsAdjRIBOut(); err == nil {
+			prfx.IsAdjRIBOut = f
+		}
+		if f, err := ph.IsLocRIB(); err == nil {
+			prfx.IsLocRIB = f
+		}
+		if f, err := ph.IsLocRIBFiltered(); err == nil {
+			prfx.IsLocRIBFiltered = f
+		}
+		// RFC 9069: Set TableName for LocRIB peers
+		if prfx.IsLocRIB {
+			prfx.TableName = p.GetTableName(ph.GetPeerBGPIDString(), ph.GetPeerDistinguisherString())
+		}
+
 		prfxs = append(prfxs, prfx)
 	}
 


### PR DESCRIPTION
Add TableName field to all message structs and update parsers to populate it for LocRIB peers (PeerType3) using the table name from Informational TLV Type 3.

Changes:
- Add TableName field to 13 message structs in types.go
- Add missing IsAdjRIBOut/IsLocRIB fields to 4 structs
- Update 12 NLRI parsers to set TableName for LocRIB peers
- Fix VPLS parser which was missing all RIB flag handling

This completes Phase 2 of the RFC 9069 LOC-RIB implementation.