### PR TITLE
Add passive BMP connection limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ nats_config:
 ```yaml
 # Listening
 bmp_listen_port: 5000        # TCP port for BMP sessions (default: 5000)
+max_passive_connections: 0   # max concurrent inbound BMP sessions; 0 = unlimited (passive mode only, ignored when active_mode: true)
 
 # Performance monitoring (disabled when omitted or 0)
 performance_port: 56767      # pprof port; any value > 0 enables collection

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,8 +67,10 @@ type Config struct {
 	SplitAF         *bool        `yaml:"split_af"`
 	BmpListenPort   int          `yaml:"bmp_listen_port"`
 	PerformancePort int          `yaml:"performance_port"` // > 0 enables pprof collection
-	ActiveMode      bool         `yaml:"active_mode"`
-	SpeakersList    []string     `yaml:"speakers_list"`
+	// MaxPassiveConnections caps concurrent BMP sessions in passive mode. 0 means no limit.
+	MaxPassiveConnections int      `yaml:"max_passive_connections"`
+	ActiveMode            bool     `yaml:"active_mode"`
+	SpeakersList          []string `yaml:"speakers_list"`
 }
 
 func LoadConfig(path string) (*Config, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,7 +67,8 @@ type Config struct {
 	SplitAF         *bool        `yaml:"split_af"`
 	BmpListenPort   int          `yaml:"bmp_listen_port"`
 	PerformancePort int          `yaml:"performance_port"` // > 0 enables pprof collection
-	// MaxPassiveConnections caps concurrent BMP sessions in passive mode. 0 means no limit.
+	// MaxPassiveConnections caps concurrent passive-mode BMP TCP sessions (0 = unlimited).
+	// YAML key is max_passive_connections (not max_connections). Ignored in active_mode.
 	MaxPassiveConnections int      `yaml:"max_passive_connections"`
 	ActiveMode            bool     `yaml:"active_mode"`
 	SpeakersList          []string `yaml:"speakers_list"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -78,8 +78,10 @@ type Config struct {
 	SplitAF         *bool        `yaml:"split_af"`
 	BmpListenPort   int          `yaml:"bmp_listen_port"`
 	PerformancePort int          `yaml:"performance_port"` // > 0 enables pprof collection
-	ActiveMode      bool         `yaml:"active_mode"`
-	SpeakersList    []string     `yaml:"speakers_list"`
+	// MaxPassiveConnections caps concurrent BMP sessions in passive mode. 0 means no limit.
+	MaxPassiveConnections int      `yaml:"max_passive_connections"`
+	ActiveMode            bool     `yaml:"active_mode"`
+	SpeakersList          []string `yaml:"speakers_list"`
 }
 
 func LoadConfig(path string) (*Config, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -78,7 +78,8 @@ type Config struct {
 	SplitAF         *bool        `yaml:"split_af"`
 	BmpListenPort   int          `yaml:"bmp_listen_port"`
 	PerformancePort int          `yaml:"performance_port"` // > 0 enables pprof collection
-	// MaxPassiveConnections caps concurrent BMP sessions in passive mode. 0 means no limit.
+	// MaxPassiveConnections caps concurrent passive-mode BMP TCP sessions (0 = unlimited).
+	// YAML key is max_passive_connections (not max_connections). Ignored in active_mode.
 	MaxPassiveConnections int      `yaml:"max_passive_connections"`
 	ActiveMode            bool     `yaml:"active_mode"`
 	SpeakersList          []string `yaml:"speakers_list"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -88,6 +88,9 @@ func TestLoadConfig_Defaults(t *testing.T) {
 	if cfg.Publisher != nil {
 		t.Error("Publisher should be nil after LoadConfig")
 	}
+	if cfg.MaxPassiveConnections != 0 {
+		t.Errorf("MaxPassiveConnections = %d, want 0 (default unlimited)", cfg.MaxPassiveConnections)
+	}
 }
 
 func TestLoadConfig_SpeakersListEmpty(t *testing.T) {
@@ -346,5 +349,16 @@ kafka_config:
 	}
 	if cfg.KafkaConfig.KafkaCA != "" {
 		t.Errorf("KafkaCA = %q, want empty", cfg.KafkaConfig.KafkaCA)
+	}
+}
+
+func TestLoadConfig_MaxPassiveConnections(t *testing.T) {
+	path := writeTemp(t, "max_passive_connections: 10\n")
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig() unexpected error: %v", err)
+	}
+	if cfg.MaxPassiveConnections != 10 {
+		t.Errorf("MaxPassiveConnections = %d, want 10", cfg.MaxPassiveConnections)
 	}
 }

--- a/pkg/gobmpsrv/gobmpsrv.go
+++ b/pkg/gobmpsrv/gobmpsrv.go
@@ -426,7 +426,7 @@ func (srv *bmpServer) connectSpeaker(speaker *bgpSpeaker) {
 		}
 		speaker.mu.Lock()
 		speaker.isConnected = true
-		speaker.nextAttempt = time.Time{} // allow immediate reconnect after a clean disconnect
+		speaker.nextAttempt = time.Time{} // clear any stale backoff timestamp while the speaker is connected
 		speaker.mu.Unlock()
 		srv.wg.Add(1)
 		srv.clients[client] = struct{}{}

--- a/pkg/gobmpsrv/gobmpsrv.go
+++ b/pkg/gobmpsrv/gobmpsrv.go
@@ -21,6 +21,15 @@ import (
 // maxBMPMessagePayload is the maximum allowed BMP message payload size (1 MB).
 const maxBMPMessagePayload = 1 << 20
 
+// stableSessionThreshold is the minimum duration the bmpWorker session must run
+// before the session is considered long-lived and retryDelay is reset to 1 s.
+// The classification is purely duration-based: any session shorter than this
+// — regardless of why it ended — is treated as unstable (e.g. a proxy that
+// accepts TCP but drops the BMP session immediately) and causes retryDelay to
+// double. Declared as a var so tests can shorten it without a real
+// 30-second wall-clock wait.
+var stableSessionThreshold = 30 * time.Second
+
 // BMPServer defines methods to manage BMP Server
 type BMPServer interface {
 	Start()
@@ -390,8 +399,9 @@ func (srv *bmpServer) connectSpeaker(speaker *bgpSpeaker) {
 			newDelay := speaker.retryDelay * 2
 			speaker.retryDelay = min(newDelay, 5*time.Minute)
 			speaker.nextAttempt = time.Now().Add(speaker.retryDelay)
+			logDelay := speaker.retryDelay
 			speaker.mu.Unlock()
-			glog.Infof("Will retry connection to %s in %v", speaker.Address, speaker.retryDelay)
+			glog.Infof("Will retry connection to %s in %v", speaker.Address, logDelay)
 			continue
 		}
 
@@ -410,13 +420,13 @@ func (srv *bmpServer) connectSpeaker(speaker *bgpSpeaker) {
 		}
 		speaker.mu.Lock()
 		speaker.isConnected = true
-		speaker.retryDelay = 1 * time.Second // reset backoff on a successful connection
-		speaker.nextAttempt = time.Time{}    // allow immediate reconnect after a clean disconnect
+		speaker.nextAttempt = time.Time{} // allow immediate reconnect after a clean disconnect
 		speaker.mu.Unlock()
 		srv.wg.Add(1)
 		srv.clients[client] = struct{}{}
 		srv.mu.Unlock()
 
+		connectedAt := time.Now()
 		glog.V(5).Infof("client %s connected, calling bmpWorker", speaker.Address)
 		// Run bmpWorker synchronously: this goroutine is dedicated to this
 		// speaker, so blocking here is correct and avoids an extra goroutine.
@@ -435,11 +445,24 @@ func (srv *bmpServer) connectSpeaker(speaker *bgpSpeaker) {
 			defer func() { _ = client.Close() }()
 			srv.bmpWorker(client)
 		}()
-		// bmpWorker returned — the connection dropped; schedule reconnect with backoff.
+		// bmpWorker returned — the connection dropped; schedule reconnect.
+		// If the session was stable (ran long enough to be a real BMP session),
+		// reset backoff so the next reconnect is fast. If it was short-lived
+		// (e.g. a proxy accepted the TCP dial but immediately dropped the BMP
+		// session), apply exponential backoff to avoid a tight retry loop.
 		speaker.mu.Lock()
+		if time.Since(connectedAt) >= stableSessionThreshold {
+			// Stable session — reset backoff to allow a fast reconnect.
+			speaker.retryDelay = 1 * time.Second
+		} else {
+			// Unstable / proxy-terminated session — back off.
+			newDelay := speaker.retryDelay * 2
+			speaker.retryDelay = min(newDelay, 5*time.Minute)
+		}
 		speaker.nextAttempt = time.Now().Add(speaker.retryDelay)
+		logDelay := speaker.retryDelay
 		speaker.mu.Unlock()
-		glog.Infof("connectSpeaker(%s): bmpWorker exited, scheduling reconnect in %v", speaker.Address, speaker.retryDelay)
+		glog.Infof("connectSpeaker(%s): bmpWorker exited, scheduling reconnect in %v", speaker.Address, logDelay)
 	}
 }
 

--- a/pkg/gobmpsrv/gobmpsrv.go
+++ b/pkg/gobmpsrv/gobmpsrv.go
@@ -472,7 +472,11 @@ func (srv *bmpServer) connectSpeaker(speaker *bgpSpeaker) {
 	}
 }
 
-// NewBMPServer instantiates a new instance of BMP Server
+// NewBMPServer instantiates a new instance of BMP server from cfg.
+// In passive mode it binds cfg.BmpListenPort. When cfg.MaxPassiveConnections > 0,
+// the server refuses additional TCP accepts beyond that cap (see max_passive_connections).
+// This constructor does not configure per-connection read timeouts; operators rely on
+// BMP peers or intermediates to drop idle sessions if needed.
 func NewBMPServer(cfg *config.Config) (BMPServer, error) {
 	if cfg == nil {
 		return nil, errors.New("config cannot be nil")

--- a/pkg/gobmpsrv/gobmpsrv.go
+++ b/pkg/gobmpsrv/gobmpsrv.go
@@ -3,6 +3,7 @@ package gobmpsrv
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"strconv"
@@ -473,6 +474,9 @@ func NewBMPServer(cfg *config.Config) (BMPServer, error) {
 	}
 	if cfg.Publisher == nil {
 		return nil, errors.New("publisher cannot be nil")
+	}
+	if cfg.MaxPassiveConnections < 0 {
+		return nil, fmt.Errorf("max_passive_connections must be >= 0, got %d", cfg.MaxPassiveConnections)
 	}
 	bmpSrv := bmpServer{
 		isActive:    cfg.ActiveMode,

--- a/pkg/gobmpsrv/gobmpsrv.go
+++ b/pkg/gobmpsrv/gobmpsrv.go
@@ -21,15 +21,6 @@ import (
 // maxBMPMessagePayload is the maximum allowed BMP message payload size (1 MB).
 const maxBMPMessagePayload = 1 << 20
 
-// stableSessionThreshold is the minimum duration the bmpWorker session must run
-// for before the session is considered long-lived and retryDelay is reset to 1 s.
-// The classification is purely duration-based: any session shorter than this
-// — regardless of why it ended — is treated as unstable (e.g. a proxy that
-// accepts TCP but drops the BMP session immediately) and causes retryDelay to
-// double. Declared as a var so tests can shorten it without a real
-// 30-second wall-clock wait.
-var stableSessionThreshold = 30 * time.Second
-
 // BMPServer defines methods to manage BMP Server
 type BMPServer interface {
 	Start()
@@ -51,6 +42,7 @@ type bmpServer struct {
 	stopOnce  sync.Once
 	clients   map[net.Conn]struct{} // active bmpWorker connections
 	closing   bool                  // set to true in Stop() before iterating clients
+	connSem   chan struct{}         // non-nil only when MaxPassiveConnections > 0 (passive mode)
 	bmpRaw    bool
 	adminID   string
 	// Active-mode fields — all nil/zero in passive mode.
@@ -123,6 +115,18 @@ func (srv *bmpServer) server() {
 			glog.Errorf("fail to accept client connection with error: %+v", err)
 			continue
 		}
+		// Enforce connection limit when a semaphore is configured.
+		// A nil connSem means no limit — skip the select so tests and
+		// in-package construction paths do not reject every connection.
+		if srv.connSem != nil {
+			select {
+			case srv.connSem <- struct{}{}:
+			default:
+				glog.Warningf("connection limit reached (%d), rejecting %v", cap(srv.connSem), client.RemoteAddr())
+				_ = client.Close()
+				continue
+			}
+		}
 		glog.V(5).Infof("client %+v accepted, calling bmpWorker", client.RemoteAddr())
 		srv.startWorker(client)
 	}
@@ -146,6 +150,10 @@ func (srv *bmpServer) startWorker(client net.Conn) {
 	if srv.closing {
 		srv.mu.Unlock()
 		_ = client.Close()
+		// Release semaphore slot acquired by server() before this call.
+		if srv.connSem != nil {
+			<-srv.connSem
+		}
 		return
 	}
 	srv.wg.Add(1)
@@ -157,6 +165,10 @@ func (srv *bmpServer) startWorker(client net.Conn) {
 			delete(srv.clients, client)
 			srv.mu.Unlock()
 			srv.wg.Done()
+			// Release connection semaphore slot (passive mode only).
+			if srv.connSem != nil {
+				<-srv.connSem
+			}
 		}()
 		srv.bmpWorker(client)
 	}()
@@ -398,8 +410,9 @@ func (srv *bmpServer) connectSpeaker(speaker *bgpSpeaker) {
 		}
 		speaker.mu.Lock()
 		speaker.isConnected = true
+		speaker.retryDelay = 1 * time.Second // reset backoff on a successful connection
+		speaker.nextAttempt = time.Time{}    // allow immediate reconnect after a clean disconnect
 		speaker.mu.Unlock()
-		connectedAt := time.Now()
 		srv.wg.Add(1)
 		srv.clients[client] = struct{}{}
 		srv.mu.Unlock()
@@ -422,20 +435,8 @@ func (srv *bmpServer) connectSpeaker(speaker *bgpSpeaker) {
 			defer func() { _ = client.Close() }()
 			srv.bmpWorker(client)
 		}()
-		// bmpWorker returned — the connection dropped; schedule reconnect.
-		// If the session was stable (ran long enough to be a real BMP session),
-		// reset backoff so the next reconnect is fast.  If it was short-lived
-		// (e.g. a proxy accepted the TCP dial but immediately dropped the BMP
-		// session), apply exponential backoff to avoid a tight retry loop.
+		// bmpWorker returned — the connection dropped; schedule reconnect with backoff.
 		speaker.mu.Lock()
-		if time.Since(connectedAt) >= stableSessionThreshold {
-			// Stable session — reset backoff to allow a fast reconnect.
-			speaker.retryDelay = 1 * time.Second
-		} else {
-			// Unstable / proxy-terminated session — back off.
-			newDelay := speaker.retryDelay * 2
-			speaker.retryDelay = min(newDelay, 5*time.Minute)
-		}
 		speaker.nextAttempt = time.Now().Add(speaker.retryDelay)
 		speaker.mu.Unlock()
 		glog.Infof("connectSpeaker(%s): bmpWorker exited, scheduling reconnect in %v", speaker.Address, speaker.retryDelay)
@@ -464,6 +465,9 @@ func NewBMPServer(cfg *config.Config) (BMPServer, error) {
 			return nil, err
 		}
 		bmpSrv.incoming = incoming
+		if cfg.MaxPassiveConnections > 0 {
+			bmpSrv.connSem = make(chan struct{}, cfg.MaxPassiveConnections)
+		}
 	}
 	if bmpSrv.isActive && len(bmpSrv.bgpSpeakers) == 0 {
 		return nil, errors.New("active_mode is true but speakers_list is empty")

--- a/pkg/gobmpsrv/gobmpsrv.go
+++ b/pkg/gobmpsrv/gobmpsrv.go
@@ -128,9 +128,11 @@ func (srv *bmpServer) server() {
 		// Enforce connection limit when a semaphore is configured.
 		// A nil connSem means no limit — skip the select so tests and
 		// in-package construction paths do not reject every connection.
+		hasSem := false
 		if srv.connSem != nil {
 			select {
 			case srv.connSem <- struct{}{}:
+				hasSem = true
 			default:
 				glog.Warningf("connection limit reached (%d), rejecting %v", cap(srv.connSem), client.RemoteAddr())
 				_ = client.Close()
@@ -138,12 +140,17 @@ func (srv *bmpServer) server() {
 			}
 		}
 		glog.V(5).Infof("client %+v accepted, calling bmpWorker", client.RemoteAddr())
-		srv.startWorker(client)
+		srv.startWorker(client, hasSem)
 	}
 }
 
 // startWorker registers the new connection with the WaitGroup and the active
 // client set, then spawns a bmpWorker goroutine.
+//
+// hasSem records whether the caller already acquired a connSem slot for this
+// client. Only the caller that acquired a slot is allowed to release it:
+// draining the channel on every call with connSem != nil would consume tokens
+// that belong to other in-flight workers.
 //
 // Both the wg.Add and the map insertion are performed under mu, the same lock
 // that Stop() holds when it sets closing=true and iterates the clients map.
@@ -155,13 +162,12 @@ func (srv *bmpServer) server() {
 //   - If Stop() acquires mu first (sets closing=true, iterates) → startWorker
 //     sees closing=true, closes the connection immediately, and returns without
 //     touching the WaitGroup.
-func (srv *bmpServer) startWorker(client net.Conn) {
+func (srv *bmpServer) startWorker(client net.Conn, hasSem bool) {
 	srv.mu.Lock()
 	if srv.closing {
 		srv.mu.Unlock()
 		_ = client.Close()
-		// Release semaphore slot acquired by server() before this call.
-		if srv.connSem != nil {
+		if hasSem {
 			<-srv.connSem
 		}
 		return
@@ -175,8 +181,7 @@ func (srv *bmpServer) startWorker(client net.Conn) {
 			delete(srv.clients, client)
 			srv.mu.Unlock()
 			srv.wg.Done()
-			// Release connection semaphore slot (passive mode only).
-			if srv.connSem != nil {
+			if hasSem {
 				<-srv.connSem
 			}
 		}()

--- a/pkg/gobmpsrv/gobmpsrv.go
+++ b/pkg/gobmpsrv/gobmpsrv.go
@@ -180,10 +180,10 @@ func (srv *bmpServer) startWorker(client net.Conn, hasSem bool) {
 			srv.mu.Lock()
 			delete(srv.clients, client)
 			srv.mu.Unlock()
-			srv.wg.Done()
 			if hasSem {
 				<-srv.connSem
 			}
+			srv.wg.Done()
 		}()
 		srv.bmpWorker(client)
 	}()

--- a/pkg/gobmpsrv/gobmpsrv_test.go
+++ b/pkg/gobmpsrv/gobmpsrv_test.go
@@ -565,7 +565,7 @@ func TestStartWorker_WhenClosing_ClosesConnection(t *testing.T) {
 		publisher: newMockPublisher(),
 	}
 	srv.closing = true // pre-set as Stop() would have done
-	srv.startWorker(serverConn)
+	srv.startWorker(serverConn, false)
 
 	// serverConn must be closed by startWorker; reading from clientConn returns an error.
 	_ = clientConn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
@@ -1528,7 +1528,7 @@ func TestStartWorker_WhenClosing_ReleasesSemaphore(t *testing.T) {
 	serverConn, clientConn := net.Pipe()
 	defer func() { _ = clientConn.Close() }()
 
-	srv.startWorker(serverConn)
+	srv.startWorker(serverConn, true)
 
 	// Semaphore should be drained (released by startWorker's early-return path).
 	select {
@@ -1554,7 +1554,7 @@ func TestStartWorker_ConnSem_ReleasedOnWorkerExit(t *testing.T) {
 	// Simulate server() acquiring the semaphore before startWorker.
 	srv.connSem <- struct{}{}
 
-	srv.startWorker(serverConn)
+	srv.startWorker(serverConn, true)
 
 	// Closing the client causes bmpWorker to see io.EOF and return,
 	// triggering the defer that releases the semaphore slot.

--- a/pkg/gobmpsrv/gobmpsrv_test.go
+++ b/pkg/gobmpsrv/gobmpsrv_test.go
@@ -1482,14 +1482,7 @@ func TestBMPServer_ConnectionLimit_ServerRejects(t *testing.T) {
 	srv.connSem <- struct{}{}
 
 	srv.Start()
-	defer func() {
-		// Drain the semaphore so Stop() does not hang waiting for bmpWorker exits.
-		select {
-		case <-srv.connSem:
-		default:
-		}
-		srv.Stop()
-	}()
+	defer srv.Stop()
 
 	port := ln.Addr().(*net.TCPAddr).Port
 	client, err := net.Dial("tcp", "127.0.0.1:"+strconv.Itoa(port))

--- a/pkg/gobmpsrv/gobmpsrv_test.go
+++ b/pkg/gobmpsrv/gobmpsrv_test.go
@@ -1186,9 +1186,12 @@ func TestConnectSpeaker_NextAttemptInFutureAfterFailure(t *testing.T) {
 	}
 }
 
-// TestConnectSpeaker_BackoffResetOnSuccess verifies that retryDelay is reset
-// to 1 second after a successful dial, regardless of how high it had grown.
-func TestConnectSpeaker_BackoffResetOnSuccess(t *testing.T) {
+// TestConnectSpeaker_BackoffPreservedOnConnect verifies that a successful TCP
+// dial does NOT reset retryDelay. The reset happens only after a stable BMP
+// session ends (see TestConnectSpeaker_StableSession_ResetsRetryDelay), so that
+// a proxy that accepts TCP but immediately drops the session still accumulates
+// exponential backoff across attempts.
+func TestConnectSpeaker_BackoffPreservedOnConnect(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Listen: %v", err)
@@ -1198,8 +1201,8 @@ func TestConnectSpeaker_BackoffResetOnSuccess(t *testing.T) {
 	srv, cleanup := newConnectSpeakerSrv()
 	defer cleanup()
 
-	// Pre-set a high retryDelay to verify it gets reset on success.
-	speaker := &bgpSpeaker{Address: ln.Addr().String(), retryDelay: 3 * time.Minute}
+	const initial = 3 * time.Minute
+	speaker := &bgpSpeaker{Address: ln.Addr().String(), retryDelay: initial}
 	done := runConnectSpeaker(srv, speaker)
 
 	conn, err := acceptWithTimeout(ln, 3*time.Second)
@@ -1215,8 +1218,9 @@ func TestConnectSpeaker_BackoffResetOnSuccess(t *testing.T) {
 	delay := speaker.retryDelay
 	speaker.mu.Unlock()
 
-	if delay != 1*time.Second {
-		t.Errorf("retryDelay after successful connect = %v, want 1s", delay)
+	// retryDelay must not be reset by a TCP connect alone.
+	if delay != initial {
+		t.Errorf("retryDelay after TCP connect = %v, want %v (should be unchanged)", delay, initial)
 	}
 
 	cleanup()
@@ -1257,6 +1261,88 @@ func TestConnectSpeaker_PostDisconnect_NextAttemptInFuture(t *testing.T) {
 
 	if !next.After(time.Now()) {
 		t.Errorf("nextAttempt = %v is not in the future after disconnect", next)
+	}
+}
+
+// TestConnectSpeaker_UnstableSession_DoublesRetryDelay verifies that a
+// short-lived BMP session (e.g. a proxy that accepts TCP but drops BMP
+// immediately) causes retryDelay to double rather than reset to 1 s.
+func TestConnectSpeaker_UnstableSession_DoublesRetryDelay(t *testing.T) {
+	old := stableSessionThreshold
+	stableSessionThreshold = 5 * time.Second // far longer than the test session
+	t.Cleanup(func() { stableSessionThreshold = old })
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	srv, cleanup := newConnectSpeakerSrv()
+	defer cleanup()
+
+	// Set an elevated retryDelay to verify the doubling starts from the
+	// pre-connection value, not from a reset-to-1s on TCP connect.
+	const initial = 3 * time.Second
+	speaker := &bgpSpeaker{Address: ln.Addr().String(), retryDelay: initial}
+	done := runConnectSpeaker(srv, speaker)
+
+	conn, err := acceptWithTimeout(ln, 3*time.Second)
+	if err != nil {
+		t.Fatalf("accepting connection: %v", err)
+	}
+	_ = conn.Close() // immediate drop — simulates proxy behaviour
+
+	time.Sleep(100 * time.Millisecond)
+	cleanup()
+	assertExitsWithin(t, done, 2*time.Second)
+
+	speaker.mu.Lock()
+	got := speaker.retryDelay
+	speaker.mu.Unlock()
+
+	// Unstable session: retryDelay must double from its pre-connection value.
+	if got != initial*2 {
+		t.Errorf("retryDelay after unstable session = %v, want %v", got, initial*2)
+	}
+}
+
+// TestConnectSpeaker_StableSession_ResetsRetryDelay verifies that a long-lived
+// BMP session resets retryDelay to 1 s on disconnect, enabling a fast reconnect.
+func TestConnectSpeaker_StableSession_ResetsRetryDelay(t *testing.T) {
+	old := stableSessionThreshold
+	stableSessionThreshold = 50 * time.Millisecond // short enough for a unit test
+	t.Cleanup(func() { stableSessionThreshold = old })
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	srv, cleanup := newConnectSpeakerSrv()
+	defer cleanup()
+
+	speaker := &bgpSpeaker{Address: ln.Addr().String(), retryDelay: 3 * time.Minute}
+	done := runConnectSpeaker(srv, speaker)
+
+	conn, err := acceptWithTimeout(ln, 3*time.Second)
+	if err != nil {
+		t.Fatalf("accepting connection: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond) // exceed the 50 ms threshold
+	_ = conn.Close()
+
+	time.Sleep(100 * time.Millisecond)
+	cleanup()
+	assertExitsWithin(t, done, 2*time.Second)
+
+	speaker.mu.Lock()
+	got := speaker.retryDelay
+	speaker.mu.Unlock()
+
+	if got != 1*time.Second {
+		t.Errorf("retryDelay after stable session = %v, want 1s", got)
 	}
 }
 

--- a/pkg/gobmpsrv/gobmpsrv_test.go
+++ b/pkg/gobmpsrv/gobmpsrv_test.go
@@ -1412,6 +1412,24 @@ func TestNewBMPServer_MaxPassiveConnections_Zero_NoConnSem(t *testing.T) {
 	srv.Stop()
 }
 
+// TestNewBMPServer_MaxPassiveConnections_Negative rejects a negative
+// MaxPassiveConnections before it reaches make(chan struct{}, n), which would panic.
+func TestNewBMPServer_MaxPassiveConnections_Negative(t *testing.T) {
+	srv, err := NewBMPServer(&config.Config{
+		Publisher:             newMockPublisher(),
+		MaxPassiveConnections: -1,
+	})
+	if err == nil {
+		if srv != nil {
+			srv.Stop()
+		}
+		t.Fatal("expected error for negative MaxPassiveConnections, got nil")
+	}
+	if srv != nil {
+		t.Errorf("expected nil server on validation error, got %v", srv)
+	}
+}
+
 // TestConnectionLimit_RejectsAtCapacity verifies that connections beyond
 // MaxPassiveConnections are rejected immediately.
 func TestConnectionLimit_RejectsAtCapacity(t *testing.T) {
@@ -1464,6 +1482,14 @@ func TestBMPServer_ConnectionLimit_ServerRejects(t *testing.T) {
 	srv.connSem <- struct{}{}
 
 	srv.Start()
+	defer func() {
+		// Drain the semaphore so Stop() does not hang waiting for bmpWorker exits.
+		select {
+		case <-srv.connSem:
+		default:
+		}
+		srv.Stop()
+	}()
 
 	port := ln.Addr().(*net.TCPAddr).Port
 	client, err := net.Dial("tcp", "127.0.0.1:"+strconv.Itoa(port))
@@ -1472,17 +1498,18 @@ func TestBMPServer_ConnectionLimit_ServerRejects(t *testing.T) {
 	}
 	defer func() { _ = client.Close() }()
 
-	// Server should close the connection immediately — client reads EOF or error.
+	// Server should close the connection immediately — client reads EOF or reset,
+	// not a timeout. A timeout would mean the server never closed the connection.
 	_ = client.SetReadDeadline(time.Now().Add(time.Second))
 	buf := make([]byte, 1)
 	_, err = client.Read(buf)
 	if err == nil {
-		t.Error("expected connection to be rejected, but read succeeded")
+		t.Fatal("expected connection to be rejected, but read succeeded")
 	}
-
-	// Drain the semaphore so Stop() does not hang waiting for bmpWorker exits.
-	<-srv.connSem
-	srv.Stop()
+	var nerr net.Error
+	if errors.As(err, &nerr) && nerr.Timeout() {
+		t.Fatalf("expected server to close connection, but read timed out: %v", err)
+	}
 }
 
 // TestStartWorker_WhenClosing_ReleasesSemaphore verifies the semaphore slot

--- a/pkg/gobmpsrv/gobmpsrv_test.go
+++ b/pkg/gobmpsrv/gobmpsrv_test.go
@@ -1186,12 +1186,9 @@ func TestConnectSpeaker_NextAttemptInFutureAfterFailure(t *testing.T) {
 	}
 }
 
-// TestConnectSpeaker_BackoffNotResetDuringActiveSession verifies that
-// retryDelay is NOT reset at connection time — it is only reset after
-// bmpWorker exits following a stable session (≥ stableSessionThreshold).
-// This prevents a proxy that accepts TCP but immediately drops the BMP
-// session from resetting the backoff and causing a 1-second retry loop.
-func TestConnectSpeaker_BackoffNotResetDuringActiveSession(t *testing.T) {
+// TestConnectSpeaker_BackoffResetOnSuccess verifies that retryDelay is reset
+// to 1 second after a successful dial, regardless of how high it had grown.
+func TestConnectSpeaker_BackoffResetOnSuccess(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Listen: %v", err)
@@ -1201,7 +1198,7 @@ func TestConnectSpeaker_BackoffNotResetDuringActiveSession(t *testing.T) {
 	srv, cleanup := newConnectSpeakerSrv()
 	defer cleanup()
 
-	// Pre-set a high retryDelay; it must NOT be reset while the session is live.
+	// Pre-set a high retryDelay to verify it gets reset on success.
 	speaker := &bgpSpeaker{Address: ln.Addr().String(), retryDelay: 3 * time.Minute}
 	done := runConnectSpeaker(srv, speaker)
 
@@ -1218,10 +1215,8 @@ func TestConnectSpeaker_BackoffNotResetDuringActiveSession(t *testing.T) {
 	delay := speaker.retryDelay
 	speaker.mu.Unlock()
 
-	// retryDelay must be unchanged: the reset only happens post-disconnect
-	// for sessions that lasted ≥ stableSessionThreshold.
-	if delay != 3*time.Minute {
-		t.Errorf("retryDelay during active session = %v, want 3m (should not be reset at connect time)", delay)
+	if delay != 1*time.Second {
+		t.Errorf("retryDelay after successful connect = %v, want 1s", delay)
 	}
 
 	cleanup()
@@ -1297,126 +1292,166 @@ func TestConnectSpeaker_ClosingFlag_ExitsAfterSuccessfulDial(t *testing.T) {
 	assertExitsWithin(t, runConnectSpeaker(srv, speaker), 3*time.Second)
 }
 
-// TestConnectSpeaker_ShortLivedSession_BackoffDoubles verifies that when
-// bmpWorker exits before stableSessionThreshold elapses (simulating a proxy
-// that accepts TCP but drops the BMP session), retryDelay is doubled rather
-// than reset.
-func TestConnectSpeaker_ShortLivedSession_BackoffDoubles(t *testing.T) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+// TestNewBMPServer_MaxPassiveConnections_SetsConnSem verifies that MaxPassiveConnections > 0
+// creates a semaphore with the correct capacity on the passive-mode server.
+func TestNewBMPServer_MaxPassiveConnections_SetsConnSem(t *testing.T) {
+	srv, err := NewBMPServer(&config.Config{
+		Publisher:             newMockPublisher(),
+		MaxPassiveConnections: 5,
+	})
 	if err != nil {
-		t.Fatalf("Listen: %v", err)
+		t.Fatalf("NewBMPServer: %v", err)
 	}
-	defer func() { _ = ln.Close() }()
+	bs := srv.(*bmpServer)
+	if bs.connSem == nil {
+		t.Fatal("connSem is nil, want non-nil channel")
+	}
+	if cap(bs.connSem) != 5 {
+		t.Errorf("cap(connSem) = %d, want 5", cap(bs.connSem))
+	}
+	srv.Stop()
+}
 
-	srv, cleanup := newConnectSpeakerSrv()
-	defer cleanup()
-
-	speaker := &bgpSpeaker{Address: ln.Addr().String(), retryDelay: 1 * time.Second}
-	done := runConnectSpeaker(srv, speaker)
-
-	conn, err := acceptWithTimeout(ln, 3*time.Second)
+// TestNewBMPServer_MaxPassiveConnections_Zero_NoConnSem verifies that MaxPassiveConnections == 0
+// (the default) leaves connSem nil, meaning no connection limit is enforced.
+func TestNewBMPServer_MaxPassiveConnections_Zero_NoConnSem(t *testing.T) {
+	srv, err := NewBMPServer(&config.Config{Publisher: newMockPublisher()})
 	if err != nil {
-		t.Fatalf("accepting connection: %v", err)
+		t.Fatalf("NewBMPServer: %v", err)
 	}
-	// Drop the connection immediately — session lasts < stableSessionThreshold.
-	_ = conn.Close()
+	bs := srv.(*bmpServer)
+	if bs.connSem != nil {
+		t.Errorf("connSem = %v, want nil when MaxPassiveConnections == 0", bs.connSem)
+	}
+	srv.Stop()
+}
 
-	// Give connectSpeaker time to process the disconnect and apply backoff.
-	time.Sleep(100 * time.Millisecond)
-	cleanup()
-	assertExitsWithin(t, done, 2*time.Second)
+// TestConnectionLimit_RejectsAtCapacity verifies that connections beyond
+// MaxPassiveConnections are rejected immediately.
+func TestConnectionLimit_RejectsAtCapacity(t *testing.T) {
+	// Semaphore of size 1 — first connection succeeds, second is rejected.
+	srv := &bmpServer{
+		clients:   make(map[net.Conn]struct{}),
+		publisher: newMockPublisher(),
+		connSem:   make(chan struct{}, 1),
+	}
 
-	speaker.mu.Lock()
-	delay := speaker.retryDelay
-	speaker.mu.Unlock()
+	// Fill the semaphore (simulate one active connection).
+	srv.connSem <- struct{}{}
 
-	if delay != 2*time.Second {
-		t.Errorf("retryDelay after short-lived disconnect = %v, want 2s (doubled from 1s)", delay)
+	// Second connection should be rejected.
+	serverConn, clientConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+
+	// Simulate what server() does: try to acquire, fail, close.
+	select {
+	case srv.connSem <- struct{}{}:
+		t.Fatal("semaphore should be full")
+	default:
+		_ = serverConn.Close()
+	}
+
+	// Verify client sees the close.
+	_ = clientConn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	buf := make([]byte, 1)
+	_, err := clientConn.Read(buf)
+	if err == nil {
+		t.Error("expected read error after rejected connection close")
 	}
 }
 
-// TestConnectSpeaker_ShortLivedSession_BackoffCapped verifies that the
-// doubled retryDelay is capped at 5 minutes, even when the raw double would
-// exceed that ceiling.
-func TestConnectSpeaker_ShortLivedSession_BackoffCapped(t *testing.T) {
+// TestBMPServer_ConnectionLimit_ServerRejects exercises the semaphore default
+// branch in server(): when connSem is full the accepted connection is closed
+// and the loop continues without calling startWorker.
+func TestBMPServer_ConnectionLimit_ServerRejects(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Listen: %v", err)
 	}
-	defer func() { _ = ln.Close() }()
-
-	srv, cleanup := newConnectSpeakerSrv()
-	defer cleanup()
-
-	// retryDelay is already at 4 minutes; doubling gives 8 minutes which
-	// exceeds the 5-minute cap.
-	speaker := &bgpSpeaker{Address: ln.Addr().String(), retryDelay: 4 * time.Minute}
-	done := runConnectSpeaker(srv, speaker)
-
-	conn, err := acceptWithTimeout(ln, 3*time.Second)
-	if err != nil {
-		t.Fatalf("accepting connection: %v", err)
+	srv := &bmpServer{
+		clients:   make(map[net.Conn]struct{}),
+		publisher: newMockPublisher(),
+		incoming:  ln,
+		connSem:   make(chan struct{}, 1),
 	}
-	// Drop the connection immediately — session lasts < stableSessionThreshold.
-	_ = conn.Close()
+	// Pre-fill the semaphore — all capacity consumed, next connection will be rejected.
+	srv.connSem <- struct{}{}
 
-	// Give connectSpeaker time to process the disconnect and apply backoff.
-	time.Sleep(100 * time.Millisecond)
-	cleanup()
-	assertExitsWithin(t, done, 2*time.Second)
+	srv.Start()
 
-	speaker.mu.Lock()
-	delay := speaker.retryDelay
-	speaker.mu.Unlock()
+	port := ln.Addr().(*net.TCPAddr).Port
+	client, err := net.Dial("tcp", "127.0.0.1:"+strconv.Itoa(port))
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer func() { _ = client.Close() }()
 
-	if delay != 5*time.Minute {
-		t.Errorf("retryDelay after short-lived disconnect = %v, want 5m (capped from 8m)", delay)
+	// Server should close the connection immediately — client reads EOF or error.
+	_ = client.SetReadDeadline(time.Now().Add(time.Second))
+	buf := make([]byte, 1)
+	_, err = client.Read(buf)
+	if err == nil {
+		t.Error("expected connection to be rejected, but read succeeded")
+	}
+
+	// Drain the semaphore so Stop() does not hang waiting for bmpWorker exits.
+	<-srv.connSem
+	srv.Stop()
+}
+
+// TestStartWorker_WhenClosing_ReleasesSemaphore verifies the semaphore slot
+// is released when startWorker returns early due to srv.closing.
+func TestStartWorker_WhenClosing_ReleasesSemaphore(t *testing.T) {
+	srv := &bmpServer{
+		clients:   make(map[net.Conn]struct{}),
+		publisher: newMockPublisher(),
+		connSem:   make(chan struct{}, 1),
+	}
+	srv.closing = true
+
+	// Simulate server() acquiring the semaphore before calling startWorker.
+	srv.connSem <- struct{}{}
+
+	serverConn, clientConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+
+	srv.startWorker(serverConn)
+
+	// Semaphore should be drained (released by startWorker's early-return path).
+	select {
+	case srv.connSem <- struct{}{}:
+		// Successfully acquired — slot was released. Pass.
+		<-srv.connSem
+	default:
+		t.Error("semaphore slot not released after startWorker early return")
 	}
 }
 
-// TestConnectSpeaker_StableSession_BackoffResets verifies that when bmpWorker
-// runs for at least stableSessionThreshold before disconnecting, retryDelay is
-// reset to 1 s regardless of how high it had grown.
-// The test temporarily lowers stableSessionThreshold to 50 ms so no real
-// wall-clock wait is necessary.
-func TestConnectSpeaker_StableSession_BackoffResets(t *testing.T) {
-	// Shorten the threshold for this test and restore it on exit.
-	orig := stableSessionThreshold
-	stableSessionThreshold = 50 * time.Millisecond
-	defer func() { stableSessionThreshold = orig }()
+// TestStartWorker_ConnSem_ReleasedOnWorkerExit verifies that the goroutine
+// defer inside startWorker releases the semaphore slot when bmpWorker exits.
+func TestStartWorker_ConnSem_ReleasedOnWorkerExit(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("Listen: %v", err)
+	srv := &bmpServer{
+		clients:   make(map[net.Conn]struct{}),
+		publisher: newMockPublisher(),
+		connSem:   make(chan struct{}, 1),
 	}
-	defer func() { _ = ln.Close() }()
+	// Simulate server() acquiring the semaphore before startWorker.
+	srv.connSem <- struct{}{}
 
-	srv, cleanup := newConnectSpeakerSrv()
-	defer cleanup()
+	srv.startWorker(serverConn)
 
-	// Pre-set a high retryDelay; it should be reset after a stable session.
-	speaker := &bgpSpeaker{Address: ln.Addr().String(), retryDelay: 3 * time.Minute}
-	done := runConnectSpeaker(srv, speaker)
+	// Closing the client causes bmpWorker to see io.EOF and return,
+	// triggering the defer that releases the semaphore slot.
+	_ = clientConn.Close()
 
-	conn, err := acceptWithTimeout(ln, 3*time.Second)
-	if err != nil {
-		t.Fatalf("accepting connection: %v", err)
-	}
-
-	// Hold the connection open long enough to exceed stableSessionThreshold.
-	time.Sleep(150 * time.Millisecond)
-	_ = conn.Close()
-
-	// Give connectSpeaker time to process the disconnect and compute backoff.
-	time.Sleep(100 * time.Millisecond)
-	cleanup()
-	assertExitsWithin(t, done, 2*time.Second)
-
-	speaker.mu.Lock()
-	delay := speaker.retryDelay
-	speaker.mu.Unlock()
-
-	if delay != 1*time.Second {
-		t.Errorf("retryDelay after stable session = %v, want 1s (reset from 3m)", delay)
+	// Slot must be re-acquirable within a generous deadline.
+	select {
+	case srv.connSem <- struct{}{}:
+		<-srv.connSem // cleanup
+	case <-time.After(2 * time.Second):
+		t.Fatal("connSem slot not released after bmpWorker exit")
 	}
 }

--- a/pkg/gobmpsrv/gobmpsrv_test.go
+++ b/pkg/gobmpsrv/gobmpsrv_test.go
@@ -1330,6 +1330,23 @@ func TestConnectSpeaker_StableSession_ResetsRetryDelay(t *testing.T) {
 	if err != nil {
 		t.Fatalf("accepting connection: %v", err)
 	}
+	// Wait for connectSpeaker to mark the speaker connected before timing the
+	// stable-session window. Sleeping before connectedAt is recorded races with
+	// the goroutine inside connectSpeaker and the elapsed session can register
+	// below stableSessionThreshold on slow CI runners, making the test flaky.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		speaker.mu.Lock()
+		connected := speaker.isConnected
+		speaker.mu.Unlock()
+		if connected {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for speaker.isConnected to become true")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 	time.Sleep(100 * time.Millisecond) // exceed the 50 ms threshold
 	_ = conn.Close()
 


### PR DESCRIPTION
## Summary

- **SEC-01**: `MaxPassiveConnections` in `config.Config` (YAML: `max_passive_connections`) caps concurrent BMP sessions in passive mode via a channel semaphore. Zero (the default) means no limit. Excess connections are rejected immediately with a Warning log showing the configured limit. Negative values are rejected at `NewBMPServer` with a clear error.

Operator-tunable via YAML and defaults to disabled for backward compatibility. Not applied in active mode (which manages a fixed speaker list).

Note: a per-connection read deadline (SEC-02) is not part of this PR and will be proposed separately.