### PR TITLE
Implements SR Policy Segment Type D per RFC 9831 Section 2.4.

### DIFF
--- a/pkg/srpolicy/srpolicy-segment.go
+++ b/pkg/srpolicy/srpolicy-segment.go
@@ -620,7 +620,7 @@ func UnmarshalTypeCSegment(b []byte) (Segment, error) {
 	return s, nil
 }
 
-// TypeDSegment defines methods to access Type D specific elements (IPv6 + SR Algorithm)
+// TypeDSegment defines methods to access Type D specific elements (IPv6 + SR Algorithm + optional SID)
 type TypeDSegment interface {
 	GetIPv6Address() []byte
 	GetSRAlgorithm() byte
@@ -645,8 +645,9 @@ func (td *typeDSegment) GetType() SegmentType {
 	return TypeD
 }
 
+// GetIPv6Address returns a 16-byte copy of the IPv6 address safe for modification
 func (td *typeDSegment) GetIPv6Address() []byte {
-	return td.ipv6Address
+	return append([]byte(nil), td.ipv6Address...)
 }
 
 func (td *typeDSegment) GetSRAlgorithm() byte {
@@ -715,7 +716,7 @@ func (td *typeDSegment) UnmarshalJSON(b []byte) error {
 	return td.unmarshalJSONObj(objmap)
 }
 
-// UnmarshalTypeDSegment instantiates an instance of Type D Segment sub tlv (IPv6 + SR Algorithm)
+// UnmarshalTypeDSegment instantiates an instance of Type D Segment sub tlv (IPv6 + SR Algorithm + optional SID)
 func UnmarshalTypeDSegment(b []byte) (Segment, error) {
 	if glog.V(5) {
 		glog.Infof("SR Policy Type D Segment STLV Raw: %s", tools.MessageHex(b))

--- a/pkg/srpolicy/srpolicy-segments_test.go
+++ b/pkg/srpolicy/srpolicy-segments_test.go
@@ -1061,6 +1061,20 @@ func TestTypeDSegment_JSON(t *testing.T) {
 				t.Errorf("Unmarshal() SR Algorithm = %d, want %d", result.srAlgorithm, tt.seg.srAlgorithm)
 			}
 
+			// Verify flags
+			if result.flags.Vflag != tt.seg.flags.Vflag {
+				t.Errorf("Unmarshal() Vflag = %v, want %v", result.flags.Vflag, tt.seg.flags.Vflag)
+			}
+			if result.flags.Aflag != tt.seg.flags.Aflag {
+				t.Errorf("Unmarshal() Aflag = %v, want %v", result.flags.Aflag, tt.seg.flags.Aflag)
+			}
+			if result.flags.Sflag != tt.seg.flags.Sflag {
+				t.Errorf("Unmarshal() Sflag = %v, want %v", result.flags.Sflag, tt.seg.flags.Sflag)
+			}
+			if result.flags.Bflag != tt.seg.flags.Bflag {
+				t.Errorf("Unmarshal() Bflag = %v, want %v", result.flags.Bflag, tt.seg.flags.Bflag)
+			}
+
 			// Verify SID
 			if tt.seg.sid == nil {
 				if result.sid != nil {


### PR DESCRIPTION
**Type D: IPv6 Node Address with SR Algorithm**
- 18 bytes without SID (flags + algorithm + IPv6 address)
- 22 bytes with optional SID
- Wire format and JSON parsing
- Input validation on all paths
