### PR TITLE
Fix message handler bugs: data race, EoR, RouterHash, Equal(), nexthop

### DIFF
--- a/pkg/message/flowspec.go
+++ b/pkg/message/flowspec.go
@@ -48,6 +48,7 @@ func (p *producer) flowspec(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, upda
 func (p *producer) buildFlowspecMessage(operation string, nlri bgp.MPNLRI, ph *bmp.PerPeerHeader, update *bgp.Update, fsnlri *flowspec.NLRI) *Flowspec {
 	fs := &Flowspec{
 		Action:         operation,
+		RouterHash:     p.speakerHash,
 		RouterIP:       p.speakerIP,
 		PeerType:       uint8(ph.PeerType),
 		PeerASN:        ph.PeerAS,

--- a/pkg/message/flowspec.go
+++ b/pkg/message/flowspec.go
@@ -133,6 +133,11 @@ func (fs *Flowspec) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(objmap["router_ip"], &o.RouterIP); err != nil {
 		return err
 	}
+	if rh, ok := objmap["router_hash"]; ok {
+		if err := json.Unmarshal(rh, &o.RouterHash); err != nil {
+			return err
+		}
+	}
 	if err := json.Unmarshal(objmap["timestamp"], &o.Timestamp); err != nil {
 		return err
 	}

--- a/pkg/message/flowspec_test.go
+++ b/pkg/message/flowspec_test.go
@@ -450,3 +450,33 @@ func TestFlowspecUnmarshalJSON_NoRD(t *testing.T) {
 		t.Errorf("RD = %q, want empty for non-VPN flowspec", fs.RD)
 	}
 }
+
+// TestFlowspec_RouterHash_RoundTrip verifies RouterHash survives JSON marshal/unmarshal.
+func TestFlowspec_RouterHash_RoundTrip(t *testing.T) {
+	orig := Flowspec{
+		Action:         "add",
+		RouterHash:     "deadbeef12345678",
+		RouterIP:       "10.0.0.1",
+		SpecHash:       "abc123",
+		IsIPv4:         true,
+		Nexthop:        "10.0.0.2",
+		PeerASN:        65000,
+		Timestamp:      "2026-01-01T00:00:00Z",
+		BaseAttributes: &bgp.BaseAttributes{},
+		IsNexthopIPv4:  true,
+	}
+	b, err := json.Marshal(&orig)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var got Flowspec
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.RouterHash != "deadbeef12345678" {
+		t.Errorf("RouterHash = %q, want %q", got.RouterHash, "deadbeef12345678")
+	}
+	if got.RouterIP != "10.0.0.1" {
+		t.Errorf("RouterIP = %q, want %q", got.RouterIP, "10.0.0.1")
+	}
+}

--- a/pkg/message/l3-vpn.go
+++ b/pkg/message/l3-vpn.go
@@ -1,22 +1,19 @@
 package message
 
 import (
+	"errors"
 	"fmt"
 	"net"
 
 	"github.com/golang/glog"
 	"github.com/sbezverk/gobmp/pkg/bgp"
 	"github.com/sbezverk/gobmp/pkg/bmp"
+	"github.com/sbezverk/gobmp/pkg/l3vpn"
 )
 
 // l3vpn process MP_REACH_NLRI AFI 1/2 SAFI 128 update message and returns
 // L3VPN prefix object.
 func (p *producer) l3vpn(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *bgp.Update) ([]L3VPNPrefix, error) {
-	nlril3vpn, err := nlri.GetNLRIL3VPN()
-	if err != nil {
-		return nil, err
-	}
-
 	var operation string
 	switch op {
 	case 0:
@@ -25,6 +22,46 @@ func (p *producer) l3vpn(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update 
 		operation = "del"
 	default:
 		return nil, fmt.Errorf("unknown operation %d", op)
+	}
+
+	nlril3vpn, err := nlri.GetNLRIL3VPN()
+	if errors.Is(err, l3vpn.ErrEmptyNLRI) {
+		// Empty NLRI signals End-of-RIB per RFC 4724 §2
+		prfx := L3VPNPrefix{
+			Action:     operation,
+			RouterHash: p.speakerHash,
+			RouterIP:   p.speakerIP,
+			PeerHash:   ph.GetPeerHash(),
+			PeerASN:    ph.PeerAS,
+			Timestamp:  ph.GetPeerTimestamp(),
+			PeerType:   uint8(ph.PeerType),
+			IsEOR:      true,
+			IsIPv4:     !nlri.IsIPv6NLRI(),
+		}
+		prfx.IsNexthopIPv4 = prfx.IsIPv4
+		prfx.PeerIP = ph.GetPeerAddrString()
+		if f, err := ph.IsAdjRIBInPost(); err == nil {
+			prfx.IsAdjRIBInPost = f
+		}
+		if f, err := ph.IsAdjRIBOutPost(); err == nil {
+			prfx.IsAdjRIBOutPost = f
+		}
+		if f, err := ph.IsAdjRIBOut(); err == nil {
+			prfx.IsAdjRIBOut = f
+		}
+		if f, err := ph.IsLocRIB(); err == nil {
+			prfx.IsLocRIB = f
+		}
+		if f, err := ph.IsLocRIBFiltered(); err == nil {
+			prfx.IsLocRIBFiltered = f
+		}
+		if prfx.IsLocRIB {
+			prfx.TableName = p.GetTableName(ph.GetPeerBGPIDString(), ph.GetPeerDistinguisherString())
+		}
+		return []L3VPNPrefix{prfx}, nil
+	}
+	if err != nil {
+		return nil, err
 	}
 	prfxs := make([]L3VPNPrefix, 0)
 	for _, e := range nlril3vpn.NLRI {

--- a/pkg/message/l3-vpn.go
+++ b/pkg/message/l3-vpn.go
@@ -26,9 +26,9 @@ func (p *producer) l3vpn(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update 
 
 	nlril3vpn, err := nlri.GetNLRIL3VPN()
 	if errors.Is(err, l3vpn.ErrEmptyNLRI) {
-		// Empty NLRI signals End-of-RIB per RFC 4724 §2
+		// Empty NLRI signals End-of-RIB per RFC 4724 §2 and is encoded as a withdrawal.
 		prfx := L3VPNPrefix{
-			Action:     operation,
+			Action:     "del",
 			RouterHash: p.speakerHash,
 			RouterIP:   p.speakerIP,
 			PeerHash:   ph.GetPeerHash(),

--- a/pkg/message/message_handler_fixes_test.go
+++ b/pkg/message/message_handler_fixes_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sbezverk/gobmp/pkg/bgp"
 	"github.com/sbezverk/gobmp/pkg/bmp"
 	"github.com/sbezverk/gobmp/pkg/l3vpn"
+	"github.com/sbezverk/gobmp/pkg/srpolicy"
 )
 
 // TestEqual_NilReceiver verifies Equal() does not panic on nil receiver (N10).
@@ -161,29 +162,26 @@ func TestSRPolicy_NexthopIPv4_IndependentOfAFI(t *testing.T) {
 		TunnelEncapAttr: nil,
 	}}
 
-	// IPv4 AFI but IPv6 nexthop
+	// IPv4 AFI with IPv6 nexthop
 	nlri := &mockMPNLRI{
-		isIPv6:         false, // IPv4 AFI
-		isNextHopIPv6_: true,  // but IPv6 nexthop
+		isIPv6:         false,
+		isNextHopIPv6_: true,
+		srpolicyRoute:  &srpolicy.NLRI73{Endpoint: []byte{10, 0, 0, 1}},
 	}
 
-	// We need a GetNLRI73 mock — srpolicy calls nlri.GetNLRI73()
-	// Since the mock returns nil, srpolicy will return an error.
-	// Instead, test the logic by calling srpolicy directly and checking the error message
-	// contains the expected behavior. Actually, let's just verify the mock field was
-	// used correctly by checking IsNextHopIPv6 returns the separate field.
-	if !nlri.IsNextHopIPv6() {
-		t.Fatal("mock IsNextHopIPv6() should return true")
+	msgs, err := p.srpolicy(nlri, 0, ph, update)
+	if err != nil {
+		t.Fatalf("srpolicy() error: %v", err)
 	}
-	if nlri.IsIPv6NLRI() {
-		t.Fatal("mock IsIPv6NLRI() should return false")
+	if len(msgs) != 1 {
+		t.Fatalf("srpolicy() returned %d messages, want 1", len(msgs))
 	}
-	// This confirms the mock separates AFI from nexthop correctly.
-	// The srpolicy.go fix uses nlri.IsNextHopIPv6() for IsNexthopIPv4,
-	// which is now decoupled from nlri.IsIPv6NLRI() for IsIPv4.
-	_ = p
-	_ = ph
-	_ = update
+	if !msgs[0].IsIPv4 {
+		t.Error("IsIPv4 = false, want true (IPv4 AFI)")
+	}
+	if msgs[0].IsNexthopIPv4 {
+		t.Error("IsNexthopIPv4 = true, want false (IPv6 nexthop with IPv4 AFI)")
+	}
 }
 
 // TestSpeakerIP_SetOnce verifies speakerIP/speakerHash are set exactly once
@@ -262,12 +260,9 @@ func parseIPv4(s string) []byte {
 	return result
 }
 
-// TestUnicast_ErrorContinuesPublishing verifies that a unicast error does not
-// prevent publishing of already-parsed messages (H2).
-func TestUnicast_ErrorContinuesPublishing(t *testing.T) {
-	// The fix changes `return` to continue-on-error in processMPUpdate.
-	// We verify the pattern: p.unicast returns partial results + error,
-	// and the caller still publishes the partial results.
+// TestUnicast_ValidNLRI_Publishes verifies a valid unicast NLRI produces a
+// message with correct fields, exercising the non-error publish path (H2).
+func TestUnicast_ValidNLRI_Publishes(t *testing.T) {
 	p := NewProducer(&mockPublisher{}, false).(*producer)
 	p.speakerIP = "10.0.0.1"
 	p.speakerHash = "abc123"
@@ -275,7 +270,6 @@ func TestUnicast_ErrorContinuesPublishing(t *testing.T) {
 	ph := makePeerHeader(t, bmp.PeerType0, 0x00)
 	update := &bgp.Update{BaseAttributes: &bgp.BaseAttributes{}}
 
-	// Build a valid unicast NLRI with one prefix
 	reachBytes := []byte{
 		0x00, 0x01, // AFI: 1
 		0x01,                   // SAFI: 1
@@ -291,12 +285,21 @@ func TestUnicast_ErrorContinuesPublishing(t *testing.T) {
 
 	msgs, err := p.unicast(nlri, 0, ph, update, false)
 	if err != nil {
-		// Even if there's an error, msgs should be usable
-		if msgs == nil {
-			t.Error("unicast() returned nil msgs on error — partial results should be preserved")
-		}
+		t.Fatalf("unicast() error: %v", err)
 	}
-
-	// Verify the caller (processMPUpdate) doesn't panic on partial results
-	p.processMPUpdate(nlri, 0, ph, update)
+	if len(msgs) != 1 {
+		t.Fatalf("unicast() returned %d messages, want 1", len(msgs))
+	}
+	if msgs[0].Prefix != "192.168.1.0" {
+		t.Errorf("Prefix = %q, want %q", msgs[0].Prefix, "192.168.1.0")
+	}
+	if msgs[0].PrefixLen != 24 {
+		t.Errorf("PrefixLen = %d, want 24", msgs[0].PrefixLen)
+	}
+	if !msgs[0].IsIPv4 {
+		t.Error("IsIPv4 = false, want true")
+	}
+	if msgs[0].RouterHash != "abc123" {
+		t.Errorf("RouterHash = %q, want %q", msgs[0].RouterHash, "abc123")
+	}
 }

--- a/pkg/message/message_handler_fixes_test.go
+++ b/pkg/message/message_handler_fixes_test.go
@@ -34,6 +34,29 @@ func TestEqual_NilReceiver(t *testing.T) {
 	}
 }
 
+// TestEqual_BaseAttributesNilMismatch verifies Equal() does not panic when one side
+// has BaseAttributes set and the other is nil.
+func TestEqual_BaseAttributesNilMismatch(t *testing.T) {
+	withAttrs := &UnicastPrefix{BaseAttributes: &bgp.BaseAttributes{}}
+	noAttrs := &UnicastPrefix{}
+
+	eq, diffs := withAttrs.Equal(noAttrs)
+	if eq {
+		t.Error("Equal() = true, want false when u has BaseAttributes but ou does not")
+	}
+	if len(diffs) == 0 {
+		t.Error("Equal() returned no diffs, want at least one")
+	}
+
+	eq, diffs = noAttrs.Equal(withAttrs)
+	if eq {
+		t.Error("Equal() = true, want false when u has no BaseAttributes but ou does")
+	}
+	if len(diffs) == 0 {
+		t.Error("Equal() returned no diffs, want at least one")
+	}
+}
+
 // TestFlowspec_RouterHash verifies flowspec messages include RouterHash (P3-20).
 func TestFlowspec_RouterHash(t *testing.T) {
 	p := NewProducer(&mockPublisher{}, false).(*producer)

--- a/pkg/message/message_handler_fixes_test.go
+++ b/pkg/message/message_handler_fixes_test.go
@@ -1,7 +1,7 @@
 package message
 
 import (
-	"fmt"
+	"net"
 	"testing"
 
 	"github.com/sbezverk/gobmp/pkg/bgp"
@@ -110,12 +110,15 @@ func TestL3VPN_EoR_LocRIB(t *testing.T) {
 		isIPv6:   false,
 	}
 
-	msgs, err := p.l3vpn(nlri, 0, ph, &bgp.Update{BaseAttributes: &bgp.BaseAttributes{}})
+	msgs, err := p.l3vpn(nlri, 1, ph, &bgp.Update{BaseAttributes: &bgp.BaseAttributes{}})
 	if err != nil {
 		t.Fatalf("l3vpn() error: %v", err)
 	}
 	if len(msgs) != 1 {
 		t.Fatalf("l3vpn() returned %d messages, want 1", len(msgs))
+	}
+	if msgs[0].Action != "del" {
+		t.Errorf("Action = %q, want \"del\"", msgs[0].Action)
 	}
 	if !msgs[0].IsLocRIB {
 		t.Error("IsLocRIB = false, want true")
@@ -138,12 +141,15 @@ func TestL3VPN_EoR_IPv6(t *testing.T) {
 		isIPv6:   true,
 	}
 
-	msgs, err := p.l3vpn(nlri, 0, ph, &bgp.Update{BaseAttributes: &bgp.BaseAttributes{}})
+	msgs, err := p.l3vpn(nlri, 1, ph, &bgp.Update{BaseAttributes: &bgp.BaseAttributes{}})
 	if err != nil {
 		t.Fatalf("l3vpn() error: %v", err)
 	}
 	if len(msgs) != 1 {
 		t.Fatalf("l3vpn() returned %d messages, want 1", len(msgs))
+	}
+	if msgs[0].Action != "del" {
+		t.Errorf("Action = %q, want \"del\"", msgs[0].Action)
 	}
 	if msgs[0].IsIPv4 {
 		t.Error("IsIPv4 = true, want false for IPv6")
@@ -164,9 +170,9 @@ func TestSRPolicy_NexthopIPv4_IndependentOfAFI(t *testing.T) {
 
 	// IPv4 AFI with IPv6 nexthop
 	nlri := &mockMPNLRI{
-		isIPv6:         false,
-		isNextHopIPv6_: true,
-		srpolicyRoute:  &srpolicy.NLRI73{Endpoint: []byte{10, 0, 0, 1}},
+		isIPv6:        false,
+		isNextHopIPv6: true,
+		srpolicyRoute: &srpolicy.NLRI73{Endpoint: []byte{10, 0, 0, 1}},
 	}
 
 	msgs, err := p.srpolicy(nlri, 0, ph, update)
@@ -233,7 +239,7 @@ func buildPeerUpMessage(t *testing.T, localIP string) *bmp.PeerUpMessage {
 	localAddr := make([]byte, 16)
 	ip := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff}
 	// Parse localIP as IPv4
-	parts := parseIPv4(localIP)
+	parts := parseIPv4(t, localIP)
 	ip = append(ip, parts...)
 	copy(localAddr, ip)
 
@@ -247,17 +253,13 @@ func buildPeerUpMessage(t *testing.T, localIP string) *bmp.PeerUpMessage {
 }
 
 // parseIPv4 parses a dotted-quad IPv4 into 4 bytes.
-func parseIPv4(s string) []byte {
-	result := make([]byte, 4)
-	var a, b, c, d int
-	n, _ := fmt.Sscanf(s, "%d.%d.%d.%d", &a, &b, &c, &d)
-	if n == 4 {
-		result[0] = byte(a)
-		result[1] = byte(b)
-		result[2] = byte(c)
-		result[3] = byte(d)
+func parseIPv4(t *testing.T, s string) []byte {
+	t.Helper()
+	ip := net.ParseIP(s).To4()
+	if ip == nil {
+		t.Fatalf("parseIPv4: invalid address %q", s)
 	}
-	return result
+	return []byte(ip)
 }
 
 // TestUnicast_ValidNLRI_Publishes verifies a valid unicast NLRI produces a

--- a/pkg/message/message_handler_fixes_test.go
+++ b/pkg/message/message_handler_fixes_test.go
@@ -1,0 +1,302 @@
+package message
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sbezverk/gobmp/pkg/bgp"
+	"github.com/sbezverk/gobmp/pkg/bmp"
+	"github.com/sbezverk/gobmp/pkg/l3vpn"
+)
+
+// TestEqual_NilReceiver verifies Equal() does not panic on nil receiver (N10).
+func TestEqual_NilReceiver(t *testing.T) {
+	var u *UnicastPrefix
+	nonNil := &UnicastPrefix{Prefix: "10.0.0.0"}
+
+	// nil.Equal(non-nil) should return false, not panic
+	eq, _ := u.Equal(nonNil)
+	if eq {
+		t.Error("nil.Equal(non-nil) = true, want false")
+	}
+
+	// nil.Equal(nil) should return true
+	eq, _ = u.Equal(nil)
+	if !eq {
+		t.Error("nil.Equal(nil) = false, want true")
+	}
+
+	// non-nil.Equal(nil) should return false
+	eq, _ = nonNil.Equal(nil)
+	if eq {
+		t.Error("non-nil.Equal(nil) = true, want false")
+	}
+}
+
+// TestFlowspec_RouterHash verifies flowspec messages include RouterHash (P3-20).
+func TestFlowspec_RouterHash(t *testing.T) {
+	p := NewProducer(&mockPublisher{}, false).(*producer)
+	p.speakerIP = "10.0.0.1"
+	p.speakerHash = "abcdef123456"
+
+	ph := makePeerHeader(t, bmp.PeerType0, 0x00)
+	update := &bgp.Update{BaseAttributes: &bgp.BaseAttributes{}}
+
+	// Build a flowspec message with nil NLRI (withdraw-all path)
+	fs := p.buildFlowspecMessage("del", &mockMPNLRI{isIPv6: false}, ph, update, nil)
+	if fs.RouterHash != "abcdef123456" {
+		t.Errorf("RouterHash = %q, want %q", fs.RouterHash, "abcdef123456")
+	}
+	if fs.RouterIP != "10.0.0.1" {
+		t.Errorf("RouterIP = %q, want %q", fs.RouterIP, "10.0.0.1")
+	}
+}
+
+// TestL3VPN_EoR verifies L3VPN produces an EoR message for empty NLRI (N6).
+func TestL3VPN_EoR(t *testing.T) {
+	p := NewProducer(&mockPublisher{}, false).(*producer)
+	p.speakerIP = "10.0.0.1"
+	p.speakerHash = "abc123"
+
+	ph := makePeerHeader(t, bmp.PeerType0, 0x00)
+
+	nlri := &mockMPNLRI{
+		l3vpnErr: l3vpn.ErrEmptyNLRI,
+		isIPv6:   false,
+	}
+
+	msgs, err := p.l3vpn(nlri, 1, ph, &bgp.Update{BaseAttributes: &bgp.BaseAttributes{}})
+	if err != nil {
+		t.Fatalf("l3vpn() error: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("l3vpn() returned %d messages, want 1", len(msgs))
+	}
+	r := msgs[0]
+	if !r.IsEOR {
+		t.Error("IsEOR = false, want true")
+	}
+	if r.Action != "del" {
+		t.Errorf("Action = %q, want %q", r.Action, "del")
+	}
+	if !r.IsIPv4 {
+		t.Error("IsIPv4 = false, want true for IPv4")
+	}
+	if r.RouterHash != "abc123" {
+		t.Errorf("RouterHash = %q, want %q", r.RouterHash, "abc123")
+	}
+}
+
+// TestL3VPN_EoR_LocRIB verifies L3VPN EoR sets TableName for LocRIB peers.
+func TestL3VPN_EoR_LocRIB(t *testing.T) {
+	p := NewProducer(&mockPublisher{}, false).(*producer)
+	p.speakerIP = "10.0.0.1"
+	p.speakerHash = "abc123"
+
+	ph := makePeerHeader(t, bmp.PeerType3, 0x00)
+	tableKey := ph.GetPeerBGPIDString() + ph.GetPeerDistinguisherString()
+	p.tableLock.Lock()
+	p.tableProperties[tableKey] = PerTableProperties{
+		addPathCapable: make(map[int]bool),
+		tableInfoTLVs: []bmp.InformationalTLV{
+			{InformationType: 3, Information: []byte("VRF-L3VPN-EoR")},
+		},
+	}
+	p.tableLock.Unlock()
+
+	nlri := &mockMPNLRI{
+		l3vpnErr: l3vpn.ErrEmptyNLRI,
+		isIPv6:   false,
+	}
+
+	msgs, err := p.l3vpn(nlri, 0, ph, &bgp.Update{BaseAttributes: &bgp.BaseAttributes{}})
+	if err != nil {
+		t.Fatalf("l3vpn() error: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("l3vpn() returned %d messages, want 1", len(msgs))
+	}
+	if !msgs[0].IsLocRIB {
+		t.Error("IsLocRIB = false, want true")
+	}
+	if msgs[0].TableName != "VRF-L3VPN-EoR" {
+		t.Errorf("TableName = %q, want %q", msgs[0].TableName, "VRF-L3VPN-EoR")
+	}
+}
+
+// TestL3VPN_EoR_IPv6 verifies L3VPN IPv6 EoR sets IsIPv4 = false.
+func TestL3VPN_EoR_IPv6(t *testing.T) {
+	p := NewProducer(&mockPublisher{}, false).(*producer)
+	p.speakerIP = "fd00::1"
+	p.speakerHash = "ipv6hash"
+
+	ph := makePeerHeader(t, bmp.PeerType0, 0x00)
+
+	nlri := &mockMPNLRI{
+		l3vpnErr: l3vpn.ErrEmptyNLRI,
+		isIPv6:   true,
+	}
+
+	msgs, err := p.l3vpn(nlri, 0, ph, &bgp.Update{BaseAttributes: &bgp.BaseAttributes{}})
+	if err != nil {
+		t.Fatalf("l3vpn() error: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("l3vpn() returned %d messages, want 1", len(msgs))
+	}
+	if msgs[0].IsIPv4 {
+		t.Error("IsIPv4 = true, want false for IPv6")
+	}
+}
+
+// TestSRPolicy_NexthopIPv4_IndependentOfAFI verifies IsNexthopIPv4 is derived
+// from actual nexthop, not from AFI (N21).
+func TestSRPolicy_NexthopIPv4_IndependentOfAFI(t *testing.T) {
+	p := NewProducer(&mockPublisher{}, false).(*producer)
+	p.speakerIP = "10.0.0.1"
+	p.speakerHash = "abc123"
+
+	ph := makePeerHeader(t, bmp.PeerType0, 0x00)
+	update := &bgp.Update{BaseAttributes: &bgp.BaseAttributes{
+		TunnelEncapAttr: nil,
+	}}
+
+	// IPv4 AFI but IPv6 nexthop
+	nlri := &mockMPNLRI{
+		isIPv6:         false, // IPv4 AFI
+		isNextHopIPv6_: true,  // but IPv6 nexthop
+	}
+
+	// We need a GetNLRI73 mock — srpolicy calls nlri.GetNLRI73()
+	// Since the mock returns nil, srpolicy will return an error.
+	// Instead, test the logic by calling srpolicy directly and checking the error message
+	// contains the expected behavior. Actually, let's just verify the mock field was
+	// used correctly by checking IsNextHopIPv6 returns the separate field.
+	if !nlri.IsNextHopIPv6() {
+		t.Fatal("mock IsNextHopIPv6() should return true")
+	}
+	if nlri.IsIPv6NLRI() {
+		t.Fatal("mock IsIPv6NLRI() should return false")
+	}
+	// This confirms the mock separates AFI from nexthop correctly.
+	// The srpolicy.go fix uses nlri.IsNextHopIPv6() for IsNexthopIPv4,
+	// which is now decoupled from nlri.IsIPv6NLRI() for IsIPv4.
+	_ = p
+	_ = ph
+	_ = update
+}
+
+// TestSpeakerIP_SetOnce verifies speakerIP/speakerHash are set exactly once
+// via sync.Once and subsequent PeerUp messages don't overwrite them (N8).
+func TestSpeakerIP_SetOnce(t *testing.T) {
+	p := NewProducer(&mockPublisher{}, false).(*producer)
+
+	// Build two PeerUp messages with different local IPs
+	peerUpMsg1 := buildPeerUpMessage(t, "192.168.1.1")
+	peerUpMsg2 := buildPeerUpMessage(t, "192.168.2.2")
+
+	ph := makePeerHeader(t, bmp.PeerType0, 0x00)
+
+	msg1 := bmp.Message{PeerHeader: ph, Payload: peerUpMsg1}
+	msg2 := bmp.Message{PeerHeader: ph, Payload: peerUpMsg2}
+
+	p.producePeerMessage(peerUP, msg1)
+
+	firstIP := p.speakerIP
+	firstHash := p.speakerHash
+
+	// Second PeerUp should NOT overwrite speakerIP
+	p.producePeerMessage(peerUP, msg2)
+
+	if p.speakerIP != firstIP {
+		t.Errorf("speakerIP changed from %q to %q after second PeerUp", firstIP, p.speakerIP)
+	}
+	if p.speakerHash != firstHash {
+		t.Errorf("speakerHash changed after second PeerUp")
+	}
+}
+
+// buildPeerUpMessage constructs a minimal PeerUpMessage for testing.
+func buildPeerUpMessage(t *testing.T, localIP string) *bmp.PeerUpMessage {
+	t.Helper()
+	// Build a minimal PeerUp with SentOpen and ReceivedOpen
+	sentOpen := bgp.OpenMessage{
+		Version:  4,
+		MyAS:     65000,
+		HoldTime: 90,
+		BGPID:    []byte{10, 0, 0, 1},
+	}
+	recvOpen := bgp.OpenMessage{
+		Version:  4,
+		MyAS:     65001,
+		HoldTime: 90,
+		BGPID:    []byte{10, 0, 0, 2},
+	}
+	localAddr := make([]byte, 16)
+	ip := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff}
+	// Parse localIP as IPv4
+	parts := parseIPv4(localIP)
+	ip = append(ip, parts...)
+	copy(localAddr, ip)
+
+	return &bmp.PeerUpMessage{
+		LocalAddress: localAddr,
+		LocalPort:    179,
+		RemotePort:   45678,
+		SentOpen:     &sentOpen,
+		ReceivedOpen: &recvOpen,
+	}
+}
+
+// parseIPv4 parses a dotted-quad IPv4 into 4 bytes.
+func parseIPv4(s string) []byte {
+	result := make([]byte, 4)
+	var a, b, c, d int
+	n, _ := fmt.Sscanf(s, "%d.%d.%d.%d", &a, &b, &c, &d)
+	if n == 4 {
+		result[0] = byte(a)
+		result[1] = byte(b)
+		result[2] = byte(c)
+		result[3] = byte(d)
+	}
+	return result
+}
+
+// TestUnicast_ErrorContinuesPublishing verifies that a unicast error does not
+// prevent publishing of already-parsed messages (H2).
+func TestUnicast_ErrorContinuesPublishing(t *testing.T) {
+	// The fix changes `return` to continue-on-error in processMPUpdate.
+	// We verify the pattern: p.unicast returns partial results + error,
+	// and the caller still publishes the partial results.
+	p := NewProducer(&mockPublisher{}, false).(*producer)
+	p.speakerIP = "10.0.0.1"
+	p.speakerHash = "abc123"
+
+	ph := makePeerHeader(t, bmp.PeerType0, 0x00)
+	update := &bgp.Update{BaseAttributes: &bgp.BaseAttributes{}}
+
+	// Build a valid unicast NLRI with one prefix
+	reachBytes := []byte{
+		0x00, 0x01, // AFI: 1
+		0x01,                   // SAFI: 1
+		0x04,                   // NH Length: 4
+		0x0a, 0x00, 0x00, 0x01, // NextHop
+		0x00,                   // Reserved
+		0x18, 0xc0, 0xa8, 0x01, // /24 prefix: 192.168.1.0/24
+	}
+	nlri, err := bgp.UnmarshalMPReachNLRI(reachBytes, false, map[int]bool{})
+	if err != nil {
+		t.Fatalf("UnmarshalMPReachNLRI: %v", err)
+	}
+
+	msgs, err := p.unicast(nlri, 0, ph, update, false)
+	if err != nil {
+		// Even if there's an error, msgs should be usable
+		if msgs == nil {
+			t.Error("unicast() returned nil msgs on error — partial results should be preserved")
+		}
+	}
+
+	// Verify the caller (processMPUpdate) doesn't panic on partial results
+	p.processMPUpdate(nlri, 0, ph, update)
+}

--- a/pkg/message/peer.go
+++ b/pkg/message/peer.go
@@ -57,16 +57,18 @@ func (p *producer) producePeerMessage(op int, msg bmp.Message) {
 		m.LocalBGPID = net.IP(peerUpMsg.SentOpen.BGPID).To4().String()
 		m.IsIPv4 = !msg.PeerHeader.IsRemotePeerIPv6()
 		m.LocalIP = peerUpMsg.GetLocalAddressString()
-		// Saving local bgp speaker identities.
-		p.speakerIP = m.LocalIP
-		md5Sum := md5.Sum([]byte(p.speakerIP))
-		p.speakerHash = hex.EncodeToString(md5Sum[:])
+		// Saving local bgp speaker identities inside sync.Once so the writes
+		// happen exactly once and happen-before the channel close.  After the
+		// first PeerUp the fields are immutable — no data race with readers
+		// that wait on speakerReady.
+		p.speakerReadyOnce.Do(func() {
+			p.speakerIP = m.LocalIP
+			md5Sum := md5.Sum([]byte(p.speakerIP))
+			p.speakerHash = hex.EncodeToString(md5Sum[:])
+			close(p.speakerReady)
+		})
 		m.RouterIP = p.speakerIP
 		m.RouterHash = p.speakerHash
-		// Signal all goroutines waiting in producingWorker that speakerIP is now
-		// populated.  sync.Once guarantees the channel is closed exactly once even
-		// if multiple PeerUp messages arrive (e.g. reconnections).
-		p.speakerReadyOnce.Do(func() { close(p.speakerReady) })
 
 		m.LocalASN = uint32(peerUpMsg.SentOpen.MyAS)
 		if lasn, ok := peerUpMsg.SentOpen.Is4BytesASCapable(); ok {

--- a/pkg/message/process-mp-update.go
+++ b/pkg/message/process-mp-update.go
@@ -1,7 +1,6 @@
 package message
 
 import (
-	"errors"
 	"strconv"
 	"strings"
 
@@ -9,7 +8,6 @@ import (
 	"github.com/sbezverk/gobmp/pkg/base"
 	"github.com/sbezverk/gobmp/pkg/bgp"
 	"github.com/sbezverk/gobmp/pkg/bmp"
-	"github.com/sbezverk/gobmp/pkg/l3vpn"
 	"github.com/sbezverk/gobmp/pkg/srv6"
 )
 
@@ -87,9 +85,8 @@ func (p *producer) processMPUpdate(nlri bgp.MPNLRI, operation int, ph *bmp.PerPe
 		msgs, err := p.unicast(nlri, operation, ph, update, labeled)
 		if err != nil {
 			glog.Errorf("failed to produce unicast messages with error: %+v", err)
-			return
 		}
-		// Loop through and publish all collected messages
+		// Publish whatever messages were successfully parsed (may be partial on error)
 		for _, m := range msgs {
 			// Extract Color EC for RFC 9723 CPR
 			m.Color = extractColorEC(update.BaseAttributes)
@@ -114,15 +111,7 @@ func (p *producer) processMPUpdate(nlri bgp.MPNLRI, operation int, ph *bmp.PerPe
 	case 19:
 		msgs, err := p.l3vpn(nlri, operation, ph, update)
 		if err != nil {
-			// L3VPN parser returns ErrEmptyNLRI for empty NLRI (EoR signal per RFC 4724 §2).
-			// Log at debug level for expected empty NLRI; error level for real failures.
-			if errors.Is(err, l3vpn.ErrEmptyNLRI) {
-				if glog.V(6) {
-					glog.Infof("L3VPN EoR: %v", err)
-				}
-			} else {
-				glog.Errorf("failed to produce l3vpn messages with error: %+v", err)
-			}
+			glog.Errorf("failed to produce l3vpn messages with error: %+v", err)
 			return
 		}
 		for _, m := range msgs {

--- a/pkg/message/srpolicy.go
+++ b/pkg/message/srpolicy.go
@@ -59,12 +59,8 @@ func (p *producer) srpolicy(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, upda
 		prfx.OriginAS = ases[len(ases)-1]
 	}
 	prfx.PeerIP = ph.GetPeerAddrString()
-	prfx.IsIPv4 = true
-	prfx.IsNexthopIPv4 = true
-	if nlri.IsIPv6NLRI() {
-		prfx.IsIPv4 = false
-		prfx.IsNexthopIPv4 = false
-	}
+	prfx.IsIPv4 = !nlri.IsIPv6NLRI()
+	prfx.IsNexthopIPv4 = !nlri.IsNextHopIPv6()
 	prfx.Distinguisher = sr.Distinguisher
 	prfx.Color = sr.Color
 	prfx.Endpoint = make([]byte, len(sr.Endpoint))

--- a/pkg/message/types.go
+++ b/pkg/message/types.go
@@ -98,6 +98,9 @@ type UnicastPrefix struct {
 }
 
 func (u *UnicastPrefix) Equal(ou *UnicastPrefix) (bool, []string) {
+	if u == nil {
+		return ou == nil, nil
+	}
 	if ou == nil {
 		return false, nil
 	}
@@ -462,6 +465,7 @@ type L3VPNPrefix struct {
 	VPNRD            string              `json:"vpn_rd,omitempty"`
 	VPNRDType        uint16              `json:"vpn_rd_type"`
 	PrefixSID        *prefixsid.PSid     `json:"prefix_sid,omitempty"`
+	IsEOR            bool                `json:"is_eor,omitempty"`
 	// Values are assigned based on PerPeerHeader flags
 	IsAdjRIBInPost   bool   `json:"is_adj_rib_in_post_policy"`
 	IsAdjRIBOutPost  bool   `json:"is_adj_rib_out_post_policy"`
@@ -711,6 +715,7 @@ type Flowspec struct {
 	Rev            string              `json:"_rev,omitempty"`
 	Action         string              `json:"action,omitempty"` // Action can be "add" or "del"
 	Sequence       int                 `json:"sequence,omitempty"`
+	RouterHash     string              `json:"router_hash,omitempty"`
 	RouterIP       string              `json:"router_ip,omitempty"`
 	BaseAttributes *bgp.BaseAttributes `json:"base_attrs,omitempty"`
 	PeerIP         string              `json:"peer_ip,omitempty"`

--- a/pkg/message/types.go
+++ b/pkg/message/types.go
@@ -114,10 +114,11 @@ func (u *UnicastPrefix) Equal(ou *UnicastPrefix) (bool, []string) {
 		if ou.BaseAttributes == nil {
 			equal = false
 			diffs = append(diffs, "bgp base attributes mismatch expected BGP BaseAttribute object is not nil, but received object is nil")
-		}
-		if eq, df := u.BaseAttributes.Equal(ou.BaseAttributes); !eq {
-			equal = false
-			diffs = append(diffs, df...)
+		} else {
+			if eq, df := u.BaseAttributes.Equal(ou.BaseAttributes); !eq {
+				equal = false
+				diffs = append(diffs, df...)
+			}
 		}
 	} else {
 		if ou.BaseAttributes != nil {

--- a/pkg/message/vpls_test.go
+++ b/pkg/message/vpls_test.go
@@ -312,15 +312,15 @@ func TestRoundTripVPLSPrefix(t *testing.T) {
 
 // mockMPNLRI implements bgp.MPNLRI interface for testing
 type mockMPNLRI struct {
-	vplsRoute      *vpls.Route
-	unicastRoute   *base.MPNLRI
-	l3vpnRoute     *base.MPNLRI
-	l3vpnErr       error
-	srpolicyRoute  *srpolicy.NLRI73
-	mvpnRoute      *mcastvpn.Route
-	nextHop        string
-	isIPv6         bool
-	isNextHopIPv6_ bool
+	vplsRoute     *vpls.Route
+	unicastRoute  *base.MPNLRI
+	l3vpnRoute    *base.MPNLRI
+	l3vpnErr      error
+	srpolicyRoute *srpolicy.NLRI73
+	mvpnRoute     *mcastvpn.Route
+	nextHop       string
+	isIPv6        bool
+	isNextHopIPv6 bool
 }
 
 func (m *mockMPNLRI) GetAFISAFIType() int {
@@ -340,7 +340,7 @@ func (m *mockMPNLRI) IsIPv6NLRI() bool {
 }
 
 func (m *mockMPNLRI) IsNextHopIPv6() bool {
-	return m.isNextHopIPv6_
+	return m.isNextHopIPv6
 }
 
 // Implement other required MPNLRI methods (not used in vpls tests)

--- a/pkg/message/vpls_test.go
+++ b/pkg/message/vpls_test.go
@@ -312,11 +312,14 @@ func TestRoundTripVPLSPrefix(t *testing.T) {
 
 // mockMPNLRI implements bgp.MPNLRI interface for testing
 type mockMPNLRI struct {
-	vplsRoute    *vpls.Route
-	unicastRoute *base.MPNLRI
-	mvpnRoute    *mcastvpn.Route
-	nextHop      string
-	isIPv6       bool
+	vplsRoute      *vpls.Route
+	unicastRoute   *base.MPNLRI
+	l3vpnRoute     *base.MPNLRI
+	l3vpnErr       error
+	mvpnRoute      *mcastvpn.Route
+	nextHop        string
+	isIPv6         bool
+	isNextHopIPv6_ bool
 }
 
 func (m *mockMPNLRI) GetAFISAFIType() int {
@@ -336,14 +339,14 @@ func (m *mockMPNLRI) IsIPv6NLRI() bool {
 }
 
 func (m *mockMPNLRI) IsNextHopIPv6() bool {
-	return m.isIPv6
+	return m.isNextHopIPv6_
 }
 
 // Implement other required MPNLRI methods (not used in vpls tests)
 func (m *mockMPNLRI) GetNLRILU() (*base.MPNLRI, error)              { return nil, nil }
 func (m *mockMPNLRI) GetNLRIUnicast() (*base.MPNLRI, error)         { return m.unicastRoute, nil }
 func (m *mockMPNLRI) GetNLRIEVPN() (*evpn.Route, error)             { return nil, nil }
-func (m *mockMPNLRI) GetNLRIL3VPN() (*base.MPNLRI, error)           { return nil, nil }
+func (m *mockMPNLRI) GetNLRIL3VPN() (*base.MPNLRI, error)           { return m.l3vpnRoute, m.l3vpnErr }
 func (m *mockMPNLRI) GetNLRI71() (*ls.NLRI71, error)                { return nil, nil }
 func (m *mockMPNLRI) GetNLRI73() (*srpolicy.NLRI73, error)          { return nil, nil }
 func (m *mockMPNLRI) GetFlowspecNLRI() (*flowspec.NLRI, error)      { return nil, nil }

--- a/pkg/message/vpls_test.go
+++ b/pkg/message/vpls_test.go
@@ -316,6 +316,7 @@ type mockMPNLRI struct {
 	unicastRoute   *base.MPNLRI
 	l3vpnRoute     *base.MPNLRI
 	l3vpnErr       error
+	srpolicyRoute  *srpolicy.NLRI73
 	mvpnRoute      *mcastvpn.Route
 	nextHop        string
 	isIPv6         bool
@@ -348,7 +349,7 @@ func (m *mockMPNLRI) GetNLRIUnicast() (*base.MPNLRI, error)         { return m.u
 func (m *mockMPNLRI) GetNLRIEVPN() (*evpn.Route, error)             { return nil, nil }
 func (m *mockMPNLRI) GetNLRIL3VPN() (*base.MPNLRI, error)           { return m.l3vpnRoute, m.l3vpnErr }
 func (m *mockMPNLRI) GetNLRI71() (*ls.NLRI71, error)                { return nil, nil }
-func (m *mockMPNLRI) GetNLRI73() (*srpolicy.NLRI73, error)          { return nil, nil }
+func (m *mockMPNLRI) GetNLRI73() (*srpolicy.NLRI73, error)          { return m.srpolicyRoute, nil }
 func (m *mockMPNLRI) GetFlowspecNLRI() (*flowspec.NLRI, error)      { return nil, nil }
 func (m *mockMPNLRI) GetAllFlowspecNLRI() ([]*flowspec.NLRI, error) { return nil, nil }
 func (m *mockMPNLRI) GetNLRIMCASTVPN() (*mcastvpn.Route, error)     { return nil, nil }


### PR DESCRIPTION
- Fix data race on speakerIP/speakerHash via sync.Once (N8)
- Add nil-receiver guard to UnicastPrefix.Equal() (N10)
- Add RouterHash field to Flowspec struct and builder (P3-20)
- Add L3VPN End-of-RIB handling per RFC 4724 §2 (N6)
- Derive SR Policy IsNexthopIPv4 from actual nexthop, not AFI (N21)
- Continue publishing partial unicast results on error (H2)