### PR TITLE
Clean up pkg/message code style

### DIFF
--- a/pkg/message/evpn.go
+++ b/pkg/message/evpn.go
@@ -3,6 +3,7 @@ package message
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/sbezverk/gobmp/pkg/bgp"
@@ -63,12 +64,14 @@ func (p *producer) evpn(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *
 			prfx.RouteType = e.GetEVPNRouteType()
 			esi := e.GetEVPNESI()
 			if esi != nil {
+				var b strings.Builder
 				for i := 0; i < ESILength; i++ {
-					prfx.ESI += fmt.Sprintf("%02x", esi[i])
-					if i < ESILength-1 {
-						prfx.ESI += ":"
+					if i > 0 {
+						b.WriteByte(':')
 					}
+					fmt.Fprintf(&b, "%02x", esi[i])
 				}
+				prfx.ESI = b.String()
 			}
 			prfx.EthTag = e.GetEVPNTAG()
 			if ip := e.GetEVPNIPLength(); ip != nil {
@@ -94,12 +97,14 @@ func (p *producer) evpn(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *
 			if mac := e.GetEVPNMACLength(); mac != nil {
 				prfx.MACLength = *mac
 				v := e.GetEVPNMAC()
+				var b strings.Builder
 				for i := 0; i < int(prfx.MACLength/8); i++ {
-					prfx.MAC += fmt.Sprintf("%02x", v[i])
-					if i < int(prfx.MACLength/8)-1 {
-						prfx.MAC += ":"
+					if i > 0 {
+						b.WriteByte(':')
 					}
+					fmt.Fprintf(&b, "%02x", v[i])
 				}
+				prfx.MAC = b.String()
 			}
 
 			for _, l := range e.GetEVPNLabel() {

--- a/pkg/message/evpn_ipv6_test.go
+++ b/pkg/message/evpn_ipv6_test.go
@@ -22,23 +22,23 @@ type evpnMockNLRI struct {
 	isIPv6  bool
 }
 
-func (m *evpnMockNLRI) GetAFISAFIType() int                            { return 24 }
-func (m *evpnMockNLRI) GetNLRILU() (*base.MPNLRI, error)               { return nil, nil }
-func (m *evpnMockNLRI) GetNLRIUnicast() (*base.MPNLRI, error)          { return nil, nil }
-func (m *evpnMockNLRI) GetNLRIMulticast() (*base.MPNLRI, error)        { return nil, nil }
-func (m *evpnMockNLRI) GetNLRIEVPN() (*evpn.Route, error)              { return m.route, nil }
-func (m *evpnMockNLRI) GetNLRIVPLS() (*vpls.Route, error)              { return nil, nil }
-func (m *evpnMockNLRI) GetNLRIL3VPN() (*base.MPNLRI, error)            { return nil, nil }
-func (m *evpnMockNLRI) GetNLRI71() (*ls.NLRI71, error)                 { return nil, nil }
-func (m *evpnMockNLRI) GetNLRI73() (*srpolicy.NLRI73, error)           { return nil, nil }
-func (m *evpnMockNLRI) GetFlowspecNLRI() (*flowspec.NLRI, error)       { return nil, nil }
-func (m *evpnMockNLRI) GetAllFlowspecNLRI() ([]*flowspec.NLRI, error)  { return nil, nil }
-func (m *evpnMockNLRI) GetNLRIMCASTVPN() (*mcastvpn.Route, error)      { return nil, nil }
-func (m *evpnMockNLRI) GetNLRIMVPN() (*mcastvpn.Route, error)          { return nil, nil }
-func (m *evpnMockNLRI) GetNLRIRTC() (*rtc.Route, error)                { return nil, nil }
-func (m *evpnMockNLRI) GetNextHop() string                             { return m.nextHop }
-func (m *evpnMockNLRI) IsIPv6NLRI() bool                               { return m.isIPv6 }
-func (m *evpnMockNLRI) IsNextHopIPv6() bool                            { return m.isIPv6 }
+func (m *evpnMockNLRI) GetAFISAFIType() int                           { return 24 }
+func (m *evpnMockNLRI) GetNLRILU() (*base.MPNLRI, error)              { return nil, nil }
+func (m *evpnMockNLRI) GetNLRIUnicast() (*base.MPNLRI, error)         { return nil, nil }
+func (m *evpnMockNLRI) GetNLRIMulticast() (*base.MPNLRI, error)       { return nil, nil }
+func (m *evpnMockNLRI) GetNLRIEVPN() (*evpn.Route, error)             { return m.route, nil }
+func (m *evpnMockNLRI) GetNLRIVPLS() (*vpls.Route, error)             { return nil, nil }
+func (m *evpnMockNLRI) GetNLRIL3VPN() (*base.MPNLRI, error)           { return nil, nil }
+func (m *evpnMockNLRI) GetNLRI71() (*ls.NLRI71, error)                { return nil, nil }
+func (m *evpnMockNLRI) GetNLRI73() (*srpolicy.NLRI73, error)          { return nil, nil }
+func (m *evpnMockNLRI) GetFlowspecNLRI() (*flowspec.NLRI, error)      { return nil, nil }
+func (m *evpnMockNLRI) GetAllFlowspecNLRI() ([]*flowspec.NLRI, error) { return nil, nil }
+func (m *evpnMockNLRI) GetNLRIMCASTVPN() (*mcastvpn.Route, error)     { return nil, nil }
+func (m *evpnMockNLRI) GetNLRIMVPN() (*mcastvpn.Route, error)         { return nil, nil }
+func (m *evpnMockNLRI) GetNLRIRTC() (*rtc.Route, error)               { return nil, nil }
+func (m *evpnMockNLRI) GetNextHop() string                            { return m.nextHop }
+func (m *evpnMockNLRI) IsIPv6NLRI() bool                              { return m.isIPv6 }
+func (m *evpnMockNLRI) IsNextHopIPv6() bool                           { return m.isIPv6 }
 
 func buildEVPNType5IPv6Wire() []byte {
 	// EVPN Type 5 IPv6: RD(8)+ESI(10)+EthTag(4)+IPLen(1)+IPv6(16)+GW(16)+Label(3) = 58
@@ -204,5 +204,67 @@ func TestEvpnIPv4Address(t *testing.T) {
 	}
 	if prfxs[0].IPLength != 24 {
 		t.Errorf("IPLength = %d, want 24", prfxs[0].IPLength)
+	}
+}
+
+// buildEVPNType2Wire builds a minimal Type 2 (MAC/IP Advertisement) EVPN wire message.
+// Wire: RouteType(1) + Length(1) + RD(8) + ESI(10) + EthTag(4) + MACLen(1) + MAC(6) + IPLen(1) + Label(3)
+func buildEVPNType2Wire(esi [10]byte, mac [6]byte) []byte {
+	data := make([]byte, 33) // RD+ESI+EthTag+MACLen+MAC+IPLen+Label
+	copy(data[8:18], esi[:])
+	data[22] = 48 // MACAddrLength in bits
+	copy(data[23:29], mac[:])
+	// data[29] = 0 (IPAddrLength = 0)
+	// data[30:33] = label = {0,0,0}
+	wire := make([]byte, 35)
+	wire[0] = 2  // RouteType
+	wire[1] = 33 // Length
+	copy(wire[2:], data)
+	return wire
+}
+
+func TestEvpnType2ESIAndMAC(t *testing.T) {
+	prod := &producer{
+		speakerHash: "test-hash",
+		speakerIP:   "10.0.0.1",
+		publisher:   &mockPublisher{},
+	}
+
+	esi := [10]byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99}
+	mac := [6]byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}
+
+	route, err := evpn.UnmarshalEVPNNLRI(buildEVPNType2Wire(esi, mac))
+	if err != nil {
+		t.Fatalf("UnmarshalEVPNNLRI() error: %v", err)
+	}
+
+	nlri := &evpnMockNLRI{
+		route:   route,
+		nextHop: "10.0.0.1",
+		isIPv6:  false,
+	}
+
+	ph := &bmp.PerPeerHeader{
+		PeerType:          0,
+		PeerBGPID:         make([]byte, 4),
+		PeerAddress:       make([]byte, 16),
+		PeerDistinguisher: make([]byte, 8),
+		PeerTimestamp:     make([]byte, 8),
+	}
+
+	update := &bgp.Update{BaseAttributes: &bgp.BaseAttributes{}}
+
+	prfxs, err := prod.evpn(nlri, 0, ph, update)
+	if err != nil {
+		t.Fatalf("evpn() error: %v", err)
+	}
+	if len(prfxs) != 1 {
+		t.Fatalf("got %d prefixes, want 1", len(prfxs))
+	}
+	if prfxs[0].ESI != "00:11:22:33:44:55:66:77:88:99" {
+		t.Errorf("ESI = %q, want '00:11:22:33:44:55:66:77:88:99'", prfxs[0].ESI)
+	}
+	if prfxs[0].MAC != "aa:bb:cc:dd:ee:ff" {
+		t.Errorf("MAC = %q, want 'aa:bb:cc:dd:ee:ff'", prfxs[0].MAC)
 	}
 }

--- a/pkg/message/mcastvpn.go
+++ b/pkg/message/mcastvpn.go
@@ -82,8 +82,9 @@ func (p *producer) mcastvpn(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, upda
 		prfx.IsIPv4 = !nlri.IsIPv6NLRI()
 
 		// Extract nexthop
-		prfx.Nexthop = nlri.GetNextHop()
-		prfx.IsNexthopIPv4 = len(nlri.GetNextHop()) > 0 && net.ParseIP(nlri.GetNextHop()).To4() != nil
+		nh := nlri.GetNextHop()
+		prfx.Nexthop = nh
+		prfx.IsNexthopIPv4 = len(nh) > 0 && net.ParseIP(nh).To4() != nil
 
 		// Extract Route Distinguisher if present
 		if rd := route.GetMCASTVPNRD(); rd != nil {

--- a/pkg/message/message_handlers_test.go
+++ b/pkg/message/message_handlers_test.go
@@ -544,6 +544,46 @@ func TestMVPN_EoR_RIBFlags(t *testing.T) {
 	}
 }
 
+// TestProcessMPUpdate_UnicastBranches exercises the consolidated
+// case 1, 2, 16, 17 branch of processMPUpdate for all AFI/SAFI combinations:
+// AFI=1/SAFI=1 (IPv4 Unicast), AFI=2/SAFI=1 (IPv6 Unicast),
+// AFI=1/SAFI=4 (IPv4 Labeled Unicast), AFI=2/SAFI=4 (IPv6 Labeled Unicast).
+// The `labeled := nlri.GetAFISAFIType() >= 16` shortcut must select the
+// right path for each combination.
+func TestProcessMPUpdate_UnicastBranches(t *testing.T) {
+	tests := []struct {
+		name string
+		afi  byte
+		safi byte
+	}{
+		{"IPv4 Unicast", 0x01, 0x01},
+		{"IPv6 Unicast", 0x02, 0x01},
+		{"IPv4 Labeled Unicast", 0x01, 0x04},
+		{"IPv6 Labeled Unicast", 0x02, 0x04},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewProducer(&mockPublisher{}, false).(*producer)
+			p.speakerIP = "10.0.0.1"
+			p.speakerHash = "abc123"
+
+			ph := makePeerHeader(t, bmp.PeerType0, 0x00)
+			update := &bgp.Update{BaseAttributes: &bgp.BaseAttributes{}}
+
+			// MP_UNREACH_NLRI with empty withdrawn routes — EoR marker that
+			// still exercises the switch branch without requiring a full
+			// unicast parse.
+			unreachBytes := []byte{0x00, tt.afi, tt.safi}
+			nlri, err := bgp.UnmarshalMPUnReachNLRI(unreachBytes, map[int]bool{})
+			if err != nil {
+				t.Fatalf("UnmarshalMPUnReachNLRI: %v", err)
+			}
+
+			p.processMPUpdate(nlri, 1, ph, update)
+		})
+	}
+}
+
 // TestProcessMPUpdate_UnknownAFISAFI verifies default case logs warning for unknown types.
 func TestProcessMPUpdate_UnknownAFISAFI(t *testing.T) {
 	p := NewProducer(&mockPublisher{}, false).(*producer)

--- a/pkg/message/message_handlers_test.go
+++ b/pkg/message/message_handlers_test.go
@@ -138,6 +138,49 @@ func TestMVPN_RIBFlags_AllFive(t *testing.T) {
 	}
 }
 
+// TestMCASTVPN_Nexthop verifies the mcastvpn handler extracts the nexthop correctly.
+func TestMCASTVPN_Nexthop(t *testing.T) {
+	p := NewProducer(&mockPublisher{}, false).(*producer)
+	p.speakerIP = "10.0.0.1"
+	p.speakerHash = "abc123"
+
+	ph := makePeerHeader(t, bmp.PeerType0, 0x00)
+	update := &bgp.Update{BaseAttributes: &bgp.BaseAttributes{}}
+
+	// MCAST-VPN (SAFI 5) Type 1 route: RD(8) + OriginatorIP(4) = 12 bytes
+	reachWithRoute := []byte{
+		0x00, 0x01, // AFI: 1
+		0x05,                   // SAFI: 5
+		0x04,                   // NH Length: 4
+		0x0a, 0x00, 0x00, 0x01, // NextHop: 10.0.0.1
+		0x00, // Reserved
+		0x01, // Route Type: 1 (Intra-AS I-PMSI A-D)
+		0x0C, // Length: 12
+		// RD (8 bytes)
+		0x00, 0x02, 0x00, 0x00, 0xFD, 0xE8, 0x00, 0x64,
+		// Originator IP (4 bytes)
+		0x0a, 0x00, 0x00, 0x01,
+	}
+	nlri, err := bgp.UnmarshalMPReachNLRI(reachWithRoute, false, map[int]bool{})
+	if err != nil {
+		t.Fatalf("UnmarshalMPReachNLRI: %v", err)
+	}
+
+	msgs, err := p.mcastvpn(nlri, 0, ph, update)
+	if err != nil {
+		t.Fatalf("mcastvpn() error: %v", err)
+	}
+	if len(msgs) < 1 {
+		t.Fatal("mcastvpn() returned 0 messages")
+	}
+	if msgs[0].Nexthop != "10.0.0.1" {
+		t.Errorf("Nexthop = %q, want '10.0.0.1'", msgs[0].Nexthop)
+	}
+	if !msgs[0].IsNexthopIPv4 {
+		t.Error("IsNexthopIPv4 = false, want true")
+	}
+}
+
 // TestL3VPN_TableName verifies L3VPN handler sets TableName for LocRIB peers.
 func TestL3VPN_TableName(t *testing.T) {
 	p := NewProducer(&mockPublisher{}, false).(*producer)

--- a/pkg/message/message_handlers_test.go
+++ b/pkg/message/message_handlers_test.go
@@ -1,6 +1,8 @@
 package message
 
 import (
+	"encoding/json"
+	"sync"
 	"testing"
 
 	"github.com/sbezverk/gobmp/pkg/base"
@@ -8,6 +10,28 @@ import (
 	"github.com/sbezverk/gobmp/pkg/bmp"
 	"github.com/sbezverk/gobmp/pkg/mcastvpn"
 )
+
+// recordingPublisher captures PublishMessage calls for test assertions.
+type recordingPublisher struct {
+	mu   sync.Mutex
+	msgs []recordedMsg
+}
+
+type recordedMsg struct {
+	msgType int
+	payload []byte
+}
+
+func (r *recordingPublisher) PublishMessage(msgType int, msgHash []byte, msg []byte) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	payload := make([]byte, len(msg))
+	copy(payload, msg)
+	r.msgs = append(r.msgs, recordedMsg{msgType: msgType, payload: payload})
+	return nil
+}
+
+func (r *recordingPublisher) Stop() {}
 
 // makePeerHeader constructs a PerPeerHeader with the given flags byte.
 func makePeerHeader(t *testing.T, peerType bmp.PeerType, flagsByte byte) *bmp.PerPeerHeader {
@@ -548,38 +572,83 @@ func TestMVPN_EoR_RIBFlags(t *testing.T) {
 // case 1, 2, 16, 17 branch of processMPUpdate for all AFI/SAFI combinations:
 // AFI=1/SAFI=1 (IPv4 Unicast), AFI=2/SAFI=1 (IPv6 Unicast),
 // AFI=1/SAFI=4 (IPv4 Labeled Unicast), AFI=2/SAFI=4 (IPv6 Labeled Unicast).
-// The `labeled := nlri.GetAFISAFIType() >= 16` shortcut must select the
-// right path for each combination.
+// Each case feeds a non-EoR MP_REACH_NLRI through processMPUpdate and asserts
+// the recorded publish. The `labeled := nlri.GetAFISAFIType() >= 16` shortcut
+// is observable via the presence/absence of parsed Labels; splitAF topic
+// selection makes IPv4 vs IPv6 dispatch observable via the msg type.
 func TestProcessMPUpdate_UnicastBranches(t *testing.T) {
+	// IPv4 nexthop (1.1.1.1) and IPv6 nexthop (2001::1) for MP_REACH payloads.
+	nhV4 := []byte{0x01, 0x01, 0x01, 0x01}
+	nhV6 := []byte{0x20, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01}
+
+	// IPv4 unicast NLRI: 10.0.0.0/8 => [prefix_len_bits, prefix_bytes...]
+	nlriV4Unicast := []byte{0x08, 0x0A}
+	// IPv6 unicast NLRI: 2001::/16
+	nlriV6Unicast := []byte{0x10, 0x20, 0x01}
+	// IPv4 labeled unicast NLRI: length 56 bits (24 label + 32 prefix),
+	// label=3 BoS, prefix 10.0.0.0/32. Mirrors pkg/unicast/unicast_test.go fixture.
+	nlriV4Labeled := []byte{0x38, 0x00, 0x00, 0x31, 0x0a, 0x00, 0x00, 0x00}
+	// IPv6 labeled unicast NLRI: length 40 bits (24 label + 16 prefix),
+	// label=3 BoS, prefix 2001::/16.
+	nlriV6Labeled := []byte{0x28, 0x00, 0x00, 0x31, 0x20, 0x01}
+
+	buildReach := func(afi uint16, safi uint8, nh, nlri []byte) []byte {
+		b := []byte{byte(afi >> 8), byte(afi), safi, byte(len(nh))}
+		b = append(b, nh...)
+		b = append(b, 0x00) // reserved
+		b = append(b, nlri...)
+		return b
+	}
+
 	tests := []struct {
-		name string
-		afi  byte
-		safi byte
+		name          string
+		reach         []byte
+		wantIsIPv4    bool
+		wantTopicType int
+		wantLabeled   bool
 	}{
-		{"IPv4 Unicast", 0x01, 0x01},
-		{"IPv6 Unicast", 0x02, 0x01},
-		{"IPv4 Labeled Unicast", 0x01, 0x04},
-		{"IPv6 Labeled Unicast", 0x02, 0x04},
+		{"IPv4 Unicast", buildReach(1, 1, nhV4, nlriV4Unicast), true, bmp.UnicastPrefixV4Msg, false},
+		{"IPv6 Unicast", buildReach(2, 1, nhV6, nlriV6Unicast), false, bmp.UnicastPrefixV6Msg, false},
+		{"IPv4 Labeled Unicast", buildReach(1, 4, nhV4, nlriV4Labeled), true, bmp.UnicastPrefixV4Msg, true},
+		{"IPv6 Labeled Unicast", buildReach(2, 4, nhV6, nlriV6Labeled), false, bmp.UnicastPrefixV6Msg, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := NewProducer(&mockPublisher{}, false).(*producer)
+			rec := &recordingPublisher{}
+			p := NewProducer(rec, true).(*producer)
 			p.speakerIP = "10.0.0.1"
 			p.speakerHash = "abc123"
 
 			ph := makePeerHeader(t, bmp.PeerType0, 0x00)
 			update := &bgp.Update{BaseAttributes: &bgp.BaseAttributes{}}
 
-			// MP_UNREACH_NLRI with empty withdrawn routes — EoR marker that
-			// still exercises the switch branch without requiring a full
-			// unicast parse.
-			unreachBytes := []byte{0x00, tt.afi, tt.safi}
-			nlri, err := bgp.UnmarshalMPUnReachNLRI(unreachBytes, map[int]bool{})
+			nlri, err := bgp.UnmarshalMPReachNLRI(tt.reach, false, map[int]bool{})
 			if err != nil {
-				t.Fatalf("UnmarshalMPUnReachNLRI: %v", err)
+				t.Fatalf("UnmarshalMPReachNLRI: %v", err)
 			}
 
-			p.processMPUpdate(nlri, 1, ph, update)
+			p.processMPUpdate(nlri, 0, ph, update)
+
+			if len(rec.msgs) != 1 {
+				t.Fatalf("published %d messages, want 1", len(rec.msgs))
+			}
+			if rec.msgs[0].msgType != tt.wantTopicType {
+				t.Errorf("topic type = %d, want %d", rec.msgs[0].msgType, tt.wantTopicType)
+			}
+			var got UnicastPrefix
+			if err := json.Unmarshal(rec.msgs[0].payload, &got); err != nil {
+				t.Fatalf("Unmarshal published message: %v", err)
+			}
+			if got.IsIPv4 != tt.wantIsIPv4 {
+				t.Errorf("IsIPv4 = %v, want %v", got.IsIPv4, tt.wantIsIPv4)
+			}
+			if got.Action != "add" {
+				t.Errorf("Action = %q, want %q", got.Action, "add")
+			}
+			hasLabels := len(got.Labels) > 0
+			if hasLabels != tt.wantLabeled {
+				t.Errorf("labels present = %v (labels=%v), want %v", hasLabels, got.Labels, tt.wantLabeled)
+			}
 		})
 	}
 }

--- a/pkg/message/mvpn.go
+++ b/pkg/message/mvpn.go
@@ -100,8 +100,9 @@ func (p *producer) mvpn(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, update *
 		prfx.IsIPv4 = !nlri.IsIPv6NLRI()
 
 		// Extract nexthop
-		prfx.Nexthop = nlri.GetNextHop()
-		prfx.IsNexthopIPv4 = len(nlri.GetNextHop()) > 0 && net.ParseIP(nlri.GetNextHop()).To4() != nil
+		nh := nlri.GetNextHop()
+		prfx.Nexthop = nh
+		prfx.IsNexthopIPv4 = len(nh) > 0 && net.ParseIP(nh).To4() != nil
 
 		// Extract Route Distinguisher if present
 		if rd := route.GetMCASTVPNRD(); rd != nil {

--- a/pkg/message/process-mp-update.go
+++ b/pkg/message/process-mp-update.go
@@ -53,35 +53,10 @@ func extractOriginValidation(attrs *bgp.BaseAttributes) *string {
 }
 
 func (p *producer) processMPUpdate(nlri bgp.MPNLRI, operation int, ph *bmp.PerPeerHeader, update *bgp.Update) {
-	labeled := false
-	labeledSet := false
 	switch nlri.GetAFISAFIType() {
-	case 1:
-		// MP_REACH_NLRI AFI 1 SAFI 1
-		if !labeledSet {
-			labeledSet = true
-			labeled = false
-		}
-		fallthrough
-	case 2:
-		// MP_REACH_NLRI AFI 2 SAFI 1
-		if !labeledSet {
-			labeledSet = true
-			labeled = false
-		}
-		fallthrough
-	case 16:
-		// MP_REACH_NLRI AFI 1 SAFI 4
-		if !labeledSet {
-			labeledSet = true
-			labeled = true
-		}
-		fallthrough
-	case 17:
-		// MP_REACH_NLRI AFI 2 SAFI 4
-		if !labeledSet {
-			labeled = true
-		}
+	case 1, 2, 16, 17:
+		// AFI 1/2 SAFI 1 = Unicast, AFI 1/2 SAFI 4 = Labeled Unicast
+		labeled := nlri.GetAFISAFIType() >= 16
 		msgs, err := p.unicast(nlri, operation, ph, update, labeled)
 		if err != nil {
 			glog.Errorf("failed to produce unicast messages with error: %+v", err)
@@ -106,9 +81,7 @@ func (p *producer) processMPUpdate(nlri bgp.MPNLRI, operation int, ph *bmp.PerPe
 				return
 			}
 		}
-	case 18:
-		fallthrough
-	case 19:
+	case 18, 19:
 		msgs, err := p.l3vpn(nlri, operation, ph, update)
 		if err != nil {
 			glog.Errorf("failed to produce l3vpn messages with error: %+v", err)
@@ -155,9 +128,7 @@ func (p *producer) processMPUpdate(nlri bgp.MPNLRI, operation int, ph *bmp.PerPe
 				return
 			}
 		}
-	case 25:
-		fallthrough
-	case 26:
+	case 25, 26:
 		msgs, err := p.srpolicy(nlri, operation, ph, update)
 		if err != nil {
 			glog.Errorf("failed to produce srpolicy messages with error: %+v", err)
@@ -197,9 +168,7 @@ func (p *producer) processMPUpdate(nlri bgp.MPNLRI, operation int, ph *bmp.PerPe
 				return
 			}
 		}
-	case 28:
-		fallthrough
-	case 29:
+	case 28, 29:
 		msgs, err := p.multicast(nlri, operation, ph, update)
 		if err != nil {
 			glog.Errorf("failed to produce multicast messages with error: %+v", err)
@@ -215,9 +184,7 @@ func (p *producer) processMPUpdate(nlri bgp.MPNLRI, operation int, ph *bmp.PerPe
 				return
 			}
 		}
-	case 32:
-		fallthrough
-	case 33:
+	case 32, 33:
 		msgs, err := p.mcastvpn(nlri, operation, ph, update)
 		if err != nil {
 			glog.Errorf("failed to produce mcastvpn messages with error: %+v", err)
@@ -233,9 +200,7 @@ func (p *producer) processMPUpdate(nlri bgp.MPNLRI, operation int, ph *bmp.PerPe
 				return
 			}
 		}
-	case 34:
-		fallthrough
-	case 35:
+	case 34, 35:
 		msgs, err := p.mvpn(nlri, operation, ph, update)
 		if err != nil {
 			glog.Errorf("failed to produce mvpn messages with error: %+v", err)
@@ -251,9 +216,7 @@ func (p *producer) processMPUpdate(nlri bgp.MPNLRI, operation int, ph *bmp.PerPe
 				return
 			}
 		}
-	case 30:
-		fallthrough
-	case 31:
+	case 30, 31:
 		msgs, err := p.rtc(nlri, operation, ph, update)
 		if err != nil {
 			glog.Errorf("failed to produce rtc messages with error: %+v", err)
@@ -324,10 +287,8 @@ func (p *producer) processNLRI71SubTypes(nlri bgp.MPNLRI, operation int, ph *bmp
 				glog.Errorf("failed to process LSLink message with error: %+v", err)
 				continue
 			}
-		case 3:
-			ipv4Flag = true
-			fallthrough
-		case 4:
+		case 3, 4:
+			ipv4Flag = e.Type == 3
 			prfx, ok := e.LS.(*base.PrefixNLRI)
 			if !ok {
 				glog.Errorf("NLRI 71 type %d: expected *base.PrefixNLRI, got %T", e.Type, e.LS)


### PR DESCRIPTION
- `processMPUpdate`: collapse redundant `labeledSet`/`fallthrough` chain into `case 1,2,16,17` with `labeled := type >= 16` (IMP-17)
- `processMPUpdate`: replace single-case fallthroughs with comma-case lists throughout (IMP-18)
- `processNLRI71SubTypes`: replace `ipv4Flag=true` + fallthrough with `case 3,4` + `ipv4Flag = e.Type==3` (IMP-18)
- `mcastvpn`/`mvpn`: cache `GetNextHop()` result to avoid triple call per route (IMP-19)
- `evpn`: replace string concat in ESI/MAC loops with `strings.Builder` (IMP-20)