### PR TITLE
Fix SR segment loss, node descriptor bounds, and prefix attr flags panic

### DIFF
--- a/pkg/base/node-descriptor.go
+++ b/pkg/base/node-descriptor.go
@@ -26,7 +26,7 @@ type NodeDescriptor struct {
 
 // GetASN returns Autonomous System Number used to uniqely identify BGP-LS domain
 func (nd *NodeDescriptor) GetASN() uint32 {
-	if tlv, ok := nd.SubTLV[512]; ok {
+	if tlv, ok := nd.SubTLV[512]; ok && len(tlv.Value) >= 4 {
 		return binary.BigEndian.Uint32(tlv.Value)
 	}
 	return 0
@@ -34,7 +34,7 @@ func (nd *NodeDescriptor) GetASN() uint32 {
 
 // GetLSID returns BGP-LS Identifier found in Node Descriptor sub tlv
 func (nd *NodeDescriptor) GetLSID() uint32 {
-	if tlv, ok := nd.SubTLV[513]; ok {
+	if tlv, ok := nd.SubTLV[513]; ok && len(tlv.Value) >= 4 {
 		return binary.BigEndian.Uint32(tlv.Value)
 	}
 	return 0
@@ -42,7 +42,7 @@ func (nd *NodeDescriptor) GetLSID() uint32 {
 
 // GetOSPFAreaID returns OSPF Area-ID found in Node Descriptor sub tlv
 func (nd *NodeDescriptor) GetOSPFAreaID() string {
-	if tlv, ok := nd.SubTLV[514]; ok {
+	if tlv, ok := nd.SubTLV[514]; ok && len(tlv.Value) >= 4 {
 		return strconv.Itoa(int(binary.BigEndian.Uint32(tlv.Value)))
 	}
 	return ""
@@ -76,7 +76,7 @@ func (nd *NodeDescriptor) GetBGPRouterID() []byte {
 
 // GetConfedMemberASN returns Confederation Member ASN (Member-ASN)
 func (nd *NodeDescriptor) GetConfedMemberASN() uint32 {
-	if tlv, ok := nd.SubTLV[517]; ok {
+	if tlv, ok := nd.SubTLV[517]; ok && len(tlv.Value) >= 4 {
 		return binary.BigEndian.Uint32(tlv.Value)
 	}
 	return 0

--- a/pkg/base/node-descriptor_test.go
+++ b/pkg/base/node-descriptor_test.go
@@ -24,6 +24,11 @@ func TestNodeDescriptorGetASN(t *testing.T) {
 			nd:   makeNodeDesc(nil),
 			want: 0,
 		},
+		{
+			name: "TLV present but short value",
+			nd:   makeNodeDesc(map[uint16]TLV{512: {Type: 512, Length: 2, Value: []byte{0x00, 0x01}}}),
+			want: 0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -50,6 +55,11 @@ func TestNodeDescriptorGetLSID(t *testing.T) {
 			nd:   makeNodeDesc(nil),
 			want: 0,
 		},
+		{
+			name: "TLV present but short value",
+			nd:   makeNodeDesc(map[uint16]TLV{513: {Type: 513, Length: 1, Value: []byte{0x01}}}),
+			want: 0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -74,6 +84,11 @@ func TestNodeDescriptorGetOSPFAreaID(t *testing.T) {
 		{
 			name: "TLV absent",
 			nd:   makeNodeDesc(nil),
+			want: "",
+		},
+		{
+			name: "TLV present but short value",
+			nd:   makeNodeDesc(map[uint16]TLV{514: {Type: 514, Length: 3, Value: []byte{0x00, 0x00, 0x07}}}),
 			want: "",
 		},
 	}
@@ -135,6 +150,11 @@ func TestNodeDescriptorGetConfedMemberASN(t *testing.T) {
 		{
 			name: "TLV absent",
 			nd:   makeNodeDesc(nil),
+			want: 0,
+		},
+		{
+			name: "TLV present but short value",
+			nd:   makeNodeDesc(map[uint16]TLV{517: {Type: 517, Length: 2, Value: []byte{0x00, 0x05}}}),
 			want: 0,
 		},
 	}

--- a/pkg/bgpls/bgpls-srv6-policy-state.go
+++ b/pkg/bgpls/bgpls-srv6-policy-state.go
@@ -602,19 +602,19 @@ type SRSegmentListSubTLV interface {
 
 // SRSegmentList defines SR Segment List objects which reports the SID-List(s) of a candidate path.
 type SRSegmentList struct {
-	FlagD  bool                           `json:"d_flag"`
-	FlagE  bool                           `json:"e_flag"`
-	FlagC  bool                           `json:"c_flag"`
-	FlagV  bool                           `json:"v_flag"`
-	FlagR  bool                           `json:"r_flag"`
-	FlagF  bool                           `json:"f_flag"`
-	FlagA  bool                           `json:"a_flag"`
-	FlagT  bool                           `json:"t_flag"`
-	FlagM  bool                           `json:"m_flag"`
-	MTID   uint16                         `json:"mtid"`
-	Algo   uint8                          `json:"algo"`
-	Weight uint32                         `json:"weight"`
-	SubTLV map[uint16]SRSegmentListSubTLV `json:"subtlv,omitempty"`
+	FlagD  bool                  `json:"d_flag"`
+	FlagE  bool                  `json:"e_flag"`
+	FlagC  bool                  `json:"c_flag"`
+	FlagV  bool                  `json:"v_flag"`
+	FlagR  bool                  `json:"r_flag"`
+	FlagF  bool                  `json:"f_flag"`
+	FlagA  bool                  `json:"a_flag"`
+	FlagT  bool                  `json:"t_flag"`
+	FlagM  bool                  `json:"m_flag"`
+	MTID   uint16                `json:"mtid"`
+	Algo   uint8                 `json:"algo"`
+	Weight uint32                `json:"weight"`
+	SubTLV []SRSegmentListSubTLV `json:"subtlv,omitempty"`
 }
 
 // UnmarshalSRSegmentList instantiates SRSegmentList from a slice of bytes
@@ -660,15 +660,16 @@ func UnmarshalSRSegmentList(b []byte) (*SRSegmentList, error) {
 	return s, nil
 }
 
-// UnmarshalSRSegmentListSubTLV instantiates a map of SR Segment List Sub TLVs from a slice of bytes
-func UnmarshalSRSegmentListSubTLV(b []byte) (map[uint16]SRSegmentListSubTLV, error) {
+// UnmarshalSRSegmentListSubTLV instantiates a slice of SR Segment List Sub TLVs from a slice of bytes.
+// Multiple SRSegment sub-TLVs (type 1206) are valid per RFC 9256 §2.4.4 — each is appended in order.
+func UnmarshalSRSegmentListSubTLV(b []byte) ([]SRSegmentListSubTLV, error) {
 	if glog.V(6) {
 		glog.Infof("SR Segment List Sub TLV Raw: %s", tools.MessageHex(b))
 	}
 	if len(b) < 4 {
 		return nil, fmt.Errorf("not enough bytes to decode SR Segment List Sub TLV")
 	}
-	s := make(map[uint16]SRSegmentListSubTLV)
+	s := make([]SRSegmentListSubTLV, 0)
 	p := 0
 	for p < len(b) {
 		t := binary.BigEndian.Uint16(b[p : p+2])
@@ -684,13 +685,13 @@ func UnmarshalSRSegmentListSubTLV(b []byte) (map[uint16]SRSegmentListSubTLV, err
 			if err != nil {
 				return nil, err
 			}
-			s[SRSegmentType] = stlv
+			s = append(s, stlv)
 		case SRSegmentListMetricType:
 			stlv, err := UnmarshalSRSegmentListMetric(b[p : p+int(l)])
 			if err != nil {
 				return nil, err
 			}
-			s[SRSegmentListMetricType] = stlv
+			s = append(s, stlv)
 		}
 		p += int(l)
 	}

--- a/pkg/bgpls/bgpls_json_roundtrip_test.go
+++ b/pkg/bgpls/bgpls_json_roundtrip_test.go
@@ -514,8 +514,11 @@ func TestUnmarshalSRSegmentListSubTLV(t *testing.T) {
 		if err != nil {
 			t.Fatalf("UnmarshalSRSegmentListSubTLV() error = %v", err)
 		}
-		if _, ok := got[SRSegmentType]; !ok {
-			t.Error("SRSegmentType key missing from result")
+		if len(got) != 1 {
+			t.Fatalf("len(got) = %d, want 1", len(got))
+		}
+		if _, ok := got[0].(*SRSegment); !ok {
+			t.Errorf("got[0] type = %T, want *SRSegment", got[0])
 		}
 	})
 
@@ -534,13 +537,12 @@ func TestUnmarshalSRSegmentListSubTLV(t *testing.T) {
 		if err != nil {
 			t.Fatalf("UnmarshalSRSegmentListSubTLV() error = %v", err)
 		}
-		tlv, ok := got[SRSegmentListMetricType]
-		if !ok {
-			t.Fatal("SRSegmentListMetricType key missing from result")
+		if len(got) != 1 {
+			t.Fatalf("len(got) = %d, want 1", len(got))
 		}
-		m, ok := tlv.(*SRSegmentListMetric)
+		m, ok := got[0].(*SRSegmentListMetric)
 		if !ok {
-			t.Fatalf("value type = %T, want *SRSegmentListMetric", tlv)
+			t.Fatalf("got[0] type = %T, want *SRSegmentListMetric", got[0])
 		}
 		if m.Metric != SRMetricTE {
 			t.Errorf("Metric = %d, want %d", m.Metric, SRMetricTE)
@@ -550,6 +552,30 @@ func TestUnmarshalSRSegmentListSubTLV(t *testing.T) {
 		}
 		if m.Margin != 100 || m.Bound != 200 || m.Value != 300 {
 			t.Errorf("Margin/Bound/Value = %d/%d/%d, want 100/200/300", m.Margin, m.Bound, m.Value)
+		}
+	})
+
+	// P3-15 regression: multiple SRSegment sub-TLVs must all be preserved.
+	// Before the fix, s[SRSegmentType] was overwritten on each iteration so
+	// only the last segment survived.
+	t.Run("MultipleSegments_AllPreserved", func(t *testing.T) {
+		seg := []byte{
+			0x04, 0xB6, 0x00, 0x04, // sub-TLV type=1206, length=4
+			0x01, 0x00, 0x00, 0x00, // SegmentType1
+		}
+		// Three identical segments back-to-back.
+		b := append(append(seg, seg...), seg...)
+		got, err := UnmarshalSRSegmentListSubTLV(b)
+		if err != nil {
+			t.Fatalf("UnmarshalSRSegmentListSubTLV() error = %v", err)
+		}
+		if len(got) != 3 {
+			t.Fatalf("len(got) = %d, want 3 (all segments must be preserved)", len(got))
+		}
+		for i, v := range got {
+			if _, ok := v.(*SRSegment); !ok {
+				t.Errorf("got[%d] type = %T, want *SRSegment", i, v)
+			}
 		}
 	})
 }

--- a/pkg/bgpls/bgpls_prefix_attr_test.go
+++ b/pkg/bgpls/bgpls_prefix_attr_test.go
@@ -113,6 +113,15 @@ func TestUnmarshalPrefixAttrFlags(t *testing.T) {
 	}
 }
 
+func TestUnmarshalPrefixAttrFlags_EmptyInput(t *testing.T) {
+	// B4: empty input must return an error, not panic with an index out-of-range.
+	for _, proto := range []base.ProtoID{base.ISISL1, base.ISISL2, base.OSPFv2, base.OSPFv3, base.BGP} {
+		if _, err := UnmarshalPrefixAttrFlags([]byte{}, proto); err == nil {
+			t.Errorf("proto %v: expected error for empty input, got nil", proto)
+		}
+	}
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Individual prefix attr flag unmarshalers
 // ─────────────────────────────────────────────────────────────────────────────

--- a/pkg/bgpls/prefix-attr-tlv.go
+++ b/pkg/bgpls/prefix-attr-tlv.go
@@ -139,18 +139,20 @@ func UnmarshalPrefixAttrFlags(b []byte, proto base.ProtoID) (PrefixAttrFlags, er
 	if glog.V(6) {
 		glog.Infof("Prefix Attr Flags Raw: %s for proto: %+v", tools.MessageHex(b), proto)
 	}
-	p := 0
+	if len(b) == 0 {
+		return nil, fmt.Errorf("not enough bytes to unmarshal Prefix Attr Flags")
+	}
 	switch proto {
 	case base.ISISL1:
 		fallthrough
 	case base.ISISL2:
-		return UnmarshalISISFlags(b[p : p+1])
+		return UnmarshalISISFlags(b[:1])
 	case base.OSPFv2:
-		return UnmarshalOSPFFlags(b[p : p+1])
+		return UnmarshalOSPFFlags(b[:1])
 	case base.OSPFv3:
-		return UnmarshalOSPFv3Flags(b[p : p+1])
+		return UnmarshalOSPFv3Flags(b[:1])
 	default:
-		return UnmarshalUnknownProtoFlags(b[p : p+1])
+		return UnmarshalUnknownProtoFlags(b[:1])
 	}
 }
 


### PR DESCRIPTION
## Summary

- **P3-15 (data loss)**: `UnmarshalSRSegmentListSubTLV` stored every `SRSegment` sub-TLV under the same map key (`SRSegmentType = 1206`), so each segment overwrote the previous one — only the last segment in a Segment List survived. Changed `SRSegmentList.SubTLV` and the function return type from `map[uint16]SRSegmentListSubTLV` to `[]SRSegmentListSubTLV` so all segments are appended in order per RFC 9256 §2.4.4.

- **P3-17 (panic)**: `GetASN`, `GetLSID`, `GetOSPFAreaID`, and `GetConfedMemberASN` in `node-descriptor.go` called `binary.BigEndian.Uint32` without checking `len(tlv.Value) >= 4`, panicking on malformed or truncated TLVs from a misbehaving peer.

- **B4 (panic)**: `UnmarshalPrefixAttrFlags` accessed `b[0]` without a `len(b) == 0` guard, panicking on empty input.