### PR TITLE
Fix BGP-LS bounds checks, segment list collision, and MarshalJSON

### DIFF
--- a/pkg/base/node-descriptor.go
+++ b/pkg/base/node-descriptor.go
@@ -24,7 +24,7 @@ type NodeDescriptor struct {
 	SubTLV map[uint16]TLV
 }
 
-// GetASN returns Autonomous System Number used to uniqely identify BGP-LS domain
+// GetASN returns Autonomous System Number used to uniquely identify BGP-LS domain
 func (nd *NodeDescriptor) GetASN() uint32 {
 	if tlv, ok := nd.SubTLV[512]; ok && len(tlv.Value) >= 4 {
 		return binary.BigEndian.Uint32(tlv.Value)

--- a/pkg/bgpls/bgpls-nlri.go
+++ b/pkg/bgpls/bgpls-nlri.go
@@ -472,6 +472,9 @@ func (ls *NLRI) GetMaxLinkBandwidthKbps() uint64 {
 		if tlv.Type != 1089 {
 			continue
 		}
+		if len(tlv.Value) < 4 {
+			continue
+		}
 		return uint64(math.Float32frombits(binary.BigEndian.Uint32(tlv.Value)) * 8 / 1000)
 	}
 
@@ -482,6 +485,9 @@ func (ls *NLRI) GetMaxLinkBandwidthKbps() uint64 {
 func (ls *NLRI) GetMaxReservableLinkBandwidthKbps() uint64 {
 	for _, tlv := range ls.LS {
 		if tlv.Type != 1090 {
+			continue
+		}
+		if len(tlv.Value) < 4 {
 			continue
 		}
 		return uint64(math.Float32frombits(binary.BigEndian.Uint32(tlv.Value)) * 8 / 1000)

--- a/pkg/bgpls/bgpls-srv6-policy-state.go
+++ b/pkg/bgpls/bgpls-srv6-policy-state.go
@@ -1400,21 +1400,25 @@ func UnmarshalSRSegment(b []byte) (SRSegmentListSubTLV, error) {
 // MarshalJSON serializes SRSegment into a slice of bytes
 func (s *SRSegment) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
-		Segment SegmentType `json:"segment_type"`
-		FlagS   bool        `json:"s_flag"`
-		FlagE   bool        `json:"e_flag"`
-		FlagV   bool        `json:"v_flag"`
-		FlagR   bool        `json:"r_flag"`
-		FlagA   bool        `json:"a_flag"`
-		SID     SID         `json:"sid"`
+		Segment           SegmentType                `json:"segment_type"`
+		FlagS             bool                       `json:"s_flag"`
+		FlagE             bool                       `json:"e_flag"`
+		FlagV             bool                       `json:"v_flag"`
+		FlagR             bool                       `json:"r_flag"`
+		FlagA             bool                       `json:"a_flag"`
+		SID               SID                        `json:"sid"`
+		SegmentDescriptor SegmentDescriptor          `json:"segment_descriptor,omitempty"`
+		SubTLV            map[uint16]SRSegmentSubTLV `json:"subtlv,omitempty"`
 	}{
-		Segment: s.Segment,
-		FlagS:   s.FlagS,
-		FlagE:   s.FlagE,
-		FlagV:   s.FlagV,
-		FlagR:   s.FlagR,
-		FlagA:   s.FlagA,
-		SID:     s.SID,
+		Segment:           s.Segment,
+		FlagS:             s.FlagS,
+		FlagE:             s.FlagE,
+		FlagV:             s.FlagV,
+		FlagR:             s.FlagR,
+		FlagA:             s.FlagA,
+		SID:               s.SID,
+		SegmentDescriptor: s.SegmentDescriptor,
+		SubTLV:            s.SubTLV,
 	})
 }
 

--- a/pkg/bgpls/bgpls-srv6-policy-state.go
+++ b/pkg/bgpls/bgpls-srv6-policy-state.go
@@ -246,7 +246,7 @@ func UnmarshalSRCandidatePathConstraintsSubTLV(b []byte) (map[uint16]SRCandidate
 	}
 	s := make(map[uint16]SRCandidatePathConstraintsSubTLV)
 	p := 0
-	for p < len(b) {
+	for p+4 <= len(b) {
 		t := binary.BigEndian.Uint16(b[p : p+2])
 		p += 2
 		l := binary.BigEndian.Uint16(b[p : p+2])
@@ -281,6 +281,9 @@ func UnmarshalSRCandidatePathConstraintsSubTLV(b []byte) (map[uint16]SRCandidate
 			s[SRDisjointGroupConstraintType] = stlv
 		}
 		p += int(l)
+	}
+	if p != len(b) {
+		return nil, fmt.Errorf("SR Candidate Path Constraints Sub TLV: %d trailing bytes", len(b)-p)
 	}
 
 	return s, nil
@@ -667,17 +670,17 @@ func UnmarshalSRSegmentListSubTLV(b []byte) ([]SRSegmentListSubTLV, error) {
 		glog.Infof("SR Segment List Sub TLV Raw: %s", tools.MessageHex(b))
 	}
 	if len(b) < 4 {
-		return nil, fmt.Errorf("not enough bytes to decode SR Segment List Sub TLV")
+		return nil, fmt.Errorf("not enough bytes to decode SR Segment List Sub TLV, need at least 4 bytes, have %d", len(b))
 	}
 	s := make([]SRSegmentListSubTLV, 0)
 	p := 0
-	for p < len(b) {
+	for p+4 <= len(b) {
 		t := binary.BigEndian.Uint16(b[p : p+2])
 		p += 2
 		l := binary.BigEndian.Uint16(b[p : p+2])
 		p += 2
 		if p+int(l) > len(b) {
-			return nil, fmt.Errorf("not enough bytes to decode SR Segment List Sub TLV")
+			return nil, fmt.Errorf("not enough bytes to decode SR Segment List Sub TLV value at offset %d, need %d bytes, have %d", p, l, len(b)-p)
 		}
 		switch t {
 		case SRSegmentType:
@@ -694,6 +697,9 @@ func UnmarshalSRSegmentListSubTLV(b []byte) ([]SRSegmentListSubTLV, error) {
 			s = append(s, stlv)
 		}
 		p += int(l)
+	}
+	if p != len(b) {
+		return nil, fmt.Errorf("SR Segment List Sub TLV: %d trailing bytes", len(b)-p)
 	}
 	return s, nil
 }
@@ -1214,11 +1220,11 @@ func UnmarshalSRSegmentSubTLV(b []byte) (map[uint16]SRSegmentSubTLV, error) {
 		glog.Infof("SR Segment Sub TLV Raw: %s", tools.MessageHex(b))
 	}
 	if len(b) < 4 {
-		return nil, fmt.Errorf("not enough bytes to decode SR Segment List Sub TLV")
+		return nil, fmt.Errorf("not enough bytes to decode SR Segment Sub TLV: need at least 4 bytes, have %d", len(b))
 	}
 	s := make(map[uint16]SRSegmentSubTLV)
 	p := 0
-	for p < len(b) {
+	for p+4 <= len(b) {
 		t := binary.BigEndian.Uint16(b[p : p+2])
 		p += 2
 		l := binary.BigEndian.Uint16(b[p : p+2])
@@ -1230,6 +1236,9 @@ func UnmarshalSRSegmentSubTLV(b []byte) (map[uint16]SRSegmentSubTLV, error) {
 		switch t {
 		}
 		p += int(l)
+	}
+	if p != len(b) {
+		return nil, fmt.Errorf("SR Segment Sub TLV: %d trailing bytes", len(b)-p)
 	}
 	return s, nil
 }

--- a/pkg/bgpls/bgpls-srv6-policy-state_test.go
+++ b/pkg/bgpls/bgpls-srv6-policy-state_test.go
@@ -10,7 +10,7 @@ func TestGetSRBindingSID(t *testing.T) {
 	// 4-byte flags+reserved + 4-byte MPLS SID (FlagD clear = MPLS, FlagU clear = PSID present)
 	// flags byte: FlagB set (0x40), FlagU clear → PSID present
 	// So: flags=0x40, reserved=0x00, reserved2=0x00,0x00, BSID=4 bytes, PSID=4 bytes → total 12 bytes
-	flags := byte(0x40) // FlagB set, FlagD clear (MPLS), FlagU clear
+	flags := byte(0x40)                         // FlagB set, FlagD clear (MPLS), FlagU clear
 	bsidLabel := []byte{0x00, 0x10, 0x00, 0x00} // label 16
 	psidLabel := []byte{0x00, 0x20, 0x00, 0x00} // label 32
 	value := append([]byte{flags, 0x00, 0x00, 0x00}, bsidLabel...)
@@ -48,10 +48,10 @@ func TestGetSRCandidatePathState(t *testing.T) {
 	// 8-byte fixed: priority(1), reserved(1), flags(1), flags2(1), preference(4)
 	// flags byte: FlagA (0x40), FlagV (0x08)
 	value := []byte{
-		0x05,       // Priority = 5
-		0x00,       // reserved
-		0x40 | 0x08, // FlagA=1, FlagV=1
-		0x00,       // flags2
+		0x05,                   // Priority = 5
+		0x00,                   // reserved
+		0x40 | 0x08,            // FlagA=1, FlagV=1
+		0x00,                   // flags2
 		0x00, 0x00, 0x00, 0x64, // Preference = 100
 	}
 
@@ -122,9 +122,9 @@ func TestGetSRCandidatePathConstraints(t *testing.T) {
 	// 8-byte fixed header: flags(1), reserved(1), MTID(2), algo(1), reserved(3)
 	// Byte 0 flags: FlagD=0x80
 	value := []byte{
-		0x80,             // FlagD=1
-		0x00,             // reserved
-		0x00, 0x00,       // MTID = 0
+		0x80,       // FlagD=1
+		0x00,       // reserved
+		0x00, 0x00, // MTID = 0
 		0x80,             // Algo = 128 (FlexAlgo 128)
 		0x00, 0x00, 0x00, // 3 reserved bytes
 	}
@@ -161,11 +161,11 @@ func TestGetSRSegmentList(t *testing.T) {
 	// 12-byte minimum: reserved(1), flags(1), flags2(1), reserved(1), MTID(2), Algo(1), reserved(1), Weight(4)
 	// flags byte at offset 1: all clear
 	value := []byte{
-		0x00,                   // reserved
-		0x00,                   // flags byte
-		0x00,                   // flags2 (FlagM)
-		0x00,                   // reserved
-		0x00, 0x00,             // MTID = 0
+		0x00,       // reserved
+		0x00,       // flags byte
+		0x00,       // flags2 (FlagM)
+		0x00,       // reserved
+		0x00, 0x00, // MTID = 0
 		0x00,                   // Algo = 0
 		0x00,                   // reserved
 		0x00, 0x00, 0x00, 0x0a, // Weight = 10
@@ -193,8 +193,8 @@ func TestGetSRSegmentList(t *testing.T) {
 func TestGetSRSegmentList_Multiple(t *testing.T) {
 	value := []byte{
 		0x00, 0x00, 0x00, 0x00, // reserved + flags
-		0x00, 0x00,             // MTID
-		0x00, 0x00,             // Algo + reserved
+		0x00, 0x00, // MTID
+		0x00, 0x00, // Algo + reserved
 		0x00, 0x00, 0x00, 0x05, // Weight = 5
 	}
 
@@ -851,8 +851,8 @@ func TestSRType8Descriptor_RoundTrip(t *testing.T) {
 // TestUnmarshalSRSegmentListMetric verifies parsing of a 16-byte Segment List Metric sub-TLV.
 func TestUnmarshalSRSegmentListMetric(t *testing.T) {
 	b := make([]byte, 16)
-	b[0] = 1       // SRMetricMinUnidirLinkDelay
-	b[1] = 0x80    // FlagM set
+	b[0] = 1                                  // SRMetricMinUnidirLinkDelay
+	b[1] = 0x80                               // FlagM set
 	binary.BigEndian.PutUint32(b[4:8], 100)   // Margin
 	binary.BigEndian.PutUint32(b[8:12], 200)  // Bound
 	binary.BigEndian.PutUint32(b[12:16], 300) // Value
@@ -899,6 +899,39 @@ func TestUnmarshalSRSegmentSubTLV_UnknownType(t *testing.T) {
 	}
 	if len(m) != 0 {
 		t.Errorf("map len = %d, want 0 for unknown type", len(m))
+	}
+}
+
+// TestUnmarshalSRCandidatePathConstraintsSubTLV_TrailingBytes verifies that extra bytes
+// following a complete sub-TLV are rejected.
+func TestUnmarshalSRCandidatePathConstraintsSubTLV_TrailingBytes(t *testing.T) {
+	// Unknown type (0xFFFF), length=0: 4-byte TLV + 2 trailing bytes.
+	b := []byte{0xFF, 0xFF, 0x00, 0x00, 0xAB, 0xCD}
+	_, err := UnmarshalSRCandidatePathConstraintsSubTLV(b)
+	if err == nil {
+		t.Error("expected error for trailing bytes, got nil")
+	}
+}
+
+// TestUnmarshalSRSegmentListSubTLV_TrailingBytes verifies that extra bytes following
+// a complete sub-TLV are rejected.
+func TestUnmarshalSRSegmentListSubTLV_TrailingBytes(t *testing.T) {
+	// Unknown type (0xFFFF), length=0: 4-byte TLV + 2 trailing bytes.
+	b := []byte{0xFF, 0xFF, 0x00, 0x00, 0xAB, 0xCD}
+	_, err := UnmarshalSRSegmentListSubTLV(b)
+	if err == nil {
+		t.Error("expected error for trailing bytes, got nil")
+	}
+}
+
+// TestUnmarshalSRSegmentSubTLV_TrailingBytes verifies that extra bytes following
+// a complete sub-TLV are rejected.
+func TestUnmarshalSRSegmentSubTLV_TrailingBytes(t *testing.T) {
+	// Unknown type (0xFFFF), length=0: 4-byte TLV + 2 trailing bytes.
+	b := []byte{0xFF, 0xFF, 0x00, 0x00, 0xAB, 0xCD}
+	_, err := UnmarshalSRSegmentSubTLV(b)
+	if err == nil {
+		t.Error("expected error for trailing bytes, got nil")
 	}
 }
 

--- a/pkg/bgpls/bgpls_json_roundtrip_test.go
+++ b/pkg/bgpls/bgpls_json_roundtrip_test.go
@@ -520,6 +520,13 @@ func TestUnmarshalSRSegmentListSubTLV(t *testing.T) {
 		if _, ok := got[0].(*SRSegment); !ok {
 			t.Errorf("got[0] type = %T, want *SRSegment", got[0])
 		}
+		seg, ok := got[0].(*SRSegment)
+		if !ok {
+			t.Fatalf("value type = %T, want *SRSegment", got[0])
+		}
+		if seg.Segment != 1 {
+			t.Errorf("SegmentType = %d, want 1", seg.Segment)
+		}
 	})
 
 	t.Run("SRSegmentListMetricType", func(t *testing.T) {

--- a/pkg/bgpls/bgpls_json_roundtrip_test.go
+++ b/pkg/bgpls/bgpls_json_roundtrip_test.go
@@ -524,8 +524,8 @@ func TestUnmarshalSRSegmentListSubTLV(t *testing.T) {
 		if !ok {
 			t.Fatalf("value type = %T, want *SRSegment", got[0])
 		}
-		if seg.Segment != 1 {
-			t.Errorf("SegmentType = %d, want 1", seg.Segment)
+		if seg.Segment != SegmentType1 {
+			t.Errorf("SegmentType = %d, want %d", seg.Segment, SegmentType1)
 		}
 	})
 

--- a/pkg/bgpls/bgpls_nlri_extra_test.go
+++ b/pkg/bgpls/bgpls_nlri_extra_test.go
@@ -40,6 +40,11 @@ func TestGetMaxLinkBandwidthKbps(t *testing.T) {
 	if got := (&NLRI{}).GetMaxLinkBandwidthKbps(); got != 0 {
 		t.Errorf("absent → %d, want 0", got)
 	}
+	// Short value (< 4 bytes) → 0, not a panic
+	nlriShort := &NLRI{LS: []TLV{{Type: 1089, Length: 3, Value: []byte{0x01, 0x02, 0x03}}}}
+	if got := nlriShort.GetMaxLinkBandwidthKbps(); got != 0 {
+		t.Errorf("short value → %d, want 0", got)
+	}
 	// Present: 125000 bytes/s = 125000*8/1000 kbps = 1000 kbps
 	val := float32Bytes(125000)
 	nlri := &NLRI{LS: []TLV{{Type: 1089, Length: 4, Value: val}}}
@@ -51,6 +56,11 @@ func TestGetMaxLinkBandwidthKbps(t *testing.T) {
 func TestGetMaxReservableLinkBandwidthKbps(t *testing.T) {
 	if got := (&NLRI{}).GetMaxReservableLinkBandwidthKbps(); got != 0 {
 		t.Errorf("absent → %d, want 0", got)
+	}
+	// Short value (< 4 bytes) → 0, not a panic
+	nlriShort := &NLRI{LS: []TLV{{Type: 1090, Length: 2, Value: []byte{0x01, 0x02}}}}
+	if got := nlriShort.GetMaxReservableLinkBandwidthKbps(); got != 0 {
+		t.Errorf("short value → %d, want 0", got)
 	}
 	val := float32Bytes(62500)
 	nlri := &NLRI{LS: []TLV{{Type: 1090, Length: 4, Value: val}}}

--- a/pkg/bgpls/bgpls_prefix_attr_test.go
+++ b/pkg/bgpls/bgpls_prefix_attr_test.go
@@ -66,8 +66,15 @@ func TestUnmarshalPrefixAttrFlags(t *testing.T) {
 		name     string
 		proto    base.ProtoID
 		input    []byte
+		wantErr  bool
 		wantByte byte
 	}{
+		{
+			name:    "empty input returns error",
+			proto:   base.ISISL1,
+			input:   []byte{},
+			wantErr: true,
+		},
 		{
 			name:     "ISIS L1 X+R flags",
 			proto:    base.ISISL1,
@@ -103,8 +110,11 @@ func TestUnmarshalPrefixAttrFlags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := UnmarshalPrefixAttrFlags(tt.input, tt.proto)
-			if err != nil {
-				t.Fatalf("UnmarshalPrefixAttrFlags() error = %v", err)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("UnmarshalPrefixAttrFlags() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
 			}
 			if got.GetPrefixAttrFlagsByte() != tt.wantByte {
 				t.Errorf("GetPrefixAttrFlagsByte() = 0x%X, want 0x%X", got.GetPrefixAttrFlagsByte(), tt.wantByte)

--- a/pkg/bgpls/prefix-attr-tlv.go
+++ b/pkg/bgpls/prefix-attr-tlv.go
@@ -139,8 +139,8 @@ func UnmarshalPrefixAttrFlags(b []byte, proto base.ProtoID) (PrefixAttrFlags, er
 	if glog.V(6) {
 		glog.Infof("Prefix Attr Flags Raw: %s for proto: %+v", tools.MessageHex(b), proto)
 	}
-	if len(b) == 0 {
-		return nil, fmt.Errorf("not enough bytes to unmarshal Prefix Attr Flags")
+	if len(b) < 1 {
+		return nil, fmt.Errorf("prefix attr flags: need at least 1 byte, have %d", len(b))
 	}
 	switch proto {
 	case base.ISISL1:


### PR DESCRIPTION
- Add len guards to node-descriptor Uint32 getters (P3-17)
- Add empty slice guard in UnmarshalPrefixAttrFlags (B4)
- Add len guards to bandwidth TLV getters
- Fix TLV loop bounds in 3 SRv6 policy sub-TLV parsers (P3-8)
- Change SegmentListSubTLV from map to slice to retain all segments (P3-15)
- Add SegmentDescriptor and SubTLV to SRSegment.MarshalJSON (P3-16)