### PR TITLE
Add transport_ip and transport_hash (source ip) field to messages

### DIFF
--- a/BMP.md
+++ b/BMP.md
@@ -45,8 +45,8 @@ https://www.snas.io/docs/
 13: (local_asn):
 14: (local_ip):
 15: (local_hash):
-16: (transport_ip): 10.1.34.1
-17: (transport_hash): b684810f26f15fa57c62abae34d3ef07
+16: (transport_ip): 192.0.2.10
+17: (transport_hash): 9f86d081884c7d659a2feaa0c55ad015
 18: (local_port):
 19: (local_bgp_id):
 20: (info_data):
@@ -82,8 +82,8 @@ https://www.snas.io/docs/
 13: (local_asn): 100000
 14: (local_ip): 10.0.0.10
 15: (local_hash): 9e1a9a3663f25a297ed16a834b473eb0
-16: (transport_ip): 10.1.34.1
-17: (transport_hash): b684810f26f15fa57c62abae34d3ef07
+16: (transport_ip): 192.0.2.10
+17: (transport_hash): 9f86d081884c7d659a2feaa0c55ad015
 18: (local_port): 179
 19: (local_bgp_id): 10.0.0.10
 20: (info_data):
@@ -153,8 +153,8 @@ https://www.snas.io/docs/
 3: (hash): 5214a8eb996f030b3d96784c1890ab3d
 4: (router_hash): 367321d1bb7194e1f0f57f8ce99e7316
 5: (router_ip): 10.1.62.1
-6: (transport_ip):
-7: (transport_hash):
+6: (transport_ip): 192.0.2.10
+7: (transport_hash): 9f86d081884c7d659a2feaa0c55ad015
 8: (base_attr_hash): 3479c4959c47a2cf634a72ce2c416fb9
 9: (peer_hash): a4935a0f520cd5f72ed483d2b37f58ae
 10: (peer_ip): 2.2.71.1
@@ -193,8 +193,8 @@ https://www.snas.io/docs/
 4: (base_attr_hash): f7e177580a2209c7af48c6a90f707cc9
 5: (router_hash): 367321d1bb7194e1f0f57f8ce99e7316
 6: (router_ip): 10.1.62.1
-7: (transport_ip): 10.1.62.1
-8: (transport_hash): 367321d1bb7194e1f0f57f8ce99e7316
+7: (transport_ip): 192.0.2.10
+8: (transport_hash): 9f86d081884c7d659a2feaa0c55ad015
 9: (peer_hash): 1787a325b86857cdcb82e46d2e919780
 10: (peer_ip): 10.0.0.1
 11: (peer_asn): 100000
@@ -242,8 +242,8 @@ Future:
 4: (base_attr_hash): 17fcffffffffffff0000000000000000
 5: (router_hash): 367321d1bb7194e1f0f57f8ce99e7316
 6: (router_ip): 10.1.62.1
-7: (transport_ip):
-8: (transport_hash):
+7: (transport_ip): 192.0.2.10
+8: (transport_hash): 9f86d081884c7d659a2feaa0c55ad015
 9: (peer_hash): 6c6ba2119bddb79001663deb1801dfcc
 10: (peer_ip): 10.0.0.2
 11: (peer_asn): 100000
@@ -276,8 +276,8 @@ Future:
 4: (base_attr_hash): f7e177580a2209c7af48c6a90f707cc9
 5: (router_hash): 367321d1bb7194e1f0f57f8ce99e7316
 6: (router_ip): 10.1.62.1
-7: (transport_ip):
-8: (transport_hash):
+7: (transport_ip): 192.0.2.10
+8: (transport_hash): 9f86d081884c7d659a2feaa0c55ad015
 9: (peer_hash): 1787a325b86857cdcb82e46d2e919780
 10: (peer_ip): 10.0.0.1
 11: (peer_asn): 100000
