### PR TITLE
Fix stale comment typos

### DIFF
--- a/pkg/bgp/mp-unreach-nlri.go
+++ b/pkg/bgp/mp-unreach-nlri.go
@@ -43,8 +43,9 @@ func (mp *MPUnReachNLRI) GetNextHop() string {
 	return ""
 }
 
-// IsNextHopIPv6 return true if the next hop is IPv6 address, otherwise it returns flase.
-// in case of MP_UNREACH_NLRI there is no Next Hope field and this func should not be used.
+// IsNextHopIPv6 always returns false: MP_UNREACH_NLRI (path attribute 15) carries withdrawn
+// routes only and has no Next Hop field (RFC 4760 §3). Implementing MPNLRI keeps this method
+// for interface symmetry with MP_REACH_NLRI; callers must not infer next hop from it.
 func (mp *MPUnReachNLRI) IsNextHopIPv6() bool {
 	return false
 }

--- a/pkg/message/srpolicy.go
+++ b/pkg/message/srpolicy.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sbezverk/gobmp/pkg/srpolicy"
 )
 
-// evpn process MP_REACH_NLRI AFI 25 SAFI 70 update message and returns
-// EVPN prefix object.
+// srpolicy processes SR Policy NLRI (AFI 1 or 2, SAFI 73) from either MP_REACH_NLRI or
+// MP_UNREACH_NLRI in processMPUpdate and returns an SR Policy prefix object.
 func (p *producer) srpolicy(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *bgp.Update) ([]*SRPolicy, error) {
 	sr, err := nlri.GetNLRI73()
 	if err != nil {


### PR DESCRIPTION
- `IsNextHopIPv6` doc comment: `flase` → `false`, `Next Hope` → `Next Hop` (IMP-13)
- `srpolicy` function doc: copied from EVPN, corrected to SR Policy AFI 1/2 SAFI 73 (IMP-14)
- `.codecov.yml`: add 1% project/patch threshold to absorb rounding noise from comment-only diffs