### PR TITLE
Handle IPv4-mapped-IPv6 next-hop in MP_REACH_NLRI

### DIFF
--- a/pkg/bgp/mp-reach-nlri.go
+++ b/pkg/bgp/mp-reach-nlri.go
@@ -44,12 +44,13 @@ func (mp *MPReachNLRI) IsIPv6NLRI() bool {
 	return mp.AddressFamilyID == 2
 }
 
-// IsNextHopIPv6 return true if the next hop is IPv6 address, otherwise it returns flase
+// IsNextHopIPv6 return true if the next hop is IPv6 address, otherwise it returns false.
+// A 16-byte next-hop that is an IPv4-mapped-IPv6 address (::ffff:x.x.x.x) is treated as IPv4.
 func (mp *MPReachNLRI) IsNextHopIPv6() bool {
 	// https://tools.ietf.org/id/draft-mishra-bess-ipv4nlri-ipv6nh-use-cases-00.html#rfc.section.3
 	switch mp.NextHopAddressLength {
 	case 16:
-		fallthrough
+		return net.IP(mp.NextHopAddress).To4() == nil
 	case 32:
 		fallthrough
 	case 24:
@@ -74,7 +75,10 @@ func (mp *MPReachNLRI) GetNextHop() string {
 		// RD (8 bytes) + IPv4
 		return net.IP(mp.NextHopAddress[8:]).To4().String()
 	case 16:
-		// IPv6
+		// IPv4-mapped-IPv6 (::ffff:x.x.x.x) → return IPv4 string
+		if v4 := net.IP(mp.NextHopAddress).To4(); v4 != nil {
+			return v4.String()
+		}
 		return net.IP(mp.NextHopAddress).To16().String()
 	case 24:
 		// RD (8 bytes) + IPv6

--- a/pkg/bgp/mp-reach-nlri.go
+++ b/pkg/bgp/mp-reach-nlri.go
@@ -44,7 +44,7 @@ func (mp *MPReachNLRI) IsIPv6NLRI() bool {
 	return mp.AddressFamilyID == 2
 }
 
-// IsNextHopIPv6 return true if the next hop is IPv6 address, otherwise it returns false.
+// IsNextHopIPv6 returns true if the next hop is an IPv6 address; otherwise, it returns false.
 // A 16-byte next-hop that is an IPv4-mapped-IPv6 address (::ffff:x.x.x.x) is treated as IPv4.
 func (mp *MPReachNLRI) IsNextHopIPv6() bool {
 	// https://tools.ietf.org/id/draft-mishra-bess-ipv4nlri-ipv6nh-use-cases-00.html#rfc.section.3

--- a/pkg/bgp/mp-reach-nlri.go
+++ b/pkg/bgp/mp-reach-nlri.go
@@ -45,9 +45,10 @@ func (mp *MPReachNLRI) IsIPv6NLRI() bool {
 }
 
 // IsNextHopIPv6 returns true if the next hop is an IPv6 address; otherwise, it returns false.
-// A 16-byte next-hop that is an IPv4-mapped-IPv6 address (::ffff:x.x.x.x) is treated as IPv4.
+// A 16-byte next-hop that is an IPv4-mapped-IPv6 address (::ffff:x.x.x.x per RFC 4291 §2.5.5.2)
+// is treated as IPv4.
 func (mp *MPReachNLRI) IsNextHopIPv6() bool {
-	// https://tools.ietf.org/id/draft-mishra-bess-ipv4nlri-ipv6nh-use-cases-00.html#rfc.section.3
+	// Per RFC 4291 §2.5.5.2 and draft-mishra-bess-ipv4nlri-ipv6nh-use-cases §3
 	switch mp.NextHopAddressLength {
 	case 16:
 		return net.IP(mp.NextHopAddress).To4() == nil
@@ -75,7 +76,7 @@ func (mp *MPReachNLRI) GetNextHop() string {
 		// RD (8 bytes) + IPv4
 		return net.IP(mp.NextHopAddress[8:]).To4().String()
 	case 16:
-		// IPv4-mapped-IPv6 (::ffff:x.x.x.x) → return IPv4 string
+		// IPv4-mapped-IPv6 (::ffff:x.x.x.x per RFC 4291 §2.5.5.2) → return IPv4 string
 		if v4 := net.IP(mp.NextHopAddress).To4(); v4 != nil {
 			return v4.String()
 		}

--- a/pkg/bgp/mp_reach_nlri_getters_test.go
+++ b/pkg/bgp/mp_reach_nlri_getters_test.go
@@ -101,23 +101,28 @@ func TestMPReachNLRI_IsIPv6NLRI(t *testing.T) {
 
 func TestMPReachNLRI_IsNextHopIPv6(t *testing.T) {
 	tests := []struct {
-		nhLen uint8
-		want  bool
+		name    string
+		nhLen   uint8
+		nhBytes []byte
+		want    bool
 	}{
-		{4, false},
-		{8, false},
-		{12, false},
-		{16, true},
-		{24, true},
-		{32, true},
-		{48, true},
-		{0, false},
+		{"IPv4 4-byte", 4, nil, false},
+		{"RD+IPv4 8-byte", 8, nil, false},
+		{"RD+IPv4 12-byte", 12, nil, false},
+		{"IPv6 16-byte", 16, []byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, true},
+		{"IPv4-mapped-IPv6 16-byte", 16, []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 168, 1, 1}, false},
+		{"RD+IPv6 24-byte", 24, nil, true},
+		{"IPv6+LL 32-byte", 32, nil, true},
+		{"RD+IPv6+LL 48-byte", 48, nil, true},
+		{"zero length", 0, nil, false},
 	}
 	for _, tt := range tests {
-		mp := &MPReachNLRI{NextHopAddressLength: tt.nhLen}
-		if got := mp.IsNextHopIPv6(); got != tt.want {
-			t.Errorf("IsNextHopIPv6() nhLen=%d = %v, want %v", tt.nhLen, got, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			mp := &MPReachNLRI{NextHopAddressLength: tt.nhLen, NextHopAddress: tt.nhBytes}
+			if got := mp.IsNextHopIPv6(); got != tt.want {
+				t.Errorf("IsNextHopIPv6() nhLen=%d = %v, want %v", tt.nhLen, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -155,6 +160,12 @@ func TestMPReachNLRI_GetNextHop(t *testing.T) {
 			nhLen:   16,
 			nhBytes: []byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 			want:    "2001:db8::1",
+		},
+		{
+			name:    "IPv4-mapped-IPv6 (len=16)",
+			nhLen:   16,
+			nhBytes: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 10, 0, 0, 1},
+			want:    "10.0.0.1",
 		},
 		{
 			name:  "RD+IPv6 (len=24)",


### PR DESCRIPTION
Detect IPv4-mapped-IPv6 (::ffff:x.x.x.x) in 16-byte next-hops.
GetNextHop() returns IPv4 string, IsNextHopIPv6() returns false.

Fixes Arista EOS sending 16-byte NH for IPv4 FlowSpec.