@@ -358,8 +358,8 @@ Bonus item (OpenBMP never carried remote node router ID field, which would be ve
 4: (base_attr_hash): 17fcffffffffffff0000000000000000
 5: (router_hash): 367321d1bb7194e1f0f57f8ce99e7316
 6: (router_ip): 10.1.62.1
-7: (transport_ip):
-8: (transport_hash):
+7: (transport_ip): 192.0.2.10
+8: (transport_hash): 9f86d081884c7d659a2feaa0c55ad015
 9: (peer_hash): 6c6ba2119bddb79001663deb1801dfcc
 10: (peer_ip): 10.0.0.2
 11: (peer_asn): 100000
@@ -415,8 +415,8 @@ Bonus item (OpenBMP never carried remote node router ID field, which would be ve
 4: (base_attr_hash): f7e177580a2209c7af48c6a90f707cc9
 5: (router_hash): 367321d1bb7194e1f0f57f8ce99e7316
 6: (router_ip): 10.1.62.1
-7: (transport_ip):
-8: (transport_hash):
+7: (transport_ip): 192.0.2.10
+8: (transport_hash): 9f86d081884c7d659a2feaa0c55ad015
 9: (peer_hash): 1787a325b86857cdcb82e46d2e919780
 10: (peer_ip): 10.0.0.1
 11: (peer_asn): 100000
@@ -453,8 +453,8 @@ Bonus item (OpenBMP never carried remote node router ID field, which would be ve
 4: (base_attr_hash): 17fcffffffffffff0000000000000000
 5: (router_hash): 367321d1bb7194e1f0f57f8ce99e7316
 6: (router_ip): 10.1.62.1
-7: (transport_ip):
-8: (transport_hash):
+7: (transport_ip): 192.0.2.10
+8: (transport_hash): 9f86d081884c7d659a2feaa0c55ad015
 9: (peer_hash): 30b1ce11e0c436dc3e37dc7342b12be8
 10: (peer_ip): 10.0.0.0
 11: (peer_asn): 100000
@@ -539,8 +539,8 @@ BGP-LS TLVs:
 3: (hash): 332047c6ca64451ed6f5ddb92710a29a
 4: (router_hash): b684810f26f15fa57c62abae34d3ef07
 5: (router_ip): 10.1.34.1
-6: (transport_ip):
-7: (transport_hash):
+6: (transport_ip): 192.0.2.10
+7: (transport_hash): 9f86d081884c7d659a2feaa0c55ad015
 8: (base_attr_hash): 22155edb81a03c848f36193dfd3e48f3
 9: (peer_hash): d67b274c33ea1ff0ffe9dd781938b0de
 10: (peer_ip): 10.0.0.7
@@ -577,8 +577,8 @@ BGP-LS TLVs:
 3: (hash): 332047c6ca64451ed6f5ddb92710a29a
 4: (router_hash): b684810f26f15fa57c62abae34d3ef07
 5: (router_ip): 10.1.34.1
-6: (transport_ip):
-7: (transport_hash):
+6: (transport_ip): 192.0.2.10
+7: (transport_hash): 9f86d081884c7d659a2feaa0c55ad015
 8: (base_attr_hash):
 9: (peer_hash): d67b274c33ea1ff0ffe9dd781938b0de
 10: (peer_ip): 10.0.0.7
@@ -617,8 +617,8 @@ BGP-LS TLVs:
 3: (hash):
 4: (router_hash):
 5: (router_ip):
-6: (transport_ip):
-7: (transport_hash):
+6: (transport_ip): 192.0.2.10
+7: (transport_hash): 9f86d081884c7d659a2feaa0c55ad015
 8: (peer_hash):
 9: (peer_type):
 10: (peer_ip):
@@ -664,8 +664,8 @@ BGP-LS TLVs:
 3: (hash): b44a84e415927f20ff3e6edf7103875c
 4: (router_hash): b684810f26f15fa57c62abae34d3ef07
 5: (router_ip): 10.1.34.1
-6: (transport_ip):
-7: (transport_hash):
+6: (transport_ip): 192.0.2.10
+7: (transport_hash): 9f86d081884c7d659a2feaa0c55ad015
 8: (base_attr_hash): e0895cf0bc3391438d43cdc7e43aae36
 9: (peer_hash): 0146fce99cbd730d787487de31452f88
 10: (peer_ip): 2001:1:1:f003::1                        // this is ok
@@ -761,8 +761,8 @@ Wed Mar 25 22:52:03.008 UTC
 3: (hash): 2f358ba42cb0a8a00c210b0accbf1af4
 4: (router_hash): b684810f26f15fa57c62abae34d3ef07
 5: (router_ip): 10.1.34.1
-6: (transport_ip):
-7: (transport_hash):
+6: (transport_ip): 192.0.2.10
+7: (transport_hash): 9f86d081884c7d659a2feaa0c55ad015
 8: (base_attr_hash):
 9: (peer_hash): 0146fce99cbd730d787487de31452f88
 10: (peer_ip): 2001:1:1:f003::1

--- a/BMP.md
+++ b/BMP.md
@@ -33,10 +33,10 @@ https://www.snas.io/docs/
 1: (action): down
 2: (sequence): 84
 3: (hash): d67b274c33ea1ff0ffe9dd781938b0de
-4: (router_hash): fb5d34c594dff80c59019b6d132185f7
+4: (router_hash): 9e1a9a3663f25a297ed16a834b473eb0
 5: (name):
 6: (remote_bgp_id): 10.0.0.7
-7: (router_ip): 10.1.34.1
+7: (router_ip): 10.0.0.10
 8: (timestamp): 2020-03-18 14:36:54.114438
 9: (remote_asn): 100000
 10: (remote_ip): 10.0.0.7
@@ -44,33 +44,36 @@ https://www.snas.io/docs/
 12: (remote_port):
 13: (local_asn):
 14: (local_ip):
-15: (local_port):
-16: (local_bgp_id):
-17: (info_data):
-18: (adv_cap):
-19: (recv_cap):
-20: (remote_holddown):
-21: (adv_holddown):
-22: (bmp_reason): 1
-23: (bgp_error_code): 6
-24: (bgp_error_sub_code): 4
-25: (error_text): Administratively reset
-26: (is_l): 0
-27: (is_prepolicy): 1
-28: (is_ipv4): 1
-29: (is_locrib): 0
-30: (is_locrib_filtered): 0
-31: (table_name):
+15: (local_hash):
+16: (transport_ip): 10.1.34.1
+17: (transport_hash): b684810f26f15fa57c62abae34d3ef07
+18: (local_port):
+19: (local_bgp_id):
+20: (info_data):
+21: (adv_cap):
+22: (recv_cap):
+23: (remote_holddown):
+24: (adv_holddown):
+25: (bmp_reason): 1
+26: (bgp_error_code): 6
+27: (bgp_error_sub_code): 4
+28: (error_text): Administratively reset
+29: (is_l): 0
+30: (is_prepolicy): 1
+31: (is_ipv4): 1
+32: (is_locrib): 0
+33: (is_locrib_filtered): 0
+34: (table_name):
 
 // Peer Up
 
 1: (action): up
 2: (sequence): 93
 3: (hash): d67b274c33ea1ff0ffe9dd781938b0de
-4: (router_hash): fb5d34c594dff80c59019b6d132185f7
+4: (router_hash): 9e1a9a3663f25a297ed16a834b473eb0
 5: (name):
 6: (remote_bgp_id): 10.0.0.7
-7: (router_ip): 10.1.34.1
+7: (router_ip): 10.0.0.10
 8: (timestamp): 2020-03-18 14:37:13.836872
 9: (remote_asn): 100000
 10: (remote_ip): 10.0.0.7
@@ -78,23 +81,26 @@ https://www.snas.io/docs/
 12: (remote_port): 45085
 13: (local_asn): 100000
 14: (local_ip): 10.0.0.10
-15: (local_port): 179
-16: (local_bgp_id): 10.0.0.10
-17: (info_data):
-18: (adv_cap): MPBGP (1) : afi=1 safi=1 : Unicast IPv4, MPBGP (1) : afi=1 safi=4 : Labeled Unicast IPv4, MPBGP (1) : afi=1 safi=128 : MPLS-Labeled VPN IPv4, MPBGP (1) : afi=2 safi=1 : Unicast IPv6, MPBGP (1) : afi=2 safi=128 : MPLS-Labeled VPN IPv6, MPBGP (1) : afi=16388 safi=71 : BGP-LS BGP-LS, MPBGP (1) : afi=1 safi=73 :  IPv4, Route Refresh Old (128), Route Refresh (2), 4 Octet ASN (65), ADD Path (69) : afi=1 safi=1 send/receive=3 : Unicast IPv4 Send/Receive, ADD Path (69) : afi=1 safi=4 send/receive=3 : Labeled Unicast IPv4 Send/Receive, ADD Path (69) : afi=2 safi=1 send/receive=3 : Unicast IPv6 Send/Receive, 5
-19: (recv_cap): MPBGP (1) : afi=1 safi=1 : Unicast IPv4, MPBGP (1) : afi=1 safi=4 : Labeled Unicast IPv4, MPBGP (1) : afi=1 safi=128 : MPLS-Labeled VPN IPv4, MPBGP (1) : afi=2 safi=1 : Unicast IPv6, MPBGP (1) : afi=2 safi=128 : MPLS-Labeled VPN IPv6, MPBGP (1) : afi=16388 safi=71 : BGP-LS BGP-LS, MPBGP (1) : afi=1 safi=73 :  IPv4, Route Refresh Old (128), Route Refresh (2), 4 Octet ASN (65), ADD Path (69) : afi=1 safi=1 send/receive=3 : Unicast IPv4 Send/Receive, ADD Path (69) : afi=1 safi=4 send/receive=3 : Labeled Unicast IPv4 Send/Receive, ADD Path (69) : afi=2 safi=1 send/receive=3 : Unicast IPv6 Send/Receive, 5
-20: (remote_holddown): 180
-21: (adv_holddown): 180
-22: (bmp_reason):
-23: (bgp_error_code):
-24: (bgp_error_sub_code):
-25: (error_text):
-26: (is_l): 0
-27: (is_prepolicy): 1
-28: (is_ipv4): 1
-29: (is_locrib): 0
-30: (is_locrib_filtered): 0
-31: (table_name):
+15: (local_hash): 9e1a9a3663f25a297ed16a834b473eb0
+16: (transport_ip): 10.1.34.1
+17: (transport_hash): b684810f26f15fa57c62abae34d3ef07
+18: (local_port): 179
+19: (local_bgp_id): 10.0.0.10
+20: (info_data):
+21: (adv_cap): MPBGP (1) : afi=1 safi=1 : Unicast IPv4, MPBGP (1) : afi=1 safi=4 : Labeled Unicast IPv4, MPBGP (1) : afi=1 safi=128 : MPLS-Labeled VPN IPv4, MPBGP (1) : afi=2 safi=1 : Unicast IPv6, MPBGP (1) : afi=2 safi=128 : MPLS-Labeled VPN IPv6, MPBGP (1) : afi=16388 safi=71 : BGP-LS BGP-LS, MPBGP (1) : afi=1 safi=73 :  IPv4, Route Refresh Old (128), Route Refresh (2), 4 Octet ASN (65), ADD Path (69) : afi=1 safi=1 send/receive=3 : Unicast IPv4 Send/Receive, ADD Path (69) : afi=1 safi=4 send/receive=3 : Labeled Unicast IPv4 Send/Receive, ADD Path (69) : afi=2 safi=1 send/receive=3 : Unicast IPv6 Send/Receive, 5
+22: (recv_cap): MPBGP (1) : afi=1 safi=1 : Unicast IPv4, MPBGP (1) : afi=1 safi=4 : Labeled Unicast IPv4, MPBGP (1) : afi=1 safi=128 : MPLS-Labeled VPN IPv4, MPBGP (1) : afi=2 safi=1 : Unicast IPv6, MPBGP (1) : afi=2 safi=128 : MPLS-Labeled VPN IPv6, MPBGP (1) : afi=16388 safi=71 : BGP-LS BGP-LS, MPBGP (1) : afi=1 safi=73 :  IPv4, Route Refresh Old (128), Route Refresh (2), 4 Octet ASN (65), ADD Path (69) : afi=1 safi=1 send/receive=3 : Unicast IPv4 Send/Receive, ADD Path (69) : afi=1 safi=4 send/receive=3 : Labeled Unicast IPv4 Send/Receive, ADD Path (69) : afi=2 safi=1 send/receive=3 : Unicast IPv6 Send/Receive, 5
+23: (remote_holddown): 180
+24: (adv_holddown): 180
+25: (bmp_reason):
+26: (bgp_error_code):
+27: (bgp_error_sub_code):
+28: (error_text):
+29: (is_l): 0
+30: (is_prepolicy): 1
+31: (is_ipv4): 1
+32: (is_locrib): 0
+33: (is_locrib_filtered): 0
+34: (table_name):
 
 // Peer initialization - any peer message that comes in with action "first" is not needed and should be dropped
 
@@ -109,68 +115,72 @@ https://www.snas.io/docs/
 1: (action): del
 2: (sequence): 44
 3: (hash): 5214a8eb996f030b3d96784c1890ab3d
-4: (router_hash): 963b507b39731b0675d3422e6f6be44c
+4: (router_hash): 367321d1bb7194e1f0f57f8ce99e7316
 5: (router_ip): 10.1.62.1
-6: (base_attr_hash):
-7: (peer_hash): a4935a0f520cd5f72ed483d2b37f58ae
-8: (peer_ip): 2.2.71.1
-9: (peer_asn): 7100
-10: (timestamp): 2020-03-25 22:00:53.891932
-11: (prefix): 71.71.8.0
-12: (prefix_len): 22
-13: (is_ipv4): 1
-14: (origin):
-15: (as_path):
-16: (as_path_count):
-17: (origin_as):
-18: (nexthop):
-19: (med):
-20: (local_pref):
-21: (aggregator):
-22: (community_list):
-23: (ext_community_list):
-24: (cluster_list):
-25: (isatomicagg):
-26: (is_nexthop_ipv4):
-27: (originator_id):
-28: (path_id): 0
-29: (labels):
-30: (is_prepolicy): 1
-31: (is_adj_rib_in): 1
+6: (transport_ip): 192.0.2.10
+7: (transport_hash): 9f86d081884c7d659a2feaa0c55ad015
+8: (base_attr_hash): 6d7fce9fee471194aa8b5b6e47267f03
+9: (peer_hash): a4935a0f520cd5f72ed483d2b37f58ae
+10: (peer_ip): 2.2.71.1
+11: (peer_asn): 7100
+12: (timestamp): 2020-03-25 22:00:53.891932
+13: (prefix): 71.71.8.0
+14: (prefix_len): 22
+15: (is_ipv4): 1
+16: (origin):
+17: (as_path):
+18: (as_path_count):
+19: (origin_as):
+20: (nexthop):
+21: (med):
+22: (local_pref):
+23: (aggregator):
+24: (community_list):
+25: (ext_community_list):
+26: (cluster_list):
+27: (isatomicagg):
+28: (is_nexthop_ipv4):
+29: (originator_id):
+30: (path_id): 0
+31: (labels):
+32: (is_prepolicy): 1
+33: (is_adj_rib_in): 1
 
 // add unicast_prefix
 
 1: (action): add
 2: (sequence): 46
 3: (hash): 5214a8eb996f030b3d96784c1890ab3d
-4: (router_hash): 963b507b39731b0675d3422e6f6be44c
+4: (router_hash): 367321d1bb7194e1f0f57f8ce99e7316
 5: (router_ip): 10.1.62.1
-6: (base_attr_hash): 3479c4959c47a2cf634a72ce2c416fb9
-7: (peer_hash): a4935a0f520cd5f72ed483d2b37f58ae
-8: (peer_ip): 2.2.71.1
-9: (peer_asn): 7100
-10: (timestamp): 2020-03-25 22:01:33.167989
-11: (prefix): 71.71.8.0
-12: (prefix_len): 22
-13: (is_ipv4): 1
-14: (origin): igp
-15: (as_path): 7100
-16: (as_path_count): 1
-17: (origin_as): 7100
-18: (nexthop): 2.2.71.1
-19: (med): 0
-20: (local_pref): 0
-21: (aggregator):
-22: (community_list):
-23: (ext_community_list):
-24: (cluster_list):
-25: (isatomicagg): 0
-26: (is_nexthop_ipv4): 1
-27: (originator_id):
-28: (path_id): 0
-29: (labels):
-30: (is_prepolicy): 1
-31: (is_adj_rib_in): 1
+6: (transport_ip):
+7: (transport_hash):
+8: (base_attr_hash): 3479c4959c47a2cf634a72ce2c416fb9
+9: (peer_hash): a4935a0f520cd5f72ed483d2b37f58ae
+10: (peer_ip): 2.2.71.1
+11: (peer_asn): 7100
+12: (timestamp): 2020-03-25 22:01:33.167989
+13: (prefix): 71.71.8.0
+14: (prefix_len): 22
+15: (is_ipv4): 1
+16: (origin): igp
+17: (as_path): 7100
+18: (as_path_count): 1
+19: (origin_as): 7100
+20: (nexthop): 2.2.71.1
+21: (med): 0
+22: (local_pref): 0
+23: (aggregator):
+24: (community_list):
+25: (ext_community_list):
+26: (cluster_list):
+27: (isatomicagg): 0
+28: (is_nexthop_ipv4): 1
+29: (originator_id):
+30: (path_id): 0
+31: (labels):
+32: (is_prepolicy): 1
+33: (is_adj_rib_in): 1
 ```
 
 #### BMP ls_node message:
@@ -181,28 +191,30 @@ https://www.snas.io/docs/
 2: (sequence): 21
 3: (hash): 6ed5aeb7f5ca0bbea84bdbadb61996e9
 4: (base_attr_hash): f7e177580a2209c7af48c6a90f707cc9
-5: (router_hash): 963b507b39731b0675d3422e6f6be44c
+5: (router_hash): 367321d1bb7194e1f0f57f8ce99e7316
 6: (router_ip): 10.1.62.1
-7: (peer_hash): 1787a325b86857cdcb82e46d2e919780
-8: (peer_ip): 10.0.0.1
-9: (peer_asn): 100000
-10: (timestamp): 2020-03-25 22:20:18.804927
-11: (igp_router_id): 0000.0000.0000.0000
-12: (router_id): 10.0.0.0
-13: (routing_id): 0
-14: (ls_id): 0
-15: (mt_id): 0, 2
-16: (area_id):
-17: (protocol): IS-IS_L2
-18: (flags):
-19: (as_path):
-20: (local_pref): 100
-21: (med): 0
-22: (nexthop): 10.0.0.1
-23: (name): R00
-24: (is_prepolicy): 1
-25: (is_adj_rib_in): 1
-26: (ls_sr_capabilities): I 64000 100000
+7: (transport_ip): 10.1.62.1
+8: (transport_hash): 367321d1bb7194e1f0f57f8ce99e7316
+9: (peer_hash): 1787a325b86857cdcb82e46d2e919780
+10: (peer_ip): 10.0.0.1
+11: (peer_asn): 100000
+12: (timestamp): 2020-03-25 22:20:18.804927
+13: (igp_router_id): 0000.0000.0000.0000
+14: (router_id): 10.0.0.0
+15: (routing_id): 0
+16: (ls_id): 0
+17: (mt_id): 0, 2
+18: (area_id):
+19: (protocol): IS-IS_L2
+20: (flags):
+21: (as_path):
+22: (local_pref): 100
+23: (med): 0
+24: (nexthop): 10.0.0.1
+25: (name): R00
+26: (is_prepolicy): 1
+27: (is_adj_rib_in): 1
+28: (ls_sr_capabilities): I 64000 100000
 
 Additional segment routing and SRv6 items not accounted for by OpenBMP:
 
@@ -228,28 +240,30 @@ Future:
 2: (sequence): 23
 3: (hash): 9b20947913e9b23f4d5ccf4174e9eba4
 4: (base_attr_hash): 17fcffffffffffff0000000000000000
-5: (router_hash): 963b507b39731b0675d3422e6f6be44c
+5: (router_hash): 367321d1bb7194e1f0f57f8ce99e7316
 6: (router_ip): 10.1.62.1
-7: (peer_hash): 6c6ba2119bddb79001663deb1801dfcc
-8: (peer_ip): 10.0.0.2
-9: (peer_asn): 100000
-10: (timestamp): 2020-03-25 22:25:05.143072
-11: (igp_router_id): 0000.0000.0001.0000
-12: (router_id): 0.0.0.0
-13: (routing_id): 0
-14: (ls_id): 0
-15: (mt_id):
-16: (area_id):
-17: (protocol): IS-IS_L2
-18: (flags):
-19: (as_path):
-20: (local_pref): 0
-21: (med): 0
-22: (nexthop):
-23: (name):
-24: (is_prepolicy): 1
-25: (is_adj_rib_in): 1
-26: (ls_sr_capabilities):
+7: (transport_ip):
+8: (transport_hash):
+9: (peer_hash): 6c6ba2119bddb79001663deb1801dfcc
+10: (peer_ip): 10.0.0.2
+11: (peer_asn): 100000
+12: (timestamp): 2020-03-25 22:25:05.143072
+13: (igp_router_id): 0000.0000.0001.0000
+14: (router_id): 0.0.0.0
+15: (routing_id): 0
+16: (ls_id): 0
+17: (mt_id):
+18: (area_id):
+19: (protocol): IS-IS_L2
+20: (flags):
+21: (as_path):
+22: (local_pref): 0
+23: (med): 0
+24: (nexthop):
+25: (name):
+26: (is_prepolicy): 1
+27: (is_adj_rib_in): 1
+28: (ls_sr_capabilities):
 
 ```
 #### BMP ls_link message:
@@ -260,50 +274,52 @@ Future:
 2: (sequence): 193
 3: (hash): 35c2476bc696eda06bda5837da79b16d
 4: (base_attr_hash): f7e177580a2209c7af48c6a90f707cc9
-5: (router_hash): 963b507b39731b0675d3422e6f6be44c
+5: (router_hash): 367321d1bb7194e1f0f57f8ce99e7316
 6: (router_ip): 10.1.62.1
-7: (peer_hash): 1787a325b86857cdcb82e46d2e919780
-8: (peer_ip): 10.0.0.1
-9: (peer_asn): 100000
-10: (timestamp): 2020-03-25 22:30:09.747268
-11: (igp_router_id): 0000.0000.0002.0000
-12: (router_id): 10.0.0.2
-13: (routing_id): 0
-14: (ls_id): 0
-15: (area_id): 0
-16: (protocol): IS-IS_L2
-17: (as_path):
-18: (local_pref): 100
-19: (med): 0
-20: (nexthop): 10.0.0.1
-21: (mt_id): 0
-22: (local_link_id): 0
-23: (remote_link_id): 0
-24: (intf_ip): 10.1.1.3
-25: (nei_ip): 10.1.1.2
-26: (igp_metric): 1
-27: (admin_group): 0
-28: (max_link_bw): 0
-29: (max_resv_bw): 0
-30: (unresv_bw):
-31: (max_link_bw_kbps): 1000000
-32: (max_resv_bw_kbps): 0
-33: (unresv_bw_kbps): 0, 0, 0, 0, 0, 0, 0, 0
-34: (te_default_metric): 1
-35: (link_protection):
-36: (mpls_proto_mask):
-37: (srlg):
-38: (link_name):
-39: (remote_node_hash): 6ed5aeb7f5ca0bbea84bdbadb61996e9
-40: (local_node_hash): c2679dc1c0d5615c23b3ec45f59f6b15
-41: (remote_igp_router_id): 0000.0000.0000.0000
-42: (remote_router_id): 10.0.0.0
-43: (local_node_asn): 100000
-44: (remote_node_asn): 100000
-45: (peer_node_sid):
-46: (is_prepolicy): 1
-47: (is_adj_rib_in): 1
-48: (ls_adjacency_sid): BVL 0 24004, VL 0 24005
+7: (transport_ip):
+8: (transport_hash):
+9: (peer_hash): 1787a325b86857cdcb82e46d2e919780
+10: (peer_ip): 10.0.0.1
+11: (peer_asn): 100000
+12: (timestamp): 2020-03-25 22:30:09.747268
+13: (igp_router_id): 0000.0000.0002.0000
+14: (router_id): 10.0.0.2
+15: (routing_id): 0
+16: (ls_id): 0
+17: (area_id): 0
+18: (protocol): IS-IS_L2
+19: (as_path):
+20: (local_pref): 100
+21: (med): 0
+22: (nexthop): 10.0.0.1
+23: (mt_id): 0
+24: (local_link_id): 0
+25: (remote_link_id): 0
+26: (intf_ip): 10.1.1.3
+27: (nei_ip): 10.1.1.2
+28: (igp_metric): 1
+29: (admin_group): 0
+30: (max_link_bw): 0
+31: (max_resv_bw): 0
+32: (unresv_bw):
+33: (max_link_bw_kbps): 1000000
+34: (max_resv_bw_kbps): 0
+35: (unresv_bw_kbps): 0, 0, 0, 0, 0, 0, 0, 0
+36: (te_default_metric): 1
+37: (link_protection):
+38: (mpls_proto_mask):
+39: (srlg):
+40: (link_name):
+41: (remote_node_hash): 6ed5aeb7f5ca0bbea84bdbadb61996e9
+42: (local_node_hash): c2679dc1c0d5615c23b3ec45f59f6b15
+43: (remote_igp_router_id): 0000.0000.0000.0000
+44: (remote_router_id): 10.0.0.0
+45: (local_node_asn): 100000
+46: (remote_node_asn): 100000
+47: (peer_node_sid):
+48: (is_prepolicy): 1
+49: (is_adj_rib_in): 1
+50: (ls_adjacency_sid): BVL 0 24004, VL 0 24005
 
 Additional segment routing not accounted for by OpenBMP:
 
@@ -340,50 +356,52 @@ Bonus item (OpenBMP never carried remote node router ID field, which would be ve
 2: (sequence): 102
 3: (hash): 9f60356cda03f1850cdbc818c9440a60
 4: (base_attr_hash): 17fcffffffffffff0000000000000000
-5: (router_hash): 963b507b39731b0675d3422e6f6be44c
+5: (router_hash): 367321d1bb7194e1f0f57f8ce99e7316
 6: (router_ip): 10.1.62.1
-7: (peer_hash): 6c6ba2119bddb79001663deb1801dfcc
-8: (peer_ip): 10.0.0.2
-9: (peer_asn): 100000
-10: (timestamp): 2020-03-25 22:25:00.023351
-11: (igp_router_id): 0000.0000.0000.0000
-12: (router_id): ::
-13: (routing_id): 0
-14: (ls_id): 0
-15: (area_id):
-16: (protocol): IS-IS_L2
-17: (as_path):
-18: (local_pref): 0
-19: (med): 0
-20: (nexthop):
-21: (mt_id): 2
-22: (local_link_id): 0
-23: (remote_link_id): 0
-24: (intf_ip): 10:1:1::
-25: (nei_ip): 10:1:1::1
-26: (igp_metric): 0
-27: (admin_group): 0
-28: (max_link_bw): 0
-29: (max_resv_bw): 0
-30: (unresv_bw):
-31: (max_link_bw_kbps): 0
-32: (max_resv_bw_kbps): 0
-33: (unresv_bw_kbps):
-34: (te_default_metric): 0
-35: (link_protection):
-36: (mpls_proto_mask):
-37: (srlg):
-38: (link_name):
-39: (remote_node_hash): 9b20947913e9b23f4d5ccf4174e9eba4
-40: (local_node_hash): 6ed5aeb7f5ca0bbea84bdbadb61996e9
-41: (remote_igp_router_id): 0000.0000.0001.0000
-42: (remote_router_id): ::
-43: (local_node_asn): 100000
-44: (remote_node_asn): 100000
-45: (peer_node_sid):
-46: (is_prepolicy): 1
-47: (is_adj_rib_in): 1
-48: (ls_adjacency_sid):
+7: (transport_ip):
+8: (transport_hash):
+9: (peer_hash): 6c6ba2119bddb79001663deb1801dfcc
+10: (peer_ip): 10.0.0.2
+11: (peer_asn): 100000
+12: (timestamp): 2020-03-25 22:25:00.023351
+13: (igp_router_id): 0000.0000.0000.0000
+14: (router_id): ::
+15: (routing_id): 0
+16: (ls_id): 0
+17: (area_id):
+18: (protocol): IS-IS_L2
+19: (as_path):
+20: (local_pref): 0
+21: (med): 0
+22: (nexthop):
+23: (mt_id): 2
+24: (local_link_id): 0
+25: (remote_link_id): 0
+26: (intf_ip): 10:1:1::
+27: (nei_ip): 10:1:1::1
+28: (igp_metric): 0
+29: (admin_group): 0
+30: (max_link_bw): 0
+31: (max_resv_bw): 0
+32: (unresv_bw):
+33: (max_link_bw_kbps): 0
+34: (max_resv_bw_kbps): 0
+35: (unresv_bw_kbps):
+36: (te_default_metric): 0
+37: (link_protection):
+38: (mpls_proto_mask):
+39: (srlg):
+40: (link_name):
+41: (remote_node_hash): 9b20947913e9b23f4d5ccf4174e9eba4
+42: (local_node_hash): 6ed5aeb7f5ca0bbea84bdbadb61996e9
+43: (remote_igp_router_id): 0000.0000.0001.0000
+44: (remote_router_id): ::
+45: (local_node_asn): 100000
+46: (remote_node_asn): 100000
+47: (peer_node_sid):
+48: (is_prepolicy): 1
+49: (is_adj_rib_in): 1
+50: (ls_adjacency_sid):
 
 ```
 #### BMP ls_prefix message:
@@ -395,35 +413,37 @@ Bonus item (OpenBMP never carried remote node router ID field, which would be ve
 2: (sequence): 201
 3: (hash): 47d904fe7803fa73c61ff126dd8c27d2
 4: (base_attr_hash): f7e177580a2209c7af48c6a90f707cc9
-5: (router_hash): 963b507b39731b0675d3422e6f6be44c
+5: (router_hash): 367321d1bb7194e1f0f57f8ce99e7316
 6: (router_ip): 10.1.62.1
-7: (peer_hash): 1787a325b86857cdcb82e46d2e919780
-8: (peer_ip): 10.0.0.1
-9: (peer_asn): 100000
-10: (timestamp): 2020-03-25 22:30:09.739779
-11: (igp_router_id): 0000.0000.0002.0000
-12: (router_id): 0.0.0.0
-13: (routing_id): 0
-14: (ls_id): 0
-15: (area_id):
-16: (protocol): IS-IS_L2
-17: (as_path):
-18: (local_pref): 100
-19: (med): 0
-20: (nexthop): 10.0.0.1
-21: (local_node_hash): c2679dc1c0d5615c23b3ec45f59f6b15
-22: (mt_id): 0
-23: (ospf_route_type):
-24: (igp_flags):
-25: (route_tag): 0
-26: (ext_route_tag): 0
-27: (ospf_fwd_addr): 0.0.0.0
-28: (igp_metric): 0
-29: (prefix): 10.0.0.2
-30: (prefix_len): 32
-31: (is_prepolicy): 1
-32: (is_adj_rib_in): 1
-33: (ls_prefix_sid): N SPF 2
+7: (transport_ip):
+8: (transport_hash):
+9: (peer_hash): 1787a325b86857cdcb82e46d2e919780
+10: (peer_ip): 10.0.0.1
+11: (peer_asn): 100000
+12: (timestamp): 2020-03-25 22:30:09.739779
+13: (igp_router_id): 0000.0000.0002.0000
+14: (router_id): 0.0.0.0
+15: (routing_id): 0
+16: (ls_id): 0
+17: (area_id):
+18: (protocol): IS-IS_L2
+19: (as_path):
+20: (local_pref): 100
+21: (med): 0
+22: (nexthop): 10.0.0.1
+23: (local_node_hash): c2679dc1c0d5615c23b3ec45f59f6b15
+24: (mt_id): 0
+25: (ospf_route_type):
+26: (igp_flags):
+27: (route_tag): 0
+28: (ext_route_tag): 0
+29: (ospf_fwd_addr): 0.0.0.0
+30: (igp_metric): 0
+31: (prefix): 10.0.0.2
+32: (prefix_len): 32
+33: (is_prepolicy): 1
+34: (is_adj_rib_in): 1
+35: (ls_prefix_sid): N SPF 2
 
 // delete ls_prefix
 
@@ -431,35 +451,37 @@ Bonus item (OpenBMP never carried remote node router ID field, which would be ve
 2: (sequence): 136
 3: (hash): 8b3daeb20e905895d8cfab34220b5689
 4: (base_attr_hash): 17fcffffffffffff0000000000000000
-5: (router_hash): 963b507b39731b0675d3422e6f6be44c
+5: (router_hash): 367321d1bb7194e1f0f57f8ce99e7316
 6: (router_ip): 10.1.62.1
-7: (peer_hash): 30b1ce11e0c436dc3e37dc7342b12be8
-8: (peer_ip): 10.0.0.0
-9: (peer_asn): 100000
-10: (timestamp): 2020-03-25 22:25:05.134138
-11: (igp_router_id): 0000.0000.0001.0000
-12: (router_id): 0.0.0.0
-13: (routing_id): 0
-14: (ls_id): 0
-15: (area_id):
-16: (protocol): IS-IS_L2
-17: (as_path):
-18: (local_pref): 0
-29: (med): 0
-20: (nexthop):
-21: (local_node_hash): 9b20947913e9b23f4d5ccf4174e9eba4
-22: (mt_id): 0
-23: (ospf_route_type):
-24: (igp_flags):
-25: (route_tag): 0
-26: (ext_route_tag): 0
-27: (ospf_fwd_addr): 0.0.0.0
-28: (igp_metric): 0
-39: (prefix): 10.0.0.1
-30: (prefix_len): 32
-31: (is_prepolicy): 1
-32: (is_adj_rib_in): 1
-33: (ls_prefix_sid):
+7: (transport_ip):
+8: (transport_hash):
+9: (peer_hash): 30b1ce11e0c436dc3e37dc7342b12be8
+10: (peer_ip): 10.0.0.0
+11: (peer_asn): 100000
+12: (timestamp): 2020-03-25 22:25:05.134138
+13: (igp_router_id): 0000.0000.0001.0000
+14: (router_id): 0.0.0.0
+15: (routing_id): 0
+16: (ls_id): 0
+17: (area_id):
+18: (protocol): IS-IS_L2
+19: (as_path):
+20: (local_pref): 0
+31: (med): 0
+22: (nexthop):
+23: (local_node_hash): 9b20947913e9b23f4d5ccf4174e9eba4
+24: (mt_id): 0
+25: (ospf_route_type):
+26: (igp_flags):
+27: (route_tag): 0
+28: (ext_route_tag): 0
+29: (ospf_fwd_addr): 0.0.0.0
+30: (igp_metric): 0
+41: (prefix): 10.0.0.1
+32: (prefix_len): 32
+33: (is_prepolicy): 1
+34: (is_adj_rib_in): 1
+35: (ls_prefix_sid):
 
 ```
 #### BMP ls_srv6_sid message:
@@ -515,111 +537,122 @@ BGP-LS TLVs:
 1: (action): add
 2: (sequence): 35
 3: (hash): 332047c6ca64451ed6f5ddb92710a29a
-4: (router_hash): fb5d34c594dff80c59019b6d132185f7
+4: (router_hash): b684810f26f15fa57c62abae34d3ef07
 5: (router_ip): 10.1.34.1
-6: (base_attr_hash): 22155edb81a03c848f36193dfd3e48f3
-7: (peer_hash): d67b274c33ea1ff0ffe9dd781938b0de
-8: (peer_ip): 10.0.0.7
-9: (peer_asn): 100000
-10: (timestamp): 2020-03-25 22:39:04.023783
-11: (prefix): 100.100.100.0
-12: (prefix_len): 24
-13: (is_ipv4): 1
-14: (origin): incomplete
-15: (as_path):
-16: (as_path_count): 0
-17: (origin_as): 0
-18: (nexthop): 10.0.0.7
-19: (med): 0
-20: (local_pref): 100
-21: (aggregator):
-22: (community_list):
-23: (ext_community_list): rt=100:100
-24: (cluster_list):
-25: (isatomicagg): 0
-26: (is_nexthop_ipv4): 1
-27: (originator_id):
-28: (path_id): 0
-29: (labels): 24000
-30: (is_prepolicy): 1
-31: (is_adj_rib_in): 1
-32: (vpn_rd): 100100:100
-33: (vpn_rd_type): 0
+6: (transport_ip):
+7: (transport_hash):
+8: (base_attr_hash): 22155edb81a03c848f36193dfd3e48f3
+9: (peer_hash): d67b274c33ea1ff0ffe9dd781938b0de
+10: (peer_ip): 10.0.0.7
+11: (peer_asn): 100000
+12: (timestamp): 2020-03-25 22:39:04.023783
+13: (prefix): 100.100.100.0
+14: (prefix_len): 24
+15: (is_ipv4): 1
+16: (origin): incomplete
+17: (as_path):
+18: (as_path_count): 0
+19: (origin_as): 0
+20: (nexthop): 10.0.0.7
+21: (med): 0
+22: (local_pref): 100
+23: (aggregator):
+24: (community_list):
+25: (ext_community_list): rt=100:100
+26: (cluster_list):
+27: (isatomicagg): 0
+28: (is_nexthop_ipv4): 1
+29: (originator_id):
+30: (path_id): 0
+31: (labels): 24000
+32: (is_prepolicy): 1
+33: (is_adj_rib_in): 1
+34: (vpn_rd): 100100:100
+35: (vpn_rd_type): 0
 
 // delete l3vpn (prefix) message
 
 1: (action): del
 2: (sequence): 34
 3: (hash): 332047c6ca64451ed6f5ddb92710a29a
-4: (router_hash): fb5d34c594dff80c59019b6d132185f7
+4: (router_hash): b684810f26f15fa57c62abae34d3ef07
 5: (router_ip): 10.1.34.1
-6: (base_attr_hash):
-7: (peer_hash): d67b274c33ea1ff0ffe9dd781938b0de
-8: (peer_ip): 10.0.0.7
-9: (peer_asn): 100000
-10: (timestamp): 2020-03-25 22:37:53.516968
-11: (prefix): 100.100.100.0
-12: (prefix_len): 24
-13: (is_ipv4): 1
-14: (origin):
-15: (as_path):
-16: (as_path_count):
-17: (origin_as):
-18: (nexthop):
-19: (med):
-20: (local_pref):
-21: (aggregator):
-22: (community_list):
-23: (ext_community_list):
-24: (cluster_list):
-25: (isatomicagg):
-26: (is_nexthop_ipv4):
-27: (originator_id):
-28: (path_id): 0
-29: (labels): 524288
-30: (is_prepolicy): 1
-31: (is_adj_rib_in): 1
-32: (vpn_rd): 100100:100
-33: (vpn_rd_type): 0
+6: (transport_ip):
+7: (transport_hash):
+8: (base_attr_hash):
+9: (peer_hash): d67b274c33ea1ff0ffe9dd781938b0de
+10: (peer_ip): 10.0.0.7
+11: (peer_asn): 100000
+12: (timestamp): 2020-03-25 22:37:53.516968
+13: (prefix): 100.100.100.0
+14: (prefix_len): 24
+15: (is_ipv4): 1
+16: (origin):
+17: (as_path):
+18: (as_path_count):
+19: (origin_as):
+20: (nexthop):
+21: (med):
+22: (local_pref):
+23: (aggregator):
+24: (community_list):
+25: (ext_community_list):
+26: (cluster_list):
+27: (isatomicagg):
+28: (is_nexthop_ipv4):
+29: (originator_id):
+30: (path_id): 0
+31: (labels): 524288
+32: (is_prepolicy): 1
+33: (is_adj_rib_in): 1
+34: (vpn_rd): 100100:100
+35: (vpn_rd_type): 0
 
 ```
 
 #### BMP evpn message:
 ```
 1: (action): add/del
+2: (sequence):
+3: (hash):
+4: (router_hash):
 5: (router_ip):
-8: (peer_ip):
-9: (peer_asn):
-10: (timestamp):
-11: (origin):
-12: (as_path):
-13: (as_path_count):
-14: (origin_as):
-15: (nexthop):
-16: (med):
-17: (local_pref):
-18: (aggregator):
-19: (community_list):
-20: (ext_community_list)
-21: (cluster_list):
-22: (isatomicagg):
-23: (is_nexthop_ipv4):
-24: (originator_id):
-25: (path_id):
-26: (is_prepolicy):
-27: (is_adj_rib_in):
-28: (rd):
-29: (rd_type):
-30: (rd_type):
-31: (orig_router_ip_len):
-32: (eth_tag):
-33: (eth_segment_id):
-34: (mac_len):
-35: (mac):
-36: (ip_len):
-37: (ip):
-38: (label):
-39: (label):
+6: (transport_ip):
+7: (transport_hash):
+8: (peer_hash):
+9: (peer_type):
+10: (peer_ip):
+11: (peer_asn):
+12: (timestamp):
+13: (origin):
+14: (as_path):
+15: (as_path_count):
+16: (origin_as):
+17: (nexthop):
+18: (med):
+19: (local_pref):
+20: (aggregator):
+21: (community_list):
+22: (ext_community_list)
+23: (cluster_list):
+24: (isatomicagg):
+25: (is_nexthop_ipv4):
+26: (originator_id):
+27: (path_id):
+28: (is_prepolicy):
+29: (is_adj_rib_in):
+30: (rd):
+31: (rd_type):
+32: (rd_type):
+33: (orig_router_ip_len):
+34: (eth_tag):
+35: (eth_segment_id):
+36: (mac_len):
+37: (mac):
+38: (ip_len):
+39: (ip):
+40: (label):
+41: (label):
 ```
 ### SRv6 L3VPN Message (v4 overlay, SRv6 underlay)
 
@@ -629,36 +662,38 @@ BGP-LS TLVs:
 1: (action): add
 2: (sequence): 38
 3: (hash): b44a84e415927f20ff3e6edf7103875c
-4: (router_hash): fb5d34c594dff80c59019b6d132185f7
+4: (router_hash): b684810f26f15fa57c62abae34d3ef07
 5: (router_ip): 10.1.34.1
-6: (base_attr_hash): e0895cf0bc3391438d43cdc7e43aae36
-7: (peer_hash): 0146fce99cbd730d787487de31452f88
-8: (peer_ip): 2001:1:1:f003::1                        // this is ok
-9: (peer_asn): 100000                                 // this is ok
-10: (timestamp): 2020-03-25 22:41:32.861004
-11: (prefix): 0.0.0.0                                 // should be 3.30.30.0/24
-12: (prefix_len): 0
-13: (is_ipv4): 1
-14: (origin): incomplete
-15: (as_path):
-16: (as_path_count): 0
-17: (origin_as): 0
-18: (nexthop): 32.1.0.1                               // wrong
-19: (med): 0
-20: (local_pref): 100
-21: (aggregator):
-22: (community_list):
-23: (ext_community_list): rt=300:10                   // this is ok
-24: (cluster_list):
-25: (isatomicagg): 0
-26: (is_nexthop_ipv4): 1
-27: (originator_id):
-28: (path_id): 0
-29: (labels): 1072,0                                  // VPN label should be replaced with SRv6-VPN SID: 2001:1:1:f003:43::/128
-30: (is_prepolicy): 1
-31: (is_adj_rib_in): 1
-32: (vpn_rd): 1679764780:167976478                    // ? should be 300:10
-33: (vpn_rd_type): 0
+6: (transport_ip):
+7: (transport_hash):
+8: (base_attr_hash): e0895cf0bc3391438d43cdc7e43aae36
+9: (peer_hash): 0146fce99cbd730d787487de31452f88
+10: (peer_ip): 2001:1:1:f003::1                        // this is ok
+11: (peer_asn): 100000                                 // this is ok
+12: (timestamp): 2020-03-25 22:41:32.861004
+13: (prefix): 0.0.0.0                                 // should be 3.30.30.0/24
+14: (prefix_len): 0
+15: (is_ipv4): 1
+16: (origin): incomplete
+17: (as_path):
+18: (as_path_count): 0
+19: (origin_as): 0
+20: (nexthop): 32.1.0.1                               // wrong
+21: (med): 0
+22: (local_pref): 100
+23: (aggregator):
+24: (community_list):
+25: (ext_community_list): rt=300:10                   // this is ok
+26: (cluster_list):
+27: (isatomicagg): 0
+28: (is_nexthop_ipv4): 1
+29: (originator_id):
+30: (path_id): 0
+31: (labels): 1072,0                                  // VPN label should be replaced with SRv6-VPN SID: 2001:1:1:f003:43::/128
+32: (is_prepolicy): 1
+33: (is_adj_rib_in): 1
+34: (vpn_rd): 1679764780:167976478                    // ? should be 300:10
+35: (vpn_rd_type): 0
 
 // show BGP command output for the above SRv6 l3vpn message:
 
@@ -724,33 +759,35 @@ Wed Mar 25 22:52:03.008 UTC
 1: (action): del
 2: (sequence): 37
 3: (hash): 2f358ba42cb0a8a00c210b0accbf1af4
-4: (router_hash): fb5d34c594dff80c59019b6d132185f7
+4: (router_hash): b684810f26f15fa57c62abae34d3ef07
 5: (router_ip): 10.1.34.1
-6: (base_attr_hash):
-7: (peer_hash): 0146fce99cbd730d787487de31452f88
-8: (peer_ip): 2001:1:1:f003::1
-9: (peer_asn): 100000
-10: (timestamp): 2020-03-25 22:41:03.602687
-11: (prefix): 3.30.30.0
-12: (prefix_len): 24
-13: (is_ipv4): 1
-14: (origin):
-15: (as_path):
-16: (as_path_count):
-17: (origin_as):
-18: (nexthop):
-19: (med):
-20: (local_pref):
-21: (aggregator):
-22: (community_list):
-23: (ext_community_list):
-24: (cluster_list):
-25: (isatomicagg):
-26: (is_nexthop_ipv4):
-27: (originator_id):
-28: (path_id): 0
-29: (labels): 524288
-30: (is_prepolicy): 1
-31: (is_adj_rib_in): 1
-32: (vpn_rd): 10300:10
-33: (vpn_rd_type): 0
+6: (transport_ip):
+7: (transport_hash):
+8: (base_attr_hash):
+9: (peer_hash): 0146fce99cbd730d787487de31452f88
+10: (peer_ip): 2001:1:1:f003::1
+11: (peer_asn): 100000
+12: (timestamp): 2020-03-25 22:41:03.602687
+13: (prefix): 3.30.30.0
+14: (prefix_len): 24
+15: (is_ipv4): 1
+16: (origin):
+17: (as_path):
+18: (as_path_count):
+19: (origin_as):
+20: (nexthop):
+21: (med):
+22: (local_pref):
+23: (aggregator):
+24: (community_list):
+25: (ext_community_list):
+26: (cluster_list):
+27: (isatomicagg):
+28: (is_nexthop_ipv4):
+29: (originator_id):
+30: (path_id): 0
+31: (labels): 524288
+32: (is_prepolicy): 1
+33: (is_adj_rib_in): 1
+34: (vpn_rd): 10300:10
+35: (vpn_rd_type): 0

--- a/pkg/gobmpsrv/gobmpsrv.go
+++ b/pkg/gobmpsrv/gobmpsrv.go
@@ -168,23 +168,9 @@ func (srv *bmpServer) bmpWorker(client net.Conn) {
 		_ = client.Close()
 	}()
 	var err error
-	prod := message.NewProducer(srv.publisher, srv.splitAF)
-
-	// Configure producer with admin ID for RAW message support
-	if err := prod.SetConfig(&message.Config{
-		AdminID: srv.adminID,
-	}); err != nil {
-		glog.Errorf("failed to configure producer with error: %+v", err)
-		return
-	}
-
-	prodStop := make(chan struct{})
-	producerQueue := make(chan bmp.Message)
-	// Starting messages producer per client with dedicated work queue
-	go prod.Producer(producerQueue, prodStop)
-
-	// Extract speaker IP from the TCP connection. Set on all BMP messages
-	// to provide a consistent router identity regardless of message type.
+	// Extract speaker IP from the TCP connection before starting the producer.
+	// transportIP is connection-scoped and immutable — set once at construction
+	// time so all goroutines can read it without synchronization.
 	// Type-assert to *net.TCPAddr to get a clean IP string free of
 	// ports, brackets, and IPv6 zone identifiers.
 	var speakerIP string
@@ -212,6 +198,20 @@ func (srv *bmpServer) bmpWorker(client net.Conn) {
 			}
 		}
 	}
+
+	prod := message.NewProducer(srv.publisher, srv.splitAF)
+	if err := prod.SetConfig(&message.Config{
+		AdminID:     srv.adminID,
+		TransportIP: speakerIP,
+	}); err != nil {
+		glog.Errorf("failed to configure producer with error: %+v", err)
+		return
+	}
+
+	prodStop := make(chan struct{})
+	producerQueue := make(chan bmp.Message)
+	// Starting messages producer per client with dedicated work queue
+	go prod.Producer(producerQueue, prodStop)
 
 	parserQueue := make(chan []byte)
 	parsStop := make(chan struct{})

--- a/pkg/message/base-nlri.go
+++ b/pkg/message/base-nlri.go
@@ -14,6 +14,7 @@ import (
 // a slice of UnicatPrefix.
 // Used Only by Legacy IPv4 Unicast
 func (p *producer) nlri(op int, ph *bmp.PerPeerHeader, update *bgp.Update) ([]*UnicastPrefix, error) {
+	localIP, localHash := p.peerLocal(ph.GetTableKey())
 	var operation string
 	var routes []base.Route
 	// Use per-table AddPath capability
@@ -43,22 +44,26 @@ func (p *producer) nlri(op int, ph *bmp.PerPeerHeader, update *bgp.Update) ([]*U
 		glog.Infof("><SB> Suspected EoR message for Unicast ipv4")
 		return []*UnicastPrefix{
 			{
-				Action:     operation,
-				RouterHash: p.speakerHash,
-				RouterIP:   p.speakerIP,
-				PeerHash:   ph.GetPeerHash(),
-				PeerASN:    ph.PeerAS,
-				Timestamp:  ph.GetPeerTimestamp(),
-				PeerType:   uint8(ph.PeerType),
-				IsEOR:      true,
+				Action:        operation,
+				RouterHash:    localHash,
+				RouterIP:      localIP,
+				TransportIP:   p.transportIP,
+				TransportHash: p.transportHash,
+				PeerHash:      ph.GetPeerHash(),
+				PeerASN:       ph.PeerAS,
+				Timestamp:     ph.GetPeerTimestamp(),
+				PeerType:      uint8(ph.PeerType),
+				IsEOR:         true,
 			},
 		}, nil
 	}
 	for _, pr := range routes {
 		prfx := &UnicastPrefix{
 			Action:         operation,
-			RouterHash:     p.speakerHash,
-			RouterIP:       p.speakerIP,
+			RouterHash:     localHash,
+			RouterIP:       localIP,
+			TransportIP:    p.transportIP,
+			TransportHash:  p.transportHash,
 			PeerHash:       ph.GetPeerHash(),
 			PeerASN:        ph.PeerAS,
 			Timestamp:      ph.GetPeerTimestamp(),

--- a/pkg/message/bmpstats.go
+++ b/pkg/message/bmpstats.go
@@ -29,6 +29,7 @@ func (p *producer) produceStatsMessage(msg bmp.Message) {
 		glog.Errorf("perPeerHeader is missing, cannot construct Stats message")
 		return
 	}
+	localIP, localHash := p.peerLocal(msg.PeerHeader.GetTableKey())
 	StatsMsg, ok := msg.Payload.(*bmp.StatsReport)
 	if !ok {
 		glog.Errorf("got invalid Payload type in bmp.StatsReport %+v", msg.Payload)
@@ -41,12 +42,14 @@ func (p *producer) produceStatsMessage(msg bmp.Message) {
 	}
 
 	m := Stats{
-		RemoteASN:  msg.PeerHeader.PeerAS,
-		PeerRD:     msg.PeerHeader.GetPeerDistinguisherString(),
-		Timestamp:  msg.PeerHeader.GetPeerTimestamp(),
-		RouterHash: p.speakerHash,
-		RouterIP:   p.speakerIP,
-		PeerType:   uint8(msg.PeerHeader.PeerType),
+		RemoteASN:     msg.PeerHeader.PeerAS,
+		PeerRD:        msg.PeerHeader.GetPeerDistinguisherString(),
+		Timestamp:     msg.PeerHeader.GetPeerTimestamp(),
+		RouterHash:    localHash,
+		RouterIP:      localIP,
+		TransportIP:   p.transportIP,
+		TransportHash: p.transportHash,
+		PeerType:      uint8(msg.PeerHeader.PeerType),
 	}
 	m.RemoteIP = msg.PeerHeader.GetPeerAddrString()
 	m.RemoteBGPID = msg.PeerHeader.GetPeerBGPIDString()

--- a/pkg/message/bmpstats_bounds_test.go
+++ b/pkg/message/bmpstats_bounds_test.go
@@ -21,8 +21,8 @@ func statsTestPeerHeader() *bmp.PerPeerHeader {
 // TestProduceStatsMessage_AllTypes exercises produceStatsMessage with all stat types
 func TestProduceStatsMessage_AllTypes(t *testing.T) {
 	p := &producer{
-		speakerHash: "test-hash",
-		speakerIP:   "10.0.0.1",
+		transportHash: "test-hash",
+		transportIP:   "10.0.0.1",
 		publisher:   &mockPublisher{},
 	}
 
@@ -61,8 +61,8 @@ func TestProduceStatsMessage_AllTypes(t *testing.T) {
 // TestProduceStatsMessage_TruncatedUint32 exercises the length guard for 4-byte stats
 func TestProduceStatsMessage_TruncatedUint32(t *testing.T) {
 	p := &producer{
-		speakerHash: "test-hash",
-		speakerIP:   "10.0.0.1",
+		transportHash: "test-hash",
+		transportIP:   "10.0.0.1",
 		publisher:   &mockPublisher{},
 	}
 
@@ -84,8 +84,8 @@ func TestProduceStatsMessage_TruncatedUint32(t *testing.T) {
 // TestProduceStatsMessage_TruncatedUint64 exercises the length guard for 8-byte stats
 func TestProduceStatsMessage_TruncatedUint64(t *testing.T) {
 	p := &producer{
-		speakerHash: "test-hash",
-		speakerIP:   "10.0.0.1",
+		transportHash: "test-hash",
+		transportIP:   "10.0.0.1",
 		publisher:   &mockPublisher{},
 	}
 
@@ -107,8 +107,8 @@ func TestProduceStatsMessage_TruncatedUint64(t *testing.T) {
 // TestProduceStatsMessage_NilPeerHeader exercises the nil PeerHeader guard
 func TestProduceStatsMessage_NilPeerHeader(t *testing.T) {
 	p := &producer{
-		speakerHash: "test-hash",
-		speakerIP:   "10.0.0.1",
+		transportHash: "test-hash",
+		transportIP:   "10.0.0.1",
 		publisher:   &mockPublisher{},
 	}
 	msg := bmp.Message{
@@ -121,8 +121,8 @@ func TestProduceStatsMessage_NilPeerHeader(t *testing.T) {
 // TestProduceStatsMessage_InvalidPayload exercises the type assertion guard
 func TestProduceStatsMessage_InvalidPayload(t *testing.T) {
 	p := &producer{
-		speakerHash: "test-hash",
-		speakerIP:   "10.0.0.1",
+		transportHash: "test-hash",
+		transportIP:   "10.0.0.1",
 		publisher:   &mockPublisher{},
 	}
 	msg := bmp.Message{
@@ -135,8 +135,8 @@ func TestProduceStatsMessage_InvalidPayload(t *testing.T) {
 // TestProduceStatsMessage_EmptyTLV exercises the empty TLV guard
 func TestProduceStatsMessage_EmptyTLV(t *testing.T) {
 	p := &producer{
-		speakerHash: "test-hash",
-		speakerIP:   "10.0.0.1",
+		transportHash: "test-hash",
+		transportIP:   "10.0.0.1",
 		publisher:   &mockPublisher{},
 	}
 	msg := bmp.Message{
@@ -149,8 +149,8 @@ func TestProduceStatsMessage_EmptyTLV(t *testing.T) {
 // TestProduceStatsMessage_UnknownType exercises the default case
 func TestProduceStatsMessage_UnknownType(t *testing.T) {
 	p := &producer{
-		speakerHash: "test-hash",
-		speakerIP:   "10.0.0.1",
+		transportHash: "test-hash",
+		transportIP:   "10.0.0.1",
 		publisher:   &mockPublisher{},
 	}
 	statsMsg := &bmp.StatsReport{

--- a/pkg/message/bmpstats_test.go
+++ b/pkg/message/bmpstats_test.go
@@ -22,8 +22,8 @@ func (m *mockPublisher) Stop() {
 // TestStatsType0_PrefixesRejectedInbound tests RFC 7854 Section 4.8 Type 0
 func TestStatsType0_PrefixesRejectedInbound(t *testing.T) {
 	p := &producer{
-		speakerHash: "test-router",
-		speakerIP:   "192.0.2.1",
+		transportHash: "test-router",
+		transportIP:   "192.0.2.1",
 		publisher:   &mockPublisher{},
 	}
 
@@ -51,8 +51,8 @@ func TestStatsType0_PrefixesRejectedInbound(t *testing.T) {
 	// Create Stats struct
 	m := Stats{
 		RemoteASN:  msg.PeerHeader.PeerAS,
-		RouterHash: p.speakerHash,
-		RouterIP:   p.speakerIP,
+		RouterHash: p.transportHash,
+		RouterIP:   p.transportIP,
 	}
 
 	// Process TLV
@@ -71,8 +71,8 @@ func TestStatsType0_PrefixesRejectedInbound(t *testing.T) {
 // TestStatsType14_PrePolicyAdjRIBOut tests RFC 7854 Section 4.8 Type 14
 func TestStatsType14_PrePolicyAdjRIBOut(t *testing.T) {
 	p := &producer{
-		speakerHash: "test-router",
-		speakerIP:   "192.0.2.1",
+		transportHash: "test-router",
+		transportIP:   "192.0.2.1",
 		publisher:   &mockPublisher{},
 	}
 
@@ -98,8 +98,8 @@ func TestStatsType14_PrePolicyAdjRIBOut(t *testing.T) {
 
 	m := Stats{
 		RemoteASN:  msg.PeerHeader.PeerAS,
-		RouterHash: p.speakerHash,
-		RouterIP:   p.speakerIP,
+		RouterHash: p.transportHash,
+		RouterIP:   p.transportIP,
 	}
 
 	for _, tlv := range statsMsg.StatsTLV {
@@ -116,8 +116,8 @@ func TestStatsType14_PrePolicyAdjRIBOut(t *testing.T) {
 // TestStatsType15_PostPolicyAdjRIBOut tests RFC 7854 Section 4.8 Type 15
 func TestStatsType15_PostPolicyAdjRIBOut(t *testing.T) {
 	p := &producer{
-		speakerHash: "test-router",
-		speakerIP:   "192.0.2.1",
+		transportHash: "test-router",
+		transportIP:   "192.0.2.1",
 		publisher:   &mockPublisher{},
 	}
 
@@ -142,8 +142,8 @@ func TestStatsType15_PostPolicyAdjRIBOut(t *testing.T) {
 
 	m := Stats{
 		RemoteASN:  msg.PeerHeader.PeerAS,
-		RouterHash: p.speakerHash,
-		RouterIP:   p.speakerIP,
+		RouterHash: p.transportHash,
+		RouterIP:   p.transportIP,
 	}
 
 	for _, tlv := range statsMsg.StatsTLV {
@@ -166,8 +166,8 @@ func TestStatsType15_PostPolicyAdjRIBOut(t *testing.T) {
 // TestStatsMultipleTLVs tests handling multiple stat types in single message
 func TestStatsMultipleTLVs(t *testing.T) {
 	p := &producer{
-		speakerHash: "test-router",
-		speakerIP:   "192.0.2.1",
+		transportHash: "test-router",
+		transportIP:   "192.0.2.1",
 		publisher:   &mockPublisher{},
 	}
 
@@ -199,8 +199,8 @@ func TestStatsMultipleTLVs(t *testing.T) {
 
 	m := Stats{
 		RemoteASN:  msg.PeerHeader.PeerAS,
-		RouterHash: p.speakerHash,
-		RouterIP:   p.speakerIP,
+		RouterHash: p.transportHash,
+		RouterIP:   p.transportIP,
 	}
 
 	// Process all TLVs

--- a/pkg/message/evpn.go
+++ b/pkg/message/evpn.go
@@ -17,6 +17,7 @@ const (
 // evpn process MP_REACH_NLRI AFI 25 SAFI 70 update message and returns
 // EVPN prefix object.
 func (p *producer) evpn(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *bgp.Update) ([]EVPNPrefix, error) {
+	localIP, localHash := p.peerLocal(ph.GetTableKey())
 	if glog.V(6) {
 		glog.Infof("All attributes in evpn update: %+v", update.GetAllAttributeID())
 	}
@@ -39,8 +40,10 @@ func (p *producer) evpn(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *
 		prfx := EVPNPrefix{
 			Action:         operation,
 			PeerType:       uint8(ph.PeerType),
-			RouterHash:     p.speakerHash,
-			RouterIP:       p.speakerIP,
+			RouterHash:     localHash,
+			RouterIP:       localIP,
+			TransportIP:    p.transportIP,
+			TransportHash:  p.transportHash,
 			PeerHash:       ph.GetPeerHash(),
 			PeerASN:        ph.PeerAS,
 			Timestamp:      ph.GetPeerTimestamp(),

--- a/pkg/message/evpn_ipv6_test.go
+++ b/pkg/message/evpn_ipv6_test.go
@@ -16,6 +16,16 @@ import (
 	"github.com/sbezverk/gobmp/pkg/vpls"
 )
 
+const (
+	evpnTransportIP   = "10.0.0.1"
+	evpnTransportHash = "test-hash"
+	evpnLocalIP       = "10.0.0.2"
+	evpnLocalHash     = "b026324c6904b2a9cb4b88d6d61c81d1" // md5(10.0.0.2)
+	// evpnTableKey is GetTableKey() for a PerPeerHeader with all-zero PeerBGPID
+	// and all-zero PeerDistinguisher (PeerType0): "0.0.0.0" + "0:0" = "0.0.0.00:0".
+	evpnTableKey = "0.0.0.00:0"
+)
+
 type evpnMockNLRI struct {
 	route   *evpn.Route
 	nextHop string
@@ -80,9 +90,16 @@ func buildEVPNType5IPv6Wire() []byte {
 
 func TestEvpnIPv6Address(t *testing.T) {
 	prod := &producer{
-		speakerHash: "test-hash",
-		speakerIP:   "10.0.0.1",
-		publisher:   &mockPublisher{},
+		transportIP:   evpnTransportIP,
+		transportHash: evpnTransportHash,
+		publisher:     &mockPublisher{},
+		tableProperties: map[string]PerTableProperties{
+			evpnTableKey: {
+				addPathCapable: make(map[int]bool),
+				localIP:        evpnLocalIP,
+				localHash:      evpnLocalHash,
+			},
+		},
 	}
 
 	route, err := evpn.UnmarshalEVPNNLRI(buildEVPNType5IPv6Wire())
@@ -125,6 +142,18 @@ func TestEvpnIPv6Address(t *testing.T) {
 	if prfxs[0].IPLength != 128 {
 		t.Errorf("IPLength = %d, want 128", prfxs[0].IPLength)
 	}
+	if prfxs[0].RouterIP != evpnLocalIP {
+		t.Errorf("RouterIP = %q, want %q", prfxs[0].RouterIP, evpnLocalIP)
+	}
+	if prfxs[0].RouterHash != evpnLocalHash {
+		t.Errorf("RouterHash = %q, want %q", prfxs[0].RouterHash, evpnLocalHash)
+	}
+	if prfxs[0].TransportIP != evpnTransportIP {
+		t.Errorf("TransportIP = %q, want %q", prfxs[0].TransportIP, evpnTransportIP)
+	}
+	if prfxs[0].TransportHash != evpnTransportHash {
+		t.Errorf("TransportHash = %q, want %q", prfxs[0].TransportHash, evpnTransportHash)
+	}
 }
 
 func buildEVPNType5IPv4Wire() []byte {
@@ -159,9 +188,16 @@ func buildEVPNType5IPv4Wire() []byte {
 
 func TestEvpnIPv4Address(t *testing.T) {
 	prod := &producer{
-		speakerHash: "test-hash",
-		speakerIP:   "10.0.0.1",
-		publisher:   &mockPublisher{},
+		transportIP:   evpnTransportIP,
+		transportHash: evpnTransportHash,
+		publisher:     &mockPublisher{},
+		tableProperties: map[string]PerTableProperties{
+			evpnTableKey: {
+				addPathCapable: make(map[int]bool),
+				localIP:        evpnLocalIP,
+				localHash:      evpnLocalHash,
+			},
+		},
 	}
 
 	route, err := evpn.UnmarshalEVPNNLRI(buildEVPNType5IPv4Wire())
@@ -204,5 +240,17 @@ func TestEvpnIPv4Address(t *testing.T) {
 	}
 	if prfxs[0].IPLength != 24 {
 		t.Errorf("IPLength = %d, want 24", prfxs[0].IPLength)
+	}
+	if prfxs[0].RouterIP != evpnLocalIP {
+		t.Errorf("RouterIP = %q, want %q", prfxs[0].RouterIP, evpnLocalIP)
+	}
+	if prfxs[0].RouterHash != evpnLocalHash {
+		t.Errorf("RouterHash = %q, want %q", prfxs[0].RouterHash, evpnLocalHash)
+	}
+	if prfxs[0].TransportIP != evpnTransportIP {
+		t.Errorf("TransportIP = %q, want %q", prfxs[0].TransportIP, evpnTransportIP)
+	}
+	if prfxs[0].TransportHash != evpnTransportHash {
+		t.Errorf("TransportHash = %q, want %q", prfxs[0].TransportHash, evpnTransportHash)
 	}
 }

--- a/pkg/message/flowspec.go
+++ b/pkg/message/flowspec.go
@@ -46,9 +46,13 @@ func (p *producer) flowspec(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, upda
 
 // buildFlowspecMessage constructs a single Flowspec message. Pass nil fsnlri for withdraw-all.
 func (p *producer) buildFlowspecMessage(operation string, nlri bgp.MPNLRI, ph *bmp.PerPeerHeader, update *bgp.Update, fsnlri *flowspec.NLRI) *Flowspec {
+	localIP, localHash := p.peerLocal(ph.GetTableKey())
 	fs := &Flowspec{
 		Action:         operation,
-		RouterIP:       p.speakerIP,
+		RouterIP:       localIP,
+		RouterHash:     localHash,
+		TransportIP:    p.transportIP,
+		TransportHash:  p.transportHash,
 		PeerType:       uint8(ph.PeerType),
 		PeerASN:        ph.PeerAS,
 		Timestamp:      ph.GetPeerTimestamp(),

--- a/pkg/message/flowspec.go
+++ b/pkg/message/flowspec.go
@@ -136,6 +136,21 @@ func (fs *Flowspec) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(objmap["router_ip"], &o.RouterIP); err != nil {
 		return err
 	}
+	if v, ok := objmap["router_hash"]; ok {
+		if err := json.Unmarshal(v, &o.RouterHash); err != nil {
+			return err
+		}
+	}
+	if v, ok := objmap["transport_ip"]; ok {
+		if err := json.Unmarshal(v, &o.TransportIP); err != nil {
+			return err
+		}
+	}
+	if v, ok := objmap["transport_hash"]; ok {
+		if err := json.Unmarshal(v, &o.TransportHash); err != nil {
+			return err
+		}
+	}
 	if err := json.Unmarshal(objmap["timestamp"], &o.Timestamp); err != nil {
 		return err
 	}

--- a/pkg/message/flowspec_test.go
+++ b/pkg/message/flowspec_test.go
@@ -17,6 +17,31 @@ import (
 	"github.com/sbezverk/gobmp/pkg/vpls"
 )
 
+// Distinct transport vs local identity values used across flowspec producer tests.
+// transportIP = TCP source IP; localIP = BGP local peering address (router_ip/router_hash).
+const (
+	fsTransportIP   = "192.0.2.1"
+	fsTransportHash = "d0f88d6c87767262ba8e93d6acccd784" // md5(192.0.2.1)
+	fsLocalIP       = "10.0.0.10"
+	fsLocalHash     = "9e1a9a3663f25a297ed16a834b473eb0" // md5(10.0.0.10)
+)
+
+// fsProducer returns a producer configured with distinct transport and local
+// identity values for the table key used by minimalPeerHeader().
+func fsProducer() *producer {
+	return &producer{
+		transportIP:   fsTransportIP,
+		transportHash: fsTransportHash,
+		tableProperties: map[string]PerTableProperties{
+			"10.0.0.10:0": {
+				addPathCapable: make(map[int]bool),
+				localIP:        fsLocalIP,
+				localHash:      fsLocalHash,
+			},
+		},
+	}
+}
+
 func TestFlowspecUnmarshalJSON_PrefixSpec(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -224,7 +249,7 @@ func parseOneNLRI(t *testing.T) *flowspec.NLRI {
 func TestFlowspecProducer_AddSingleNLRI(t *testing.T) {
 	nlri := parseOneNLRI(t)
 	mock := &flowspecMockNLRI{allNLRI: []*flowspec.NLRI{nlri}}
-	p := &producer{speakerIP: "10.1.1.1"}
+	p := fsProducer()
 
 	msgs, err := p.flowspec(mock, 0, minimalPeerHeader(), minimalUpdate())
 	if err != nil {
@@ -245,8 +270,17 @@ func TestFlowspecProducer_AddSingleNLRI(t *testing.T) {
 	if msgs[0].PeerIP != "10.0.0.1" {
 		t.Errorf("PeerIP = %q, want %q", msgs[0].PeerIP, "10.0.0.1")
 	}
-	if msgs[0].RouterIP != "10.1.1.1" {
-		t.Errorf("RouterIP = %q, want %q", msgs[0].RouterIP, "10.1.1.1")
+	if msgs[0].RouterIP != fsLocalIP {
+		t.Errorf("RouterIP = %q, want %q", msgs[0].RouterIP, fsLocalIP)
+	}
+	if msgs[0].RouterHash != fsLocalHash {
+		t.Errorf("RouterHash = %q, want %q", msgs[0].RouterHash, fsLocalHash)
+	}
+	if msgs[0].TransportIP != fsTransportIP {
+		t.Errorf("TransportIP = %q, want %q", msgs[0].TransportIP, fsTransportIP)
+	}
+	if msgs[0].TransportHash != fsTransportHash {
+		t.Errorf("TransportHash = %q, want %q", msgs[0].TransportHash, fsTransportHash)
 	}
 	if !msgs[0].IsIPv4 {
 		t.Error("IsIPv4 should be true for IPv4 flowspec")
@@ -267,7 +301,7 @@ func TestFlowspecProducer_AddMultiNLRI(t *testing.T) {
 		t.Fatalf("failed to parse second NLRI: %v", err)
 	}
 	mock := &flowspecMockNLRI{allNLRI: []*flowspec.NLRI{nlri1, nlri2}}
-	p := &producer{speakerIP: "10.1.1.1"}
+	p := fsProducer()
 
 	msgs, err := p.flowspec(mock, 0, minimalPeerHeader(), minimalUpdate())
 	if err != nil {
@@ -290,7 +324,7 @@ func TestFlowspecProducer_WithdrawAll(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := &flowspecMockNLRI{allNLRI: nil, isIPv6: tt.isIPv6}
-			p := &producer{speakerIP: "10.1.1.1"}
+			p := fsProducer()
 
 			msgs, err := p.flowspec(mock, 1, minimalPeerHeader(), minimalUpdate())
 			if err != nil {
@@ -311,7 +345,7 @@ func TestFlowspecProducer_WithdrawAll(t *testing.T) {
 
 func TestFlowspecProducer_UnknownOp(t *testing.T) {
 	mock := &flowspecMockNLRI{}
-	p := &producer{speakerIP: "10.1.1.1"}
+	p := fsProducer()
 
 	_, err := p.flowspec(mock, 99, minimalPeerHeader(), minimalUpdate())
 	if err == nil {
@@ -321,7 +355,7 @@ func TestFlowspecProducer_UnknownOp(t *testing.T) {
 
 func TestFlowspecProducer_GetAllFlowspecNLRI_Error(t *testing.T) {
 	mock := &flowspecMockNLRI{err: errors.New("simulated parse failure")}
-	p := &producer{speakerIP: "10.1.1.1"}
+	p := fsProducer()
 
 	_, err := p.flowspec(mock, 0, minimalPeerHeader(), minimalUpdate())
 	if err == nil {

--- a/pkg/message/flowspec_test.go
+++ b/pkg/message/flowspec_test.go
@@ -484,3 +484,61 @@ func TestFlowspecUnmarshalJSON_NoRD(t *testing.T) {
 		t.Errorf("RD = %q, want empty for non-VPN flowspec", fs.RD)
 	}
 }
+
+// TestFlowspecUnmarshalJSON_IdentityFields validates that router_hash,
+// transport_ip, and transport_hash round-trip through UnmarshalJSON.
+func TestFlowspecUnmarshalJSON_IdentityFields(t *testing.T) {
+	obj := map[string]interface{}{
+		"action":          "add",
+		"spec_hash":       "abc123",
+		"base_attrs":      map[string]interface{}{},
+		"is_ipv4":         true,
+		"is_nexthop_ipv4": true,
+		"nexthop":         "10.0.0.1",
+		"peer_asn":        float64(65000),
+		"router_ip":       fsLocalIP,
+		"router_hash":     fsLocalHash,
+		"transport_ip":    fsTransportIP,
+		"transport_hash":  fsTransportHash,
+		"timestamp":       "2026-01-01T00:00:00Z",
+	}
+	b, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	fs := &Flowspec{}
+	if err := fs.UnmarshalJSON(b); err != nil {
+		t.Fatalf("UnmarshalJSON failed: %v", err)
+	}
+	if fs.RouterIP != fsLocalIP {
+		t.Errorf("RouterIP = %q, want %q", fs.RouterIP, fsLocalIP)
+	}
+	if fs.RouterHash != fsLocalHash {
+		t.Errorf("RouterHash = %q, want %q", fs.RouterHash, fsLocalHash)
+	}
+	if fs.TransportIP != fsTransportIP {
+		t.Errorf("TransportIP = %q, want %q", fs.TransportIP, fsTransportIP)
+	}
+	if fs.TransportHash != fsTransportHash {
+		t.Errorf("TransportHash = %q, want %q", fs.TransportHash, fsTransportHash)
+	}
+}
+
+// TestFlowspecUnmarshalJSON_IdentityFieldsAbsent validates that missing
+// router_hash/transport_* fields decode to empty strings without error.
+func TestFlowspecUnmarshalJSON_IdentityFieldsAbsent(t *testing.T) {
+	input := buildFlowspecJSON(t, nil)
+	fs := &Flowspec{}
+	if err := fs.UnmarshalJSON(input); err != nil {
+		t.Fatalf("UnmarshalJSON failed: %v", err)
+	}
+	if fs.RouterHash != "" {
+		t.Errorf("RouterHash = %q, want empty when absent", fs.RouterHash)
+	}
+	if fs.TransportIP != "" {
+		t.Errorf("TransportIP = %q, want empty when absent", fs.TransportIP)
+	}
+	if fs.TransportHash != "" {
+		t.Errorf("TransportHash = %q, want empty when absent", fs.TransportHash)
+	}
+}

--- a/pkg/message/l3-vpn.go
+++ b/pkg/message/l3-vpn.go
@@ -12,6 +12,7 @@ import (
 // l3vpn process MP_REACH_NLRI AFI 1/2 SAFI 128 update message and returns
 // L3VPN prefix object.
 func (p *producer) l3vpn(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *bgp.Update) ([]L3VPNPrefix, error) {
+	localIP, localHash := p.peerLocal(ph.GetTableKey())
 	nlril3vpn, err := nlri.GetNLRIL3VPN()
 	if err != nil {
 		return nil, err
@@ -30,8 +31,10 @@ func (p *producer) l3vpn(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update 
 	for _, e := range nlril3vpn.NLRI {
 		prfx := L3VPNPrefix{
 			Action:         operation,
-			RouterHash:     p.speakerHash,
-			RouterIP:       p.speakerIP,
+			RouterHash:     localHash,
+			RouterIP:       localIP,
+			TransportIP:    p.transportIP,
+			TransportHash:  p.transportHash,
 			PeerType:       uint8(ph.PeerType),
 			PeerHash:       ph.GetPeerHash(),
 			PeerASN:        ph.PeerAS,

--- a/pkg/message/ls-link.go
+++ b/pkg/message/ls-link.go
@@ -11,6 +11,7 @@ import (
 )
 
 func (p *producer) lsLink(link *base.LinkNLRI, nextHop string, op int, ph *bmp.PerPeerHeader, update *bgp.Update, isIPv6 bool) (*LSLink, error) {
+	localIP, localHash := p.peerLocal(ph.GetTableKey())
 	var operation string
 	switch op {
 	case 0:
@@ -21,14 +22,16 @@ func (p *producer) lsLink(link *base.LinkNLRI, nextHop string, op int, ph *bmp.P
 		return nil, fmt.Errorf("unknown operation %d", op)
 	}
 	msg := LSLink{
-		Action:     operation,
-		RouterHash: p.speakerHash,
-		RouterIP:   p.speakerIP,
-		PeerType:   uint8(ph.PeerType),
-		PeerHash:   ph.GetPeerHash(),
-		PeerASN:    ph.PeerAS,
-		Timestamp:  ph.GetPeerTimestamp(),
-		DomainID:   link.GetIdentifier(),
+		Action:        operation,
+		RouterHash:    localHash,
+		RouterIP:      localIP,
+		TransportIP:   p.transportIP,
+		TransportHash: p.transportHash,
+		PeerType:      uint8(ph.PeerType),
+		PeerHash:      ph.GetPeerHash(),
+		PeerASN:       ph.PeerAS,
+		Timestamp:     ph.GetPeerTimestamp(),
+		DomainID:      link.GetIdentifier(),
 	}
 	if f, err := ph.IsAdjRIBInPost(); err == nil {
 		msg.IsAdjRIBInPost = f

--- a/pkg/message/ls-node.go
+++ b/pkg/message/ls-node.go
@@ -10,6 +10,7 @@ import (
 
 func (p *producer) lsNode(node *base.NodeNLRI, _ /* place holder for the next hop */ string,
 	op int, ph *bmp.PerPeerHeader, update *bgp.Update, isIPv6 bool) (*LSNode, error) {
+	localIP, localHash := p.peerLocal(ph.GetTableKey())
 	var operation string
 	switch op {
 	case 0:
@@ -20,14 +21,16 @@ func (p *producer) lsNode(node *base.NodeNLRI, _ /* place holder for the next ho
 		return nil, fmt.Errorf("unknown operation %d", op)
 	}
 	msg := LSNode{
-		Action:     operation,
-		RouterHash: p.speakerHash,
-		RouterIP:   p.speakerIP,
-		PeerType:   uint8(ph.PeerType),
-		PeerHash:   ph.GetPeerHash(),
-		PeerASN:    ph.PeerAS,
-		Timestamp:  ph.GetPeerTimestamp(),
-		DomainID:   node.GetIdentifier(),
+		Action:        operation,
+		RouterHash:    localHash,
+		RouterIP:      localIP,
+		TransportIP:   p.transportIP,
+		TransportHash: p.transportHash,
+		PeerType:      uint8(ph.PeerType),
+		PeerHash:      ph.GetPeerHash(),
+		PeerASN:       ph.PeerAS,
+		Timestamp:     ph.GetPeerTimestamp(),
+		DomainID:      node.GetIdentifier(),
 	}
 	if f, err := ph.IsAdjRIBInPost(); err == nil {
 		msg.IsAdjRIBInPost = f

--- a/pkg/message/ls-prefix.go
+++ b/pkg/message/ls-prefix.go
@@ -10,6 +10,7 @@ import (
 )
 
 func (p *producer) lsPrefix(prfx *base.PrefixNLRI, nextHop string, op int, ph *bmp.PerPeerHeader, update *bgp.Update, ipv4 bool) (*LSPrefix, error) {
+	localIP, localHash := p.peerLocal(ph.GetTableKey())
 	var operation string
 	switch op {
 	case 0:
@@ -20,14 +21,16 @@ func (p *producer) lsPrefix(prfx *base.PrefixNLRI, nextHop string, op int, ph *b
 		return nil, fmt.Errorf("unknown operation %d", op)
 	}
 	msg := LSPrefix{
-		Action:     operation,
-		RouterHash: p.speakerHash,
-		RouterIP:   p.speakerIP,
-		PeerType:   uint8(ph.PeerType),
-		PeerHash:   ph.GetPeerHash(),
-		PeerASN:    ph.PeerAS,
-		Timestamp:  ph.GetPeerTimestamp(),
-		DomainID:   prfx.GetIdentifier(),
+		Action:        operation,
+		RouterHash:    localHash,
+		RouterIP:      localIP,
+		TransportIP:   p.transportIP,
+		TransportHash: p.transportHash,
+		PeerType:      uint8(ph.PeerType),
+		PeerHash:      ph.GetPeerHash(),
+		PeerASN:       ph.PeerAS,
+		Timestamp:     ph.GetPeerTimestamp(),
+		DomainID:      prfx.GetIdentifier(),
 	}
 	if f, err := ph.IsAdjRIBInPost(); err == nil {
 		msg.IsAdjRIBInPost = f

--- a/pkg/message/ls-srv6-sid.go
+++ b/pkg/message/ls-srv6-sid.go
@@ -9,6 +9,7 @@ import (
 )
 
 func (p *producer) lsSRv6SID(nlri6 *srv6.SIDNLRI, nextHop string, op int, ph *bmp.PerPeerHeader, update *bgp.Update) (*LSSRv6SID, error) {
+	localIP, localHash := p.peerLocal(ph.GetTableKey())
 	var operation string
 	switch op {
 	case 0:
@@ -19,14 +20,16 @@ func (p *producer) lsSRv6SID(nlri6 *srv6.SIDNLRI, nextHop string, op int, ph *bm
 		return nil, fmt.Errorf("unknown operation %d", op)
 	}
 	msg := LSSRv6SID{
-		Action:     operation,
-		RouterHash: p.speakerHash,
-		RouterIP:   p.speakerIP,
-		PeerType:   uint8(ph.PeerType),
-		PeerHash:   ph.GetPeerHash(),
-		PeerASN:    ph.PeerAS,
-		Timestamp:  ph.GetPeerTimestamp(),
-		DomainID:   nlri6.GetIdentifier(),
+		Action:        operation,
+		RouterHash:    localHash,
+		RouterIP:      localIP,
+		TransportIP:   p.transportIP,
+		TransportHash: p.transportHash,
+		PeerType:      uint8(ph.PeerType),
+		PeerHash:      ph.GetPeerHash(),
+		PeerASN:       ph.PeerAS,
+		Timestamp:     ph.GetPeerTimestamp(),
+		DomainID:      nlri6.GetIdentifier(),
 	}
 	if f, err := ph.IsAdjRIBInPost(); err == nil {
 		msg.IsAdjRIBInPost = f

--- a/pkg/message/mcastvpn.go
+++ b/pkg/message/mcastvpn.go
@@ -12,6 +12,7 @@ import (
 
 // mcastvpn processes MP_REACH_NLRI/MP_UNREACH_NLRI AFI 1/2 SAFI 5 (MCAST-VPN)
 func (p *producer) mcastvpn(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *bgp.Update) ([]*MCASTVPNPrefix, error) {
+	localIP, localHash := p.peerLocal(ph.GetTableKey())
 	var operation string
 	switch op {
 	case 0:
@@ -32,14 +33,16 @@ func (p *producer) mcastvpn(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, upda
 	if len(mcastvpnRoute.Route) == 0 {
 		return []*MCASTVPNPrefix{
 			{
-				Action:     operation,
-				RouterHash: p.speakerHash,
-				RouterIP:   p.speakerIP,
-				PeerHash:   ph.GetPeerHash(),
-				PeerASN:    ph.PeerAS,
-				Timestamp:  ph.GetPeerTimestamp(),
-				PeerType:   uint8(ph.PeerType),
-				IsEOR:      true,
+				Action:        operation,
+				RouterHash:    localHash,
+				RouterIP:      localIP,
+				TransportIP:   p.transportIP,
+				TransportHash: p.transportHash,
+				PeerHash:      ph.GetPeerHash(),
+				PeerASN:       ph.PeerAS,
+				Timestamp:     ph.GetPeerTimestamp(),
+				PeerType:      uint8(ph.PeerType),
+				IsEOR:         true,
 			},
 		}, nil
 	}
@@ -47,8 +50,10 @@ func (p *producer) mcastvpn(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, upda
 	for _, route := range mcastvpnRoute.Route {
 		prfx := &MCASTVPNPrefix{
 			Action:         operation,
-			RouterHash:     p.speakerHash,
-			RouterIP:       p.speakerIP,
+			RouterHash:     localHash,
+			RouterIP:       localIP,
+			TransportIP:    p.transportIP,
+			TransportHash:  p.transportHash,
 			PeerType:       uint8(ph.PeerType),
 			PeerHash:       ph.GetPeerHash(),
 			PeerASN:        ph.PeerAS,

--- a/pkg/message/message_handlers_test.go
+++ b/pkg/message/message_handlers_test.go
@@ -87,8 +87,6 @@ func TestUnicastPrefixEqual_Nil(t *testing.T) {
 // TestMVPN_RIBFlags_AllFive verifies MVPN handler extracts all 5 RIB flags.
 func TestMVPN_RIBFlags_AllFive(t *testing.T) {
 	p := NewProducer(&mockPublisher{}, false).(*producer)
-	p.speakerIP = "10.0.0.1"
-	p.speakerHash = "abc123"
 
 	// AdjRIBOut Post-Policy (O=1, L=1)
 	phAdjOut := makePeerHeader(t, bmp.PeerType0, 0x50)
@@ -141,8 +139,6 @@ func TestMVPN_RIBFlags_AllFive(t *testing.T) {
 // TestL3VPN_TableName verifies L3VPN handler sets TableName for LocRIB peers.
 func TestL3VPN_TableName(t *testing.T) {
 	p := NewProducer(&mockPublisher{}, false).(*producer)
-	p.speakerIP = "10.0.0.1"
-	p.speakerHash = "abc123"
 
 	phLocRIB := makePeerHeader(t, bmp.PeerType3, 0x00)
 
@@ -195,8 +191,6 @@ func TestL3VPN_TableName(t *testing.T) {
 // TestUnicast_TableName verifies unicast handler sets TableName for LocRIB peers.
 func TestUnicast_TableName(t *testing.T) {
 	p := NewProducer(&mockPublisher{}, false).(*producer)
-	p.speakerIP = "10.0.0.1"
-	p.speakerHash = "abc123"
 
 	phLocRIB := makePeerHeader(t, bmp.PeerType3, 0x00)
 
@@ -243,8 +237,6 @@ func TestUnicast_TableName(t *testing.T) {
 // TestBaseNLRI_TableName verifies legacy IPv4 NLRI handler sets TableName for LocRIB peers.
 func TestBaseNLRI_TableName(t *testing.T) {
 	p := NewProducer(&mockPublisher{}, false).(*producer)
-	p.speakerIP = "10.0.0.1"
-	p.speakerHash = "abc123"
 
 	phLocRIB := makePeerHeader(t, bmp.PeerType3, 0x00)
 
@@ -284,8 +276,6 @@ func TestBaseNLRI_TableName(t *testing.T) {
 // TestBaseNLRI_EoR verifies legacy IPv4 EoR debug logging path.
 func TestBaseNLRI_EoR(t *testing.T) {
 	p := NewProducer(&mockPublisher{}, false).(*producer)
-	p.speakerIP = "10.0.0.1"
-	p.speakerHash = "abc123"
 
 	ph := makePeerHeader(t, bmp.PeerType0, 0x00)
 	update := &bgp.Update{
@@ -308,8 +298,6 @@ func TestBaseNLRI_EoR(t *testing.T) {
 // TestMVPN_LocRIB_TableName verifies MVPN handler sets TableName for LocRIB peers.
 func TestMVPN_LocRIB_TableName(t *testing.T) {
 	p := NewProducer(&mockPublisher{}, false).(*producer)
-	p.speakerIP = "10.0.0.1"
-	p.speakerHash = "abc123"
 
 	phLocRIB := makePeerHeader(t, bmp.PeerType3, 0x00)
 
@@ -359,8 +347,6 @@ func TestMVPN_LocRIB_TableName(t *testing.T) {
 // TestProcessMPUpdate_L3VPN_EoR verifies L3VPN EoR is handled at debug level.
 func TestProcessMPUpdate_L3VPN_EoR(t *testing.T) {
 	p := NewProducer(&mockPublisher{}, false).(*producer)
-	p.speakerIP = "10.0.0.1"
-	p.speakerHash = "abc123"
 
 	ph := makePeerHeader(t, bmp.PeerType0, 0x00)
 	update := &bgp.Update{BaseAttributes: &bgp.BaseAttributes{}}
@@ -382,8 +368,6 @@ func TestProcessMPUpdate_L3VPN_EoR(t *testing.T) {
 // TestUnicast_EoR_RIBFlags verifies EoR messages carry RIB flags and IsIPv4.
 func TestUnicast_EoR_RIBFlags(t *testing.T) {
 	p := NewProducer(&mockPublisher{}, false).(*producer)
-	p.speakerIP = "10.0.0.1"
-	p.speakerHash = "abc123"
 
 	// AdjRIBOut Post-Policy (O=1, L=1) — flags byte 0x50
 	ph := makePeerHeader(t, bmp.PeerType0, 0x50)
@@ -419,8 +403,6 @@ func TestUnicast_EoR_RIBFlags(t *testing.T) {
 // TestUnicast_EoR_LocRIB verifies EoR sets TableName for LocRIB peers.
 func TestUnicast_EoR_LocRIB(t *testing.T) {
 	p := NewProducer(&mockPublisher{}, false).(*producer)
-	p.speakerIP = "10.0.0.1"
-	p.speakerHash = "abc123"
 
 	ph := makePeerHeader(t, bmp.PeerType3, 0x00)
 	tableKey := ph.GetPeerBGPIDString() + ph.GetPeerDistinguisherString()
@@ -462,8 +444,6 @@ func TestUnicast_EoR_LocRIB(t *testing.T) {
 // TestMVPN_EoR_RIBFlags verifies MVPN EoR messages carry RIB flags.
 func TestMVPN_EoR_RIBFlags(t *testing.T) {
 	p := NewProducer(&mockPublisher{}, false).(*producer)
-	p.speakerIP = "10.0.0.1"
-	p.speakerHash = "abc123"
 
 	// AdjRIBOut Post-Policy (O=1, L=1)
 	ph := makePeerHeader(t, bmp.PeerType0, 0x50)
@@ -504,8 +484,6 @@ func TestMVPN_EoR_RIBFlags(t *testing.T) {
 // TestProcessMPUpdate_UnknownAFISAFI verifies default case logs warning for unknown types.
 func TestProcessMPUpdate_UnknownAFISAFI(t *testing.T) {
 	p := NewProducer(&mockPublisher{}, false).(*producer)
-	p.speakerIP = "10.0.0.1"
-	p.speakerHash = "abc123"
 
 	ph := makePeerHeader(t, bmp.PeerType0, 0x00)
 	update := &bgp.Update{BaseAttributes: &bgp.BaseAttributes{}}

--- a/pkg/message/mp-multicast.go
+++ b/pkg/message/mp-multicast.go
@@ -11,6 +11,7 @@ import (
 
 // multicast process nlri 14 afi 1/2 safi 2 messages and generates MulticastPrefix messages
 func (p *producer) multicast(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *bgp.Update) ([]*MulticastPrefix, error) {
+	localIP, localHash := p.peerLocal(ph.GetTableKey())
 	var operation string
 	switch op {
 	case 0:
@@ -30,22 +31,26 @@ func (p *producer) multicast(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, upd
 	if len(u.NLRI) == 0 {
 		return []*MulticastPrefix{
 			{
-				Action:     operation,
-				RouterHash: p.speakerHash,
-				RouterIP:   p.speakerIP,
-				PeerHash:   ph.GetPeerHash(),
-				PeerASN:    ph.PeerAS,
-				Timestamp:  ph.GetPeerTimestamp(),
-				PeerType:   uint8(ph.PeerType),
-				IsEOR:      true,
+				Action:        operation,
+				RouterHash:    localHash,
+				RouterIP:      localIP,
+				TransportIP:   p.transportIP,
+				TransportHash: p.transportHash,
+				PeerHash:      ph.GetPeerHash(),
+				PeerASN:       ph.PeerAS,
+				Timestamp:     ph.GetPeerTimestamp(),
+				PeerType:      uint8(ph.PeerType),
+				IsEOR:         true,
 			},
 		}, nil
 	}
 	for _, e := range u.NLRI {
 		prfx := &MulticastPrefix{
 			Action:         operation,
-			RouterHash:     p.speakerHash,
-			RouterIP:       p.speakerIP,
+			RouterHash:     localHash,
+			RouterIP:       localIP,
+			TransportIP:    p.transportIP,
+			TransportHash:  p.transportHash,
 			PeerType:       uint8(ph.PeerType),
 			PeerHash:       ph.GetPeerHash(),
 			PeerASN:        ph.PeerAS,

--- a/pkg/message/mp-unicast.go
+++ b/pkg/message/mp-unicast.go
@@ -12,6 +12,7 @@ import (
 
 // unicast process nlri 14 afi 1/2 safi 1 messages and generates UnicastPrefix messages
 func (p *producer) unicast(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *bgp.Update, label bool) ([]*UnicastPrefix, error) {
+	localIP, localHash := p.peerLocal(ph.GetTableKey())
 	var err error
 	var operation string
 	switch op {
@@ -40,22 +41,26 @@ func (p *producer) unicast(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, updat
 	if len(u.NLRI) == 0 {
 		return []*UnicastPrefix{
 			{
-				Action:     operation,
-				RouterHash: p.speakerHash,
-				RouterIP:   p.speakerIP,
-				PeerHash:   ph.GetPeerHash(),
-				PeerASN:    ph.PeerAS,
-				Timestamp:  ph.GetPeerTimestamp(),
-				PeerType:   uint8(ph.PeerType),
-				IsEOR:      true,
+				Action:        operation,
+				RouterHash:    localHash,
+				RouterIP:      localIP,
+				TransportIP:   p.transportIP,
+				TransportHash: p.transportHash,
+				PeerHash:      ph.GetPeerHash(),
+				PeerASN:       ph.PeerAS,
+				Timestamp:     ph.GetPeerTimestamp(),
+				PeerType:      uint8(ph.PeerType),
+				IsEOR:         true,
 			},
 		}, nil
 	}
 	for _, e := range u.NLRI {
 		prfx := &UnicastPrefix{
 			Action:         operation,
-			RouterHash:     p.speakerHash,
-			RouterIP:       p.speakerIP,
+			RouterHash:     localHash,
+			RouterIP:       localIP,
+			TransportIP:    p.transportIP,
+			TransportHash:  p.transportHash,
 			PeerType:       uint8(ph.PeerType),
 			PeerHash:       ph.GetPeerHash(),
 			PeerASN:        ph.PeerAS,

--- a/pkg/message/mvpn.go
+++ b/pkg/message/mvpn.go
@@ -12,6 +12,7 @@ import (
 
 // mvpn processes MP_REACH_NLRI/MP_UNREACH_NLRI AFI 1/2 SAFI 129 (MVPN)
 func (p *producer) mvpn(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *bgp.Update) ([]*MVPNPrefix, error) {
+	localIP, localHash := p.peerLocal(ph.GetTableKey())
 	var operation string
 	switch op {
 	case 0:
@@ -32,14 +33,16 @@ func (p *producer) mvpn(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *
 	if len(mvpnRoute.Route) == 0 {
 		return []*MVPNPrefix{
 			{
-				Action:     operation,
-				RouterHash: p.speakerHash,
-				RouterIP:   p.speakerIP,
-				PeerHash:   ph.GetPeerHash(),
-				PeerASN:    ph.PeerAS,
-				Timestamp:  ph.GetPeerTimestamp(),
-				PeerType:   uint8(ph.PeerType),
-				IsEOR:      true,
+				Action:        operation,
+				RouterHash:    localHash,
+				RouterIP:      localIP,
+				TransportIP:   p.transportIP,
+				TransportHash: p.transportHash,
+				PeerHash:      ph.GetPeerHash(),
+				PeerASN:       ph.PeerAS,
+				Timestamp:     ph.GetPeerTimestamp(),
+				PeerType:      uint8(ph.PeerType),
+				IsEOR:         true,
 			},
 		}, nil
 	}
@@ -47,8 +50,10 @@ func (p *producer) mvpn(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *
 	for _, route := range mvpnRoute.Route {
 		prfx := &MVPNPrefix{
 			Action:         operation,
-			RouterHash:     p.speakerHash,
-			RouterIP:       p.speakerIP,
+			RouterHash:     localHash,
+			RouterIP:       localIP,
+			TransportIP:    p.transportIP,
+			TransportHash:  p.transportHash,
 			PeerType:       uint8(ph.PeerType),
 			PeerHash:       ph.GetPeerHash(),
 			PeerASN:        ph.PeerAS,

--- a/pkg/message/peer.go
+++ b/pkg/message/peer.go
@@ -57,12 +57,15 @@ func (p *producer) producePeerMessage(op int, msg bmp.Message) {
 		m.LocalBGPID = net.IP(peerUpMsg.SentOpen.BGPID).To4().String()
 		m.IsIPv4 = !msg.PeerHeader.IsRemotePeerIPv6()
 		m.LocalIP = peerUpMsg.GetLocalAddressString()
-		// Saving local bgp speaker identities.
+		localSum := md5.Sum([]byte(m.LocalIP))
+		m.LocalHash = hex.EncodeToString(localSum[:])
+		m.RouterIP = m.LocalIP
+		m.RouterHash = m.LocalHash
+		m.TransportIP = p.transportIP
+		m.TransportHash = p.transportHash
+		// Saving local bgp speaker identities for the speakerReady mechanism.
 		p.speakerIP = m.LocalIP
-		md5Sum := md5.Sum([]byte(p.speakerIP))
-		p.speakerHash = hex.EncodeToString(md5Sum[:])
-		m.RouterIP = p.speakerIP
-		m.RouterHash = p.speakerHash
+		p.speakerHash = m.LocalHash
 		// Signal all goroutines waiting in producingWorker that speakerIP is now
 		// populated.  sync.Once guarantees the channel is closed exactly once even
 		// if multiple PeerUp messages arrive (e.g. reconnections).
@@ -80,6 +83,8 @@ func (p *producer) producePeerMessage(op int, msg bmp.Message) {
 		p.tableLock.Lock()
 		ptp := PerTableProperties{
 			addPathCapable: make(map[int]bool),
+			localIP:        m.LocalIP,
+			localHash:      m.LocalHash,
 		}
 
 		// Check AddPath capability for this specific peer/table
@@ -116,15 +121,19 @@ func (p *producer) producePeerMessage(op int, msg bmp.Message) {
 			glog.Errorf("got invalid Payload type in bmp.Message")
 			return
 		}
+		// Fetch per-peer router identity before deleting table properties.
+		routerIP, routerHash := p.peerLocal(msg.PeerHeader.GetTableKey())
 		m = PeerStateChange{
-			Action:     "down",
-			RouterIP:   p.speakerIP,
-			PeerType:   uint8(msg.PeerHeader.PeerType),
-			RouterHash: p.speakerHash,
-			BMPReason:  int(peerDownMsg.Reason),
-			RemoteASN:  msg.PeerHeader.PeerAS,
-			PeerRD:     msg.PeerHeader.GetPeerDistinguisherString(),
-			Timestamp:  msg.PeerHeader.GetPeerTimestamp(),
+			Action:        "down",
+			RouterIP:      routerIP,
+			RouterHash:    routerHash,
+			TransportIP:   p.transportIP,
+			TransportHash: p.transportHash,
+			PeerType:      uint8(msg.PeerHeader.PeerType),
+			BMPReason:     int(peerDownMsg.Reason),
+			RemoteASN:     msg.PeerHeader.PeerAS,
+			PeerRD:        msg.PeerHeader.GetPeerDistinguisherString(),
+			Timestamp:     msg.PeerHeader.GetPeerTimestamp(),
 		}
 		m.RemoteIP = msg.PeerHeader.GetPeerAddrString()
 		m.RemoteBGPID = msg.PeerHeader.GetPeerBGPIDString()

--- a/pkg/message/peer.go
+++ b/pkg/message/peer.go
@@ -63,14 +63,6 @@ func (p *producer) producePeerMessage(op int, msg bmp.Message) {
 		m.RouterHash = m.LocalHash
 		m.TransportIP = p.transportIP
 		m.TransportHash = p.transportHash
-		// Saving local bgp speaker identities for the speakerReady mechanism.
-		p.speakerIP = m.LocalIP
-		p.speakerHash = m.LocalHash
-		// Signal all goroutines waiting in producingWorker that speakerIP is now
-		// populated.  sync.Once guarantees the channel is closed exactly once even
-		// if multiple PeerUp messages arrive (e.g. reconnections).
-		p.speakerReadyOnce.Do(func() { close(p.speakerReady) })
-
 		m.LocalASN = uint32(peerUpMsg.SentOpen.MyAS)
 		if lasn, ok := peerUpMsg.SentOpen.Is4BytesASCapable(); ok {
 			// Local BGP speaker is 4 bytes AS capable
@@ -103,9 +95,16 @@ func (p *producer) producePeerMessage(op int, msg bmp.Message) {
 		ptp.tableInfoTLVs = make([]bmp.InformationalTLV, len(peerUpMsg.Information))
 		copy(ptp.tableInfoTLVs, peerUpMsg.Information)
 
-		// Store properties for this table
+		// Store properties for this table before signalling speakerReady, so
+		// that RouteMonitor goroutines unblocked by the channel close below can
+		// immediately call peerLocal() and find the entry.
 		p.tableProperties[msg.PeerHeader.GetTableKey()] = ptp
 		p.tableLock.Unlock()
+
+		// Signal all goroutines waiting in producingWorker that the table entry
+		// is now populated.  sync.Once guarantees the channel is closed exactly
+		// once even if multiple PeerUp messages arrive (e.g. reconnections).
+		p.speakerReadyOnce.Do(func() { close(p.speakerReady) })
 
 		m.AdvCapabilities = peerUpMsg.SentOpen.GetCapabilities()
 		m.RcvCapabilities = peerUpMsg.ReceivedOpen.GetCapabilities()

--- a/pkg/message/peer.go
+++ b/pkg/message/peer.go
@@ -95,22 +95,20 @@ func (p *producer) producePeerMessage(op int, msg bmp.Message) {
 		ptp.tableInfoTLVs = make([]bmp.InformationalTLV, len(peerUpMsg.Information))
 		copy(ptp.tableInfoTLVs, peerUpMsg.Information)
 
-		// Store properties for this table before signalling speakerReady, so
-		// that RouteMonitor goroutines unblocked by the channel close below can
-		// immediately call peerLocal() and find the entry.
+		// Store properties for this table before signalling readiness, so that
+		// RouteMonitor goroutines unblocked by markTableReady can immediately
+		// call peerLocal() and find the entry.
 		p.tableProperties[msg.PeerHeader.GetTableKey()] = ptp
 		p.tableLock.Unlock()
 
-		// Signal all goroutines waiting in producingWorker that the table entry
-		// is now populated.  sync.Once guarantees the channel is closed exactly
-		// once even if multiple PeerUp messages arrive (e.g. reconnections).
-		p.speakerReadyOnce.Do(func() { close(p.speakerReady) })
+		// Signal goroutines waiting for this specific table's PeerUp to complete.
+		p.markTableReady(msg.PeerHeader.GetTableKey())
 
 		m.AdvCapabilities = peerUpMsg.SentOpen.GetCapabilities()
 		m.RcvCapabilities = peerUpMsg.ReceivedOpen.GetCapabilities()
 		if glog.V(6) {
-			glog.Infof("producer for speaker ip: %s table: %s add path: %+v",
-				p.speakerIP,
+			glog.Infof("producer for transport ip: %s table: %s add path: %+v",
+				p.transportIP,
 				msg.PeerHeader.GetTableKey(),
 				ptp.addPathCapable)
 		}
@@ -140,6 +138,9 @@ func (p *producer) producePeerMessage(op int, msg bmp.Message) {
 		m.InfoData = make([]byte, len(peerDownMsg.Data))
 		copy(m.InfoData, peerDownMsg.Data)
 
+		// Reset the per-table ready channel before deleting properties so the
+		// next session's goroutines wait for the new PeerUp.
+		p.resetTableReady(msg.PeerHeader.GetTableKey())
 		// Clean up table properties when peer goes down
 		// This prevents memory leaks and ensures stale data isn't used
 		p.tableLock.Lock()

--- a/pkg/message/producer.go
+++ b/pkg/message/producer.go
@@ -47,8 +47,8 @@ type producer struct {
 	publisher     pub.Publisher
 	transportIP   string
 	transportHash string
-	speakerIP   string
-	speakerHash string
+	speakerIP     string
+	speakerHash   string
 	// speakerReady is closed exactly once (by speakerReadyOnce) when the first
 	// PeerUp message has been processed and speakerIP/speakerHash are populated.
 	// RouteMonitor and StatsReport goroutines block here before reading speakerIP,

--- a/pkg/message/producer.go
+++ b/pkg/message/producer.go
@@ -3,6 +3,7 @@ package message
 import (
 	"crypto/md5"
 	"encoding/hex"
+	"fmt"
 	"sync"
 
 	"github.com/golang/glog"
@@ -22,6 +23,8 @@ const (
 type PerTableProperties struct {
 	addPathCapable map[int]bool
 	tableInfoTLVs  []bmp.InformationalTLV
+	localIP        string
+	localHash      string
 }
 
 // Config holds producer configuration options
@@ -29,6 +32,9 @@ type Config struct {
 	// AdminID is the collector identifier for RAW messages
 	// Used to generate collector hash for OpenBMP compatibility
 	AdminID string
+	// TransportIP is the TCP source IP of the BMP speaker. It is known at
+	// connection time and immutable for the lifetime of this producer.
+	TransportIP string
 }
 
 // Producer defines methods to act as a message producer
@@ -38,7 +44,9 @@ type Producer interface {
 }
 
 type producer struct {
-	publisher   pub.Publisher
+	publisher     pub.Publisher
+	transportIP   string
+	transportHash string
 	speakerIP   string
 	speakerHash string
 	// speakerReady is closed exactly once (by speakerReadyOnce) when the first
@@ -132,6 +140,17 @@ func (p *producer) SetConfig(config *Config) error {
 		p.adminHash = hex.EncodeToString(hash[:])
 	}
 
+	if config.TransportIP != "" {
+		if p.transportIP != "" && p.transportIP != config.TransportIP {
+			return fmt.Errorf("TransportIP is immutable: already set to %q, cannot change to %q", p.transportIP, config.TransportIP)
+		}
+		if p.transportIP == "" {
+			p.transportIP = config.TransportIP
+			hash := md5.Sum([]byte(config.TransportIP))
+			p.transportHash = hex.EncodeToString(hash[:])
+		}
+	}
+
 	return nil
 }
 
@@ -172,6 +191,18 @@ func (p *producer) GetTableName(bgpID, rd string) string {
 	}
 
 	return tn
+}
+
+// peerLocal returns the BGP local peering address and its hash for the given
+// table key. Returns empty strings if the peer is not yet known.
+func (p *producer) peerLocal(tableKey string) (localIP, localHash string) {
+	p.tableLock.RLock()
+	defer p.tableLock.RUnlock()
+	if props, ok := p.tableProperties[tableKey]; ok {
+		localIP = props.localIP
+		localHash = props.localHash
+	}
+	return
 }
 
 // NewProducer instantiates a new instance of a producer with Publisher interface

--- a/pkg/message/producer.go
+++ b/pkg/message/producer.go
@@ -16,6 +16,13 @@ const (
 	peerDown
 )
 
+// tableReadyEntry holds a readiness channel and a flag to prevent double-close
+// if duplicate PeerUp messages arrive for the same table key.
+type tableReadyEntry struct {
+	ch     chan struct{}
+	closed bool
+}
+
 // PerTableProperties holds per-VRF/per-table properties
 // Each VRF (identified by BGP-ID + Peer Distinguisher) has its own:
 // - AddPath capability map (per AFI/SAFI)
@@ -52,12 +59,14 @@ type producer struct {
 	// ready channels so they can exit cleanly if the producer is shut down before
 	// the relevant PeerUp arrives.
 	stopCh chan struct{}
-	// tableReady maps table keys to channels that are closed once the table's
-	// PeerUp goroutine has fully populated tableProperties for that key.
+	// tableReady maps table keys to per-table readiness entries.
+	// Each entry holds an open channel that is closed exactly once when the
+	// table's PeerUp goroutine has fully populated tableProperties. The closed
+	// flag prevents a double-close panic if duplicate PeerUp messages arrive.
 	// RouteMonitor and StatsReport goroutines block on the per-table channel
 	// rather than a single global channel, so a route burst for one VRF cannot
 	// be unblocked by a PeerUp for a different VRF.
-	tableReady     map[string]chan struct{}
+	tableReady     map[string]*tableReadyEntry
 	tableReadyLock sync.Mutex
 	// Per-VRF table properties tracking (replaces global addPathCapable)
 	// Key format: BGP-ID + Peer Distinguisher (e.g., "10.0.0.10:0")
@@ -78,36 +87,50 @@ type producer struct {
 func (p *producer) tableReadyCh(tableKey string) chan struct{} {
 	p.tableReadyLock.Lock()
 	defer p.tableReadyLock.Unlock()
-	if ch, ok := p.tableReady[tableKey]; ok {
-		return ch
+	if e, ok := p.tableReady[tableKey]; ok {
+		return e.ch
 	}
-	ch := make(chan struct{})
-	p.tableReady[tableKey] = ch
-	return ch
+	e := &tableReadyEntry{ch: make(chan struct{})}
+	p.tableReady[tableKey] = e
+	return e.ch
 }
 
 // markTableReady closes the per-table ready channel for tableKey, unblocking
 // any RouteMonitor/StatsReport goroutines waiting for that table's PeerUp.
 // Must be called after tableProperties[tableKey] has been written.
+// Safe to call multiple times for the same generation: duplicate PeerUp
+// messages are silently ignored after the first close.
 func (p *producer) markTableReady(tableKey string) {
 	p.tableReadyLock.Lock()
-	ch, ok := p.tableReady[tableKey]
+	e, ok := p.tableReady[tableKey]
 	if !ok {
-		ch = make(chan struct{})
-		p.tableReady[tableKey] = ch
+		e = &tableReadyEntry{ch: make(chan struct{})}
+		p.tableReady[tableKey] = e
+	}
+	if !e.closed {
+		e.closed = true
+		p.tableReadyLock.Unlock()
+		close(e.ch)
+		return
 	}
 	p.tableReadyLock.Unlock()
-	close(ch)
 }
 
-// resetTableReady replaces the per-table ready channel with a new open channel
-// so that goroutines for the next session wait for the next PeerUp rather than
-// passing through a stale closed channel. Called from PeerDown before
+// resetTableReady closes the current per-table channel (if not already closed)
+// to unblock any goroutines that are still waiting on it, then installs a new
+// open channel for the next PeerUp session. Called from PeerDown before
 // tableProperties is deleted.
 func (p *producer) resetTableReady(tableKey string) {
 	p.tableReadyLock.Lock()
 	defer p.tableReadyLock.Unlock()
-	p.tableReady[tableKey] = make(chan struct{})
+	if e, ok := p.tableReady[tableKey]; ok && !e.closed {
+		// Close the channel so goroutines blocked on this generation wake up.
+		// They will subsequently detect that tableProperties is gone and drop
+		// their message rather than emitting it with empty router identity.
+		e.closed = true
+		close(e.ch)
+	}
+	p.tableReady[tableKey] = &tableReadyEntry{ch: make(chan struct{})}
 }
 
 // Producer dispatches kafka workers upon request received from the channel
@@ -118,7 +141,18 @@ func (p *producer) Producer(queue chan bmp.Message, stop chan struct{}) {
 	for {
 		select {
 		case msg := <-queue:
-			go p.producingWorker(msg)
+			// Snapshot the per-table ready channel at dequeue time for
+			// RouteMonitor/StatsReport messages. This ensures the goroutine
+			// waits on the channel generation that was current when the message
+			// was received, not a newer one installed by a later PeerDown+PeerUp.
+			var readyCh chan struct{}
+			switch msg.Payload.(type) {
+			case *bmp.RouteMonitor, *bmp.StatsReport:
+				if msg.PeerHeader != nil {
+					readyCh = p.tableReadyCh(msg.PeerHeader.GetTableKey())
+				}
+			}
+			go p.producingWorker(msg, readyCh)
 		case <-stop:
 			glog.Infof("received interrupt, stopping.")
 			return
@@ -126,31 +160,39 @@ func (p *producer) Producer(queue chan bmp.Message, stop chan struct{}) {
 	}
 }
 
-func (p *producer) producingWorker(msg bmp.Message) {
+func (p *producer) producingWorker(msg bmp.Message, readyCh chan struct{}) {
 	switch obj := msg.Payload.(type) {
 	case *bmp.PeerUpMessage:
 		p.producePeerMessage(peerUP, msg)
 	case *bmp.PeerDownMessage:
 		p.producePeerMessage(peerDown, msg)
 	case *bmp.RouteMonitor:
-		// Wait until PeerUp for this specific table has populated tableProperties
-		// before producing any route message. Using a per-table channel ensures
-		// a route burst for one VRF cannot be unblocked by a PeerUp for a
-		// different VRF. After the channel is closed, receives are non-blocking.
-		if msg.PeerHeader != nil {
+		// Wait until PeerUp for this specific table has populated tableProperties.
+		// readyCh was snapshotted at dequeue time in Producer(), so we wait on
+		// the channel generation that was current when this message was received.
+		if readyCh != nil {
 			select {
-			case <-p.tableReadyCh(msg.PeerHeader.GetTableKey()):
+			case <-readyCh:
 			case <-p.stopCh:
+				return
+			}
+			// PeerDown may have woken us by closing the old channel before a new
+			// PeerUp arrived. If tableProperties is gone, drop the message rather
+			// than producing it with empty router identity.
+			if localIP, _ := p.peerLocal(msg.PeerHeader.GetTableKey()); localIP == "" {
 				return
 			}
 		}
 		p.produceRouteMonitorMessage(msg)
 	case *bmp.StatsReport:
-		// Same per-table wait as RouteMonitor above.
-		if msg.PeerHeader != nil {
+		// Same per-table wait and stale-table check as RouteMonitor above.
+		if readyCh != nil {
 			select {
-			case <-p.tableReadyCh(msg.PeerHeader.GetTableKey()):
+			case <-readyCh:
 			case <-p.stopCh:
+				return
+			}
+			if localIP, _ := p.peerLocal(msg.PeerHeader.GetTableKey()); localIP == "" {
 				return
 			}
 		}
@@ -248,6 +290,6 @@ func NewProducer(publisher pub.Publisher, splitAF bool) Producer {
 		publisher:       publisher,
 		splitAF:         splitAF,
 		tableProperties: make(map[string]PerTableProperties),
-		tableReady:      make(map[string]chan struct{}),
+		tableReady:      make(map[string]*tableReadyEntry),
 	}
 }

--- a/pkg/message/producer.go
+++ b/pkg/message/producer.go
@@ -47,20 +47,18 @@ type producer struct {
 	publisher     pub.Publisher
 	transportIP   string
 	transportHash string
-	speakerIP     string
-	speakerHash   string
-	// speakerReady is closed exactly once (by speakerReadyOnce) when the first
-	// PeerUp message has been processed and speakerIP/speakerHash are populated.
-	// RouteMonitor and StatsReport goroutines block here before reading speakerIP,
-	// eliminating the race against FRR's initial Loc-RIB burst in active mode.
-	// After the channel is closed, all subsequent receives are immediately non-blocking.
-	speakerReady     chan struct{}
-	speakerReadyOnce sync.Once
 	// stopCh is set to the stop channel passed to Producer() before the dispatch
-	// loop starts.  producingWorker goroutines select on it alongside speakerReady
-	// so they can exit cleanly if the producer is shut down before any PeerUp
-	// arrives (e.g. the connection drops before BGP session establishment).
+	// loop starts. producingWorker goroutines select on it alongside per-table
+	// ready channels so they can exit cleanly if the producer is shut down before
+	// the relevant PeerUp arrives.
 	stopCh chan struct{}
+	// tableReady maps table keys to channels that are closed once the table's
+	// PeerUp goroutine has fully populated tableProperties for that key.
+	// RouteMonitor and StatsReport goroutines block on the per-table channel
+	// rather than a single global channel, so a route burst for one VRF cannot
+	// be unblocked by a PeerUp for a different VRF.
+	tableReady     map[string]chan struct{}
+	tableReadyLock sync.Mutex
 	// Per-VRF table properties tracking (replaces global addPathCapable)
 	// Key format: BGP-ID + Peer Distinguisher (e.g., "10.0.0.10:0")
 	// Per RFC 9069 Section 4: uniquely identifies each Loc-RIB instance
@@ -74,9 +72,47 @@ type producer struct {
 	adminHash string
 }
 
+// tableReadyCh returns the ready channel for the given table key, creating it
+// if it does not yet exist. The returned channel is closed by markTableReady
+// once PeerUp for that table has fully populated tableProperties.
+func (p *producer) tableReadyCh(tableKey string) chan struct{} {
+	p.tableReadyLock.Lock()
+	defer p.tableReadyLock.Unlock()
+	if ch, ok := p.tableReady[tableKey]; ok {
+		return ch
+	}
+	ch := make(chan struct{})
+	p.tableReady[tableKey] = ch
+	return ch
+}
+
+// markTableReady closes the per-table ready channel for tableKey, unblocking
+// any RouteMonitor/StatsReport goroutines waiting for that table's PeerUp.
+// Must be called after tableProperties[tableKey] has been written.
+func (p *producer) markTableReady(tableKey string) {
+	p.tableReadyLock.Lock()
+	ch, ok := p.tableReady[tableKey]
+	if !ok {
+		ch = make(chan struct{})
+		p.tableReady[tableKey] = ch
+	}
+	p.tableReadyLock.Unlock()
+	close(ch)
+}
+
+// resetTableReady replaces the per-table ready channel with a new open channel
+// so that goroutines for the next session wait for the next PeerUp rather than
+// passing through a stale closed channel. Called from PeerDown before
+// tableProperties is deleted.
+func (p *producer) resetTableReady(tableKey string) {
+	p.tableReadyLock.Lock()
+	defer p.tableReadyLock.Unlock()
+	p.tableReady[tableKey] = make(chan struct{})
+}
+
 // Producer dispatches kafka workers upon request received from the channel
 func (p *producer) Producer(queue chan bmp.Message, stop chan struct{}) {
-	// Store stop before spawning any goroutine.  The Go memory model guarantees
+	// Store stop before spawning any goroutine. The Go memory model guarantees
 	// that all goroutines created inside the loop below observe this write.
 	p.stopCh = stop
 	for {
@@ -97,25 +133,26 @@ func (p *producer) producingWorker(msg bmp.Message) {
 	case *bmp.PeerDownMessage:
 		p.producePeerMessage(peerDown, msg)
 	case *bmp.RouteMonitor:
-		// Wait until PeerUp has populated speakerIP/speakerHash before producing
-		// any route message.  In active mode (gobmp dials the router) FRR floods
-		// its full Loc-RIB in a burst that races the PeerUp goroutine.  Blocking
-		// here costs nothing after the channel is closed: a closed-channel receive
-		// is a single no-op instruction with no lock or syscall involved.
-		// The stopCh arm handles the case where the connection is terminated before
-		// any PeerUp arrives, preventing these goroutines from leaking forever.
-		select {
-		case <-p.speakerReady:
-		case <-p.stopCh:
-			return
+		// Wait until PeerUp for this specific table has populated tableProperties
+		// before producing any route message. Using a per-table channel ensures
+		// a route burst for one VRF cannot be unblocked by a PeerUp for a
+		// different VRF. After the channel is closed, receives are non-blocking.
+		if msg.PeerHeader != nil {
+			select {
+			case <-p.tableReadyCh(msg.PeerHeader.GetTableKey()):
+			case <-p.stopCh:
+				return
+			}
 		}
 		p.produceRouteMonitorMessage(msg)
 	case *bmp.StatsReport:
-		// Same cancellable wait as RouteMonitor above.
-		select {
-		case <-p.speakerReady:
-		case <-p.stopCh:
-			return
+		// Same per-table wait as RouteMonitor above.
+		if msg.PeerHeader != nil {
+			select {
+			case <-p.tableReadyCh(msg.PeerHeader.GetTableKey()):
+			case <-p.stopCh:
+				return
+			}
 		}
 		p.produceStatsMessage(msg)
 	case *bmp.RawMessage:
@@ -211,6 +248,6 @@ func NewProducer(publisher pub.Publisher, splitAF bool) Producer {
 		publisher:       publisher,
 		splitAF:         splitAF,
 		tableProperties: make(map[string]PerTableProperties),
-		speakerReady:    make(chan struct{}),
+		tableReady:      make(map[string]chan struct{}),
 	}
 }

--- a/pkg/message/router_identity_test.go
+++ b/pkg/message/router_identity_test.go
@@ -1,0 +1,132 @@
+package message
+
+import (
+	"crypto/md5"
+	"fmt"
+	"testing"
+)
+
+// TestTransportIPSetAtConstruction verifies that transport_ip/transport_hash are
+// set once at construction time via SetConfig and remain immutable.
+func TestTransportIPSetAtConstruction(t *testing.T) {
+	mockPub := &mockPublisher{}
+	p := NewProducer(mockPub, false).(*producer)
+
+	transportIP := "192.0.2.1"
+	if err := p.SetConfig(&Config{TransportIP: transportIP}); err != nil {
+		t.Fatalf("SetConfig() error: %v", err)
+	}
+
+	if p.transportIP != transportIP {
+		t.Errorf("transportIP = %v, want %v", p.transportIP, transportIP)
+	}
+	wantHash := fmt.Sprintf("%x", md5.Sum([]byte(transportIP)))
+	if p.transportHash != wantHash {
+		t.Errorf("transportHash = %v, want %v", p.transportHash, wantHash)
+	}
+}
+
+// TestPeerLocalPerTable verifies that router_ip/router_hash (BGP local address) are
+// stored and retrieved per-peer, so multiple BGP peers on a single BMP session
+// each return their own local peering address.
+func TestPeerLocalPerTable(t *testing.T) {
+	mockPub := &mockPublisher{}
+	p := NewProducer(mockPub, false).(*producer)
+
+	peer1Key := "10.0.0.10:0"
+	peer1LocalIP := "192.0.2.10"
+
+	peer2Key := "10.0.0.11:65000:100"
+	peer2LocalIP := "172.16.0.1"
+
+	p.tableLock.Lock()
+	p.tableProperties[peer1Key] = PerTableProperties{
+		addPathCapable: make(map[int]bool),
+		localIP:        peer1LocalIP,
+		localHash:      fmt.Sprintf("%x", md5.Sum([]byte(peer1LocalIP))),
+	}
+	p.tableProperties[peer2Key] = PerTableProperties{
+		addPathCapable: make(map[int]bool),
+		localIP:        peer2LocalIP,
+		localHash:      fmt.Sprintf("%x", md5.Sum([]byte(peer2LocalIP))),
+	}
+	p.tableLock.Unlock()
+
+	got1IP, got1Hash := p.peerLocal(peer1Key)
+	if got1IP != peer1LocalIP {
+		t.Errorf("peer1 localIP = %v, want %v", got1IP, peer1LocalIP)
+	}
+	want1Hash := fmt.Sprintf("%x", md5.Sum([]byte(peer1LocalIP)))
+	if got1Hash != want1Hash {
+		t.Errorf("peer1 localHash = %v, want %v", got1Hash, want1Hash)
+	}
+
+	got2IP, got2Hash := p.peerLocal(peer2Key)
+	if got2IP != peer2LocalIP {
+		t.Errorf("peer2 localIP = %v, want %v", got2IP, peer2LocalIP)
+	}
+	want2Hash := fmt.Sprintf("%x", md5.Sum([]byte(peer2LocalIP)))
+	if got2Hash != want2Hash {
+		t.Errorf("peer2 localHash = %v, want %v", got2Hash, want2Hash)
+	}
+
+	// Verify peers are independent
+	if got1IP == got2IP {
+		t.Errorf("peer1 and peer2 should have different local IPs, both got %v", got1IP)
+	}
+}
+
+// TestPeerLocalUnknownTable verifies that peerLocal returns empty strings when
+// no PeerUp has been received for the given table key.
+func TestPeerLocalUnknownTable(t *testing.T) {
+	mockPub := &mockPublisher{}
+	p := NewProducer(mockPub, false).(*producer)
+
+	localIP, localHash := p.peerLocal("nonexistent-table-key")
+	if localIP != "" {
+		t.Errorf("expected empty localIP for unknown table, got %q", localIP)
+	}
+	if localHash != "" {
+		t.Errorf("expected empty localHash for unknown table, got %q", localHash)
+	}
+}
+
+// TestPeerLocalClearedOnPeerDown verifies that local_ip/local_hash are no longer
+// available after the table entry is removed (simulating PeerDown cleanup).
+func TestPeerLocalClearedOnPeerDown(t *testing.T) {
+	mockPub := &mockPublisher{}
+	p := NewProducer(mockPub, false).(*producer)
+
+	tableKey := "10.0.0.10:0"
+	localIP := "192.0.2.10"
+
+	// Simulate PeerUp
+	p.tableLock.Lock()
+	p.tableProperties[tableKey] = PerTableProperties{
+		addPathCapable: make(map[int]bool),
+		localIP:        localIP,
+		localHash:      fmt.Sprintf("%x", md5.Sum([]byte(localIP))),
+	}
+	p.tableLock.Unlock()
+
+	gotIP, gotHash := p.peerLocal(tableKey)
+	if gotIP != localIP {
+		t.Errorf("before PeerDown: localIP = %v, want %v", gotIP, localIP)
+	}
+	if gotHash == "" {
+		t.Errorf("before PeerDown: localHash should not be empty")
+	}
+
+	// Simulate PeerDown cleanup
+	p.tableLock.Lock()
+	delete(p.tableProperties, tableKey)
+	p.tableLock.Unlock()
+
+	gotIP, gotHash = p.peerLocal(tableKey)
+	if gotIP != "" {
+		t.Errorf("after PeerDown: localIP = %v, want empty", gotIP)
+	}
+	if gotHash != "" {
+		t.Errorf("after PeerDown: localHash = %v, want empty", gotHash)
+	}
+}

--- a/pkg/message/rtc.go
+++ b/pkg/message/rtc.go
@@ -10,6 +10,7 @@ import (
 
 // rtc processes MP_REACH_NLRI/MP_UNREACH_NLRI AFI 1/2 SAFI 132 (Route Target Constraint)
 func (p *producer) rtc(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *bgp.Update) ([]*RTCPrefix, error) {
+	localIP, localHash := p.peerLocal(ph.GetTableKey())
 	var operation string
 	switch op {
 	case 0:
@@ -30,14 +31,16 @@ func (p *producer) rtc(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *b
 	if len(rtcRoute.NLRI) == 0 {
 		return []*RTCPrefix{
 			{
-				Action:     operation,
-				RouterHash: p.speakerHash,
-				RouterIP:   p.speakerIP,
-				PeerHash:   ph.GetPeerHash(),
-				PeerASN:    ph.PeerAS,
-				Timestamp:  ph.GetPeerTimestamp(),
-				PeerType:   uint8(ph.PeerType),
-				IsEOR:      true,
+				Action:        operation,
+				RouterHash:    localHash,
+				RouterIP:      localIP,
+				TransportIP:   p.transportIP,
+				TransportHash: p.transportHash,
+				PeerHash:      ph.GetPeerHash(),
+				PeerASN:       ph.PeerAS,
+				Timestamp:     ph.GetPeerTimestamp(),
+				PeerType:      uint8(ph.PeerType),
+				IsEOR:         true,
 			},
 		}, nil
 	}
@@ -45,8 +48,10 @@ func (p *producer) rtc(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *b
 	for _, e := range rtcRoute.NLRI {
 		prfx := &RTCPrefix{
 			Action:         operation,
-			RouterHash:     p.speakerHash,
-			RouterIP:       p.speakerIP,
+			RouterHash:     localHash,
+			RouterIP:       localIP,
+			TransportIP:    p.transportIP,
+			TransportHash:  p.transportHash,
 			PeerType:       uint8(ph.PeerType),
 			PeerHash:       ph.GetPeerHash(),
 			PeerASN:        ph.PeerAS,

--- a/pkg/message/srpolicy.go
+++ b/pkg/message/srpolicy.go
@@ -8,9 +8,10 @@ import (
 	"github.com/sbezverk/gobmp/pkg/srpolicy"
 )
 
-// evpn process MP_REACH_NLRI AFI 25 SAFI 70 update message and returns
-// EVPN prefix object.
+// srpolicy processes MP_REACH_NLRI AFI 1 SAFI 73 update messages and returns
+// SR Policy prefix objects per draft-ietf-idr-segment-routing-te-policy.
 func (p *producer) srpolicy(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *bgp.Update) ([]*SRPolicy, error) {
+	localIP, localHash := p.peerLocal(ph.GetTableKey())
 	sr, err := nlri.GetNLRI73()
 	if err != nil {
 		return nil, err
@@ -26,8 +27,10 @@ func (p *producer) srpolicy(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, upda
 	}
 	prfx := SRPolicy{
 		Action:         operation,
-		RouterHash:     p.speakerHash,
-		RouterIP:       p.speakerIP,
+		RouterHash:     localHash,
+		RouterIP:       localIP,
+		TransportIP:    p.transportIP,
+		TransportHash:  p.transportHash,
 		PeerType:       uint8(ph.PeerType),
 		PeerHash:       ph.GetPeerHash(),
 		PeerASN:        ph.PeerAS,

--- a/pkg/message/types.go
+++ b/pkg/message/types.go
@@ -36,6 +36,9 @@ type PeerStateChange struct {
 	RemotePort      int            `json:"remote_port,omitempty"`
 	LocalASN        uint32         `json:"local_asn,omitempty"`
 	LocalIP         string         `json:"local_ip,omitempty"`
+	LocalHash       string         `json:"local_hash,omitempty"`
+	TransportIP     string         `json:"transport_ip,omitempty"`
+	TransportHash   string         `json:"transport_hash,omitempty"`
 	LocalPort       int            `json:"local_port,omitempty"`
 	LocalBGPID      string         `json:"local_bgp_id,omitempty"`
 	InfoData        []byte         `json:"info_data,omitempty"`
@@ -70,6 +73,8 @@ type UnicastPrefix struct {
 	Hash             string              `json:"hash,omitempty"`
 	RouterHash       string              `json:"router_hash,omitempty"`
 	RouterIP         string              `json:"router_ip,omitempty"`
+	TransportIP      string              `json:"transport_ip,omitempty"`
+	TransportHash    string              `json:"transport_hash,omitempty"`
 	BaseAttributes   *bgp.BaseAttributes `json:"base_attrs,omitempty"`
 	PeerHash         string              `json:"peer_hash,omitempty"`
 	PeerIP           string              `json:"peer_ip,omitempty"`
@@ -212,6 +217,8 @@ type LSNode struct {
 	RouterHash          string                          `json:"router_hash,omitempty"`
 	DomainID            int64                           `json:"domain_id"`
 	RouterIP            string                          `json:"router_ip,omitempty"`
+	TransportIP         string                          `json:"transport_ip,omitempty"`
+	TransportHash       string                          `json:"transport_hash,omitempty"`
 	PeerHash            string                          `json:"peer_hash,omitempty"`
 	PeerIP              string                          `json:"peer_ip,omitempty"`
 	PeerType            uint8                           `json:"peer_type"`
@@ -252,6 +259,8 @@ type LSLink struct {
 	Hash                  string                        `json:"hash,omitempty"`
 	RouterHash            string                        `json:"router_hash,omitempty"`
 	RouterIP              string                        `json:"router_ip,omitempty"`
+	TransportIP           string                        `json:"transport_ip,omitempty"`
+	TransportHash         string                        `json:"transport_hash,omitempty"`
 	DomainID              int64                         `json:"domain_id"`
 	PeerHash              string                        `json:"peer_hash,omitempty"`
 	PeerIP                string                        `json:"peer_ip,omitempty"`
@@ -327,6 +336,8 @@ type MulticastPrefix struct {
 	Hash           string              `json:"hash,omitempty"`
 	RouterHash     string              `json:"router_hash,omitempty"`
 	RouterIP       string              `json:"router_ip,omitempty"`
+	TransportIP    string              `json:"transport_ip,omitempty"`
+	TransportHash  string              `json:"transport_hash,omitempty"`
 	BaseAttributes *bgp.BaseAttributes `json:"base_attrs,omitempty"`
 	PeerHash       string              `json:"peer_hash,omitempty"`
 	PeerIP         string              `json:"peer_ip,omitempty"`
@@ -361,6 +372,8 @@ type MCASTVPNPrefix struct {
 	Hash            string              `json:"hash,omitempty"`
 	RouterHash      string              `json:"router_hash,omitempty"`
 	RouterIP        string              `json:"router_ip,omitempty"`
+	TransportIP     string              `json:"transport_ip,omitempty"`
+	TransportHash   string              `json:"transport_hash,omitempty"`
 	BaseAttributes  *bgp.BaseAttributes `json:"base_attrs,omitempty"`
 	PeerHash        string              `json:"peer_hash,omitempty"`
 	PeerIP          string              `json:"peer_ip,omitempty"`
@@ -401,6 +414,8 @@ type RTCPrefix struct {
 	Hash           string              `json:"hash,omitempty"`
 	RouterHash     string              `json:"router_hash,omitempty"`
 	RouterIP       string              `json:"router_ip,omitempty"`
+	TransportIP    string              `json:"transport_ip,omitempty"`
+	TransportHash  string              `json:"transport_hash,omitempty"`
 	BaseAttributes *bgp.BaseAttributes `json:"base_attrs,omitempty"`
 	PeerHash       string              `json:"peer_hash,omitempty"`
 	PeerIP         string              `json:"peer_ip,omitempty"`
@@ -431,6 +446,8 @@ type L3VPNPrefix struct {
 	Hash             string              `json:"hash,omitempty"`
 	RouterHash       string              `json:"router_hash,omitempty"`
 	RouterIP         string              `json:"router_ip,omitempty"`
+	TransportIP      string              `json:"transport_ip,omitempty"`
+	TransportHash    string              `json:"transport_hash,omitempty"`
 	BaseAttributes   *bgp.BaseAttributes `json:"base_attrs,omitempty"`
 	PeerHash         string              `json:"peer_hash,omitempty"`
 	PeerIP           string              `json:"peer_ip,omitempty"`
@@ -469,6 +486,8 @@ type LSPrefix struct {
 	Hash                 string                        `json:"hash,omitempty"`
 	RouterHash           string                        `json:"router_hash,omitempty"`
 	RouterIP             string                        `json:"router_ip,omitempty"`
+	TransportIP          string                        `json:"transport_ip,omitempty"`
+	TransportHash        string                        `json:"transport_hash,omitempty"`
 	DomainID             int64                         `json:"domain_id"`
 	PeerHash             string                        `json:"peer_hash,omitempty"`
 	PeerIP               string                        `json:"peer_ip,omitempty"`
@@ -514,6 +533,8 @@ type LSSRv6SID struct {
 	Hash                 string                        `json:"hash,omitempty"`
 	RouterHash           string                        `json:"router_hash,omitempty"`
 	RouterIP             string                        `json:"router_ip,omitempty"`
+	TransportIP          string                        `json:"transport_ip,omitempty"`
+	TransportHash        string                        `json:"transport_hash,omitempty"`
 	DomainID             int64                         `json:"domain_id"`
 	PeerHash             string                        `json:"peer_hash,omitempty"`
 	PeerIP               string                        `json:"peer_ip,omitempty"`
@@ -560,6 +581,8 @@ type EVPNPrefix struct {
 	Hash           string              `json:"hash,omitempty"`
 	RouterHash     string              `json:"router_hash,omitempty"`
 	RouterIP       string              `json:"router_ip,omitempty"`
+	TransportIP    string              `json:"transport_ip,omitempty"`
+	TransportHash  string              `json:"transport_hash,omitempty"`
 	BaseAttributes *bgp.BaseAttributes `json:"base_attrs,omitempty"`
 	PeerHash       string              `json:"peer_hash,omitempty"`
 	RemoteBGPID    string              `json:"remote_bgp_id,omitempty"`
@@ -606,6 +629,8 @@ type VPLSPrefix struct {
 	Hash           string              `json:"hash,omitempty"`
 	RouterHash     string              `json:"router_hash,omitempty"`
 	RouterIP       string              `json:"router_ip,omitempty"`
+	TransportIP    string              `json:"transport_ip,omitempty"`
+	TransportHash  string              `json:"transport_hash,omitempty"`
 	BaseAttributes *bgp.BaseAttributes `json:"base_attrs,omitempty"`
 	PeerHash       string              `json:"peer_hash,omitempty"`
 	RemoteBGPID    string              `json:"remote_bgp_id,omitempty"`
@@ -660,6 +685,8 @@ type SRPolicy struct {
 	Hash           string                  `json:"hash,omitempty"`
 	RouterHash     string                  `json:"router_hash,omitempty"`
 	RouterIP       string                  `json:"router_ip,omitempty"`
+	TransportIP    string                  `json:"transport_ip,omitempty"`
+	TransportHash  string                  `json:"transport_hash,omitempty"`
 	BaseAttributes *bgp.BaseAttributes     `json:"base_attrs,omitempty"`
 	PeerHash       string                  `json:"peer_hash,omitempty"`
 	PeerIP         string                  `json:"peer_ip,omitempty"`
@@ -692,14 +719,17 @@ type SRPolicy struct {
 	TableName        string `json:"table_name,omitempty"` // RFC 9069 Table Name for LocRIB
 }
 
-// Flowspec defines the structure of SR Policy message
+// Flowspec defines the structure of a FlowSpec message (AFI 1/2, SAFI 133)
 type Flowspec struct {
 	Key            string              `json:"_key,omitempty"`
 	ID             string              `json:"_id,omitempty"`
 	Rev            string              `json:"_rev,omitempty"`
 	Action         string              `json:"action,omitempty"` // Action can be "add" or "del"
 	Sequence       int                 `json:"sequence,omitempty"`
+	RouterHash     string              `json:"router_hash,omitempty"`
 	RouterIP       string              `json:"router_ip,omitempty"`
+	TransportIP    string              `json:"transport_ip,omitempty"`
+	TransportHash  string              `json:"transport_hash,omitempty"`
 	BaseAttributes *bgp.BaseAttributes `json:"base_attrs,omitempty"`
 	PeerIP         string              `json:"peer_ip,omitempty"`
 	PeerType       uint8               `json:"peer_type"`
@@ -737,6 +767,8 @@ type Stats struct {
 	Sequence                   int    `json:"sequence,omitempty"`
 	RouterHash                 string `json:"router_hash,omitempty"`
 	RouterIP                   string `json:"router_ip,omitempty"`
+	TransportIP                string `json:"transport_ip,omitempty"`
+	TransportHash              string `json:"transport_hash,omitempty"`
 	PeerType                   uint8  `json:"peer_type"`
 	RemoteBGPID                string `json:"remote_bgp_id,omitempty"`
 	RemoteASN                  uint32 `json:"remote_asn,omitempty"`

--- a/pkg/message/vpls.go
+++ b/pkg/message/vpls.go
@@ -12,6 +12,7 @@ import (
 // vpls process MP_REACH_NLRI AFI 25 SAFI 65 update message and returns
 // VPLS prefix object.
 func (p *producer) vpls(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *bgp.Update) ([]VPLSPrefix, error) {
+	localIP, localHash := p.peerLocal(ph.GetTableKey())
 	if glog.V(6) {
 		glog.Infof("All attributes in vpls update: %+v", update.GetAllAttributeID())
 	}
@@ -34,8 +35,10 @@ func (p *producer) vpls(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *
 		prfx := VPLSPrefix{
 			Action:         operation,
 			PeerType:       uint8(ph.PeerType),
-			RouterHash:     p.speakerHash,
-			RouterIP:       p.speakerIP,
+			RouterHash:     localHash,
+			RouterIP:       localIP,
+			TransportIP:    p.transportIP,
+			TransportHash:  p.transportHash,
 			PeerHash:       ph.GetPeerHash(),
 			PeerASN:        ph.PeerAS,
 			Timestamp:      ph.GetPeerTimestamp(),

--- a/pkg/message/vpls_test.go
+++ b/pkg/message/vpls_test.go
@@ -18,6 +18,15 @@ import (
 	"github.com/sbezverk/gobmp/pkg/vpls"
 )
 
+// Distinct transport vs local identity values used across VPLS tests.
+// transportIP = TCP source IP; localIP = BGP local peering address (router_ip).
+const (
+	vplsTransportIP   = "192.0.2.1"
+	vplsTransportHash = "d0f88d6c87767262ba8e93d6acccd784" // md5(192.0.2.1)
+	vplsLocalIP       = "10.0.0.10"
+	vplsLocalHash     = "9e1a9a3663f25a297ed16a834b473eb0" // md5(10.0.0.10)
+)
+
 // TestVPLSMessageProducer_RFC4761 tests VPLS message production for RFC 4761 format
 func TestVPLSMessageProducer_RFC4761(t *testing.T) {
 	// Create mock NLRI (RFC 4761 - 17 bytes)
@@ -71,10 +80,16 @@ func TestVPLSMessageProducer_RFC4761(t *testing.T) {
 		},
 	}
 
-	// Create producer
 	p := &producer{
-		speakerHash: "test-speaker-hash",
-		speakerIP:   "10.1.1.1",
+		transportIP:   vplsTransportIP,
+		transportHash: vplsTransportHash,
+		tableProperties: map[string]PerTableProperties{
+			"10.0.0.20:0": {
+				addPathCapable: make(map[int]bool),
+				localIP:        vplsLocalIP,
+				localHash:      vplsLocalHash,
+			},
+		},
 	}
 
 	// Call vpls producer
@@ -94,8 +109,17 @@ func TestVPLSMessageProducer_RFC4761(t *testing.T) {
 	if msg.Action != "add" {
 		t.Errorf("Action = %s, want add", msg.Action)
 	}
-	if msg.RouterHash != "test-speaker-hash" {
-		t.Errorf("RouterHash = %s, want test-speaker-hash", msg.RouterHash)
+	if msg.RouterIP != vplsLocalIP {
+		t.Errorf("RouterIP = %s, want %s", msg.RouterIP, vplsLocalIP)
+	}
+	if msg.RouterHash != vplsLocalHash {
+		t.Errorf("RouterHash = %s, want %s", msg.RouterHash, vplsLocalHash)
+	}
+	if msg.TransportIP != vplsTransportIP {
+		t.Errorf("TransportIP = %s, want %s", msg.TransportIP, vplsTransportIP)
+	}
+	if msg.TransportHash != vplsTransportHash {
+		t.Errorf("TransportHash = %s, want %s", msg.TransportHash, vplsTransportHash)
 	}
 	if msg.PeerASN != 65000 {
 		t.Errorf("PeerASN = %d, want 65000", msg.PeerASN)
@@ -186,9 +210,17 @@ func TestVPLSMessageProducer_RFC6074(t *testing.T) {
 		},
 	}
 
+	// Use distinct transport vs local values (same constants as RFC4761 test).
 	p := &producer{
-		speakerHash: "test-speaker-hash",
-		speakerIP:   "10.1.1.1",
+		transportIP:   vplsTransportIP,
+		transportHash: vplsTransportHash,
+		tableProperties: map[string]PerTableProperties{
+			"10.0.0.30:0": {
+				addPathCapable: make(map[int]bool),
+				localIP:        vplsLocalIP,
+				localHash:      vplsLocalHash,
+			},
+		},
 	}
 
 	msgs, err := p.vpls(mockNLRI, 0, peerHeader, update)


### PR DESCRIPTION
This is an attempt to add a transport_ip and transport_hash and all messages.  This will be based on the source IP of the BMP session (sometimes refered to as speaker_ip/speakerIP).