### PR TITLE
Pass BMP A flag to AS_PATH parser to skip width heuristic

### DIFF
--- a/pkg/bgp/bgp-attr-set.go
+++ b/pkg/bgp/bgp-attr-set.go
@@ -100,7 +100,7 @@ func UnmarshalAttrSet(b []byte) (*AttrSet, error) {
 		}
 	}
 
-	baseAttrs, err := unmarshalBaseAttrsFromSlice(attrs)
+	baseAttrs, err := unmarshalBaseAttrsFromSlice(attrs, nil)
 	if err != nil {
 		return nil, fmt.Errorf("ATTR_SET: failed to build BaseAttributes from embedded attributes: %w", err)
 	}

--- a/pkg/bgp/bgp-base-attributes.go
+++ b/pkg/bgp/bgp-base-attributes.go
@@ -137,8 +137,10 @@ func (ba *BaseAttributes) Equal(oba *BaseAttributes) (bool, []string) {
 // UnmarshalBGPBaseAttributes discovers all present Base Attributes in BGP Update
 // and instantiates BaseAttributes object. It is a convenience wrapper that parses
 // the raw byte slice via UnmarshalBGPPathAttributes and then populates BaseAttributes.
-// The optional as4 argument is the BMP Per-Peer Header A flag (RFC 7854 §4.2): when
-// provided it overrides the internal heuristic for 2-byte vs 4-byte AS_PATH encoding.
+// The optional as4 argument is the derived 4-byte-ASN indicator (typically
+// PeerHeader.Is4ByteASN() per RFC 7854 §4.2, i.e. !A): true = 4-byte, false = 2-byte.
+// When provided it overrides the internal heuristic for AS_PATH encoding.
+// Do not pass the raw A bit.
 func UnmarshalBGPBaseAttributes(b []byte, as4 ...bool) (*BaseAttributes, error) {
 	attrs, baseAttrs, err := UnmarshalBGPPathAttributes(b, as4...)
 	_ = attrs // raw slice not needed by this call-path
@@ -147,7 +149,8 @@ func UnmarshalBGPBaseAttributes(b []byte, as4 ...bool) (*BaseAttributes, error) 
 
 // unmarshalBaseAttrsFromSlice populates a BaseAttributes struct from an already-parsed
 // []PathAttribute slice, avoiding a second walk of the raw byte buffer.
-// as4hint, when non-nil, overrides the AS_PATH width heuristic (RFC 7854 §4.2 flag A).
+// as4hint, when non-nil, is the derived 4-byte-ASN indicator (Is4ByteASN() = !A per
+// RFC 7854 §4.2): true = 4-byte, false = 2-byte. Overrides the AS_PATH width heuristic.
 func unmarshalBaseAttrsFromSlice(attrs []PathAttribute, as4hint *bool) (*BaseAttributes, error) {
 	baseAttr := BaseAttributes{}
 	for _, attr := range attrs {
@@ -334,9 +337,7 @@ func unmarshalAttrASPath(b []byte, as4hint *bool) ([]uint32, error) {
 	}
 	for p := 0; p < len(b); {
 		// Segment type byte — must be one of 0x01..0x04 per RFC 4271 §4.3 / RFC 5065.
-		if p+1 > len(b) {
-			return nil, fmt.Errorf("AS_PATH attribute truncated: cannot read segment type at offset %d", p)
-		}
+		// Loop condition guarantees p < len(b), so the byte is always readable.
 		segType := b[p]
 		if segType < 0x01 || segType > 0x04 {
 			return nil, fmt.Errorf("AS_PATH attribute invalid segment type 0x%02x at offset %d", segType, p)

--- a/pkg/bgp/bgp-base-attributes.go
+++ b/pkg/bgp/bgp-base-attributes.go
@@ -44,7 +44,7 @@ type BaseAttributes struct {
 	// PEDistinguisherLable
 	LgCommunityList []string      `json:"large_community_list,omitempty"`
 	BGPPrefixSID    *BGPPrefixSID `json:"bgp_prefix_sid,omitempty"`
-	OTC uint32 `json:"otc,omitempty"` // RFC 9234 Only to Customer (OTC) Attribute (Type 35)
+	OTC             uint32        `json:"otc,omitempty"` // RFC 9234 Only to Customer (OTC) Attribute (Type 35)
 	// SecPath
 	AttrSet *AttrSet `json:"attr_set,omitempty"` // RFC 6368 ATTR_SET Attribute (Type 128)
 }
@@ -319,8 +319,9 @@ func unmarshalAttrASPath(b []byte, as4hint *bool) ([]uint32, error) {
 	if as4hint != nil {
 		as4 = *as4hint
 	} else {
-		// Detect whether 2-byte or 4-byte ASNs are used. isASPath4 only inspects the
-		// first segment, so full per-segment bounds validation is done in the loop below.
+		// Detect whether 2-byte or 4-byte ASNs are used. isASPath4 walks the whole
+		// buffer; the loop below re-checks segment type and per-segment bounds so
+		// the hinted path is validated identically.
 		var err error
 		as4, err = isASPath4(b)
 		if err != nil {
@@ -332,9 +333,13 @@ func unmarshalAttrASPath(b []byte, as4hint *bool) ([]uint32, error) {
 		asSize = 4
 	}
 	for p := 0; p < len(b); {
-		// Segment type byte
+		// Segment type byte — must be one of 0x01..0x04 per RFC 4271 §4.3 / RFC 5065.
 		if p+1 > len(b) {
 			return nil, fmt.Errorf("AS_PATH attribute truncated: cannot read segment type at offset %d", p)
+		}
+		segType := b[p]
+		if segType < 0x01 || segType > 0x04 {
+			return nil, fmt.Errorf("AS_PATH attribute invalid segment type 0x%02x at offset %d", segType, p)
 		}
 		p++ // skip segment type
 		// Segment length (number of ASNs in this segment)

--- a/pkg/bgp/bgp-base-attributes.go
+++ b/pkg/bgp/bgp-base-attributes.go
@@ -137,15 +137,18 @@ func (ba *BaseAttributes) Equal(oba *BaseAttributes) (bool, []string) {
 // UnmarshalBGPBaseAttributes discovers all present Base Attributes in BGP Update
 // and instantiates BaseAttributes object. It is a convenience wrapper that parses
 // the raw byte slice via UnmarshalBGPPathAttributes and then populates BaseAttributes.
-func UnmarshalBGPBaseAttributes(b []byte) (*BaseAttributes, error) {
-	attrs, baseAttrs, err := UnmarshalBGPPathAttributes(b)
+// The optional as4 argument is the BMP Per-Peer Header A flag (RFC 7854 §4.2): when
+// provided it overrides the internal heuristic for 2-byte vs 4-byte AS_PATH encoding.
+func UnmarshalBGPBaseAttributes(b []byte, as4 ...bool) (*BaseAttributes, error) {
+	attrs, baseAttrs, err := UnmarshalBGPPathAttributes(b, as4...)
 	_ = attrs // raw slice not needed by this call-path
 	return baseAttrs, err
 }
 
 // unmarshalBaseAttrsFromSlice populates a BaseAttributes struct from an already-parsed
 // []PathAttribute slice, avoiding a second walk of the raw byte buffer.
-func unmarshalBaseAttrsFromSlice(attrs []PathAttribute) (*BaseAttributes, error) {
+// as4hint, when non-nil, overrides the AS_PATH width heuristic (RFC 7854 §4.2 flag A).
+func unmarshalBaseAttrsFromSlice(attrs []PathAttribute, as4hint *bool) (*BaseAttributes, error) {
 	baseAttr := BaseAttributes{}
 	for _, attr := range attrs {
 		b := attr.Attribute
@@ -154,7 +157,7 @@ func unmarshalBaseAttrsFromSlice(attrs []PathAttribute) (*BaseAttributes, error)
 			baseAttr.Origin = unmarshalAttrOrigin(b)
 		case 2:
 			var err error
-			baseAttr.ASPath, err = unmarshalAttrASPath(b)
+			baseAttr.ASPath, err = unmarshalAttrASPath(b, as4hint)
 			if err != nil {
 				return nil, err
 			}
@@ -304,17 +307,25 @@ func unmarshalAttrOrigin(b []byte) string {
 	}
 }
 
-// unmarshalAttrASPath returns a slice with a list of ASes
-func unmarshalAttrASPath(b []byte) ([]uint32, error) {
+// unmarshalAttrASPath returns a slice with a list of ASes.
+// as4hint, when non-nil, overrides the heuristic: true means 4-byte ASNs, false means 2-byte.
+// Per RFC 7854 §4.2 the BMP Per-Peer A flag is authoritative for the encoding used.
+func unmarshalAttrASPath(b []byte, as4hint *bool) ([]uint32, error) {
 	if len(b) == 0 {
 		return []uint32{}, nil
 	}
 	path := make([]uint32, 0, len(b)/2)
-	// Detect whether 2-byte or 4-byte ASNs are used. isASPath4 only inspects the
-	// first segment, so full per-segment bounds validation is done in the loop below.
-	as4, err := isASPath4(b)
-	if err != nil {
-		return nil, err
+	var as4 bool
+	if as4hint != nil {
+		as4 = *as4hint
+	} else {
+		// Detect whether 2-byte or 4-byte ASNs are used. isASPath4 only inspects the
+		// first segment, so full per-segment bounds validation is done in the loop below.
+		var err error
+		as4, err = isASPath4(b)
+		if err != nil {
+			return nil, err
+		}
 	}
 	asSize := 2
 	if as4 {

--- a/pkg/bgp/bgp-base-attributes.go
+++ b/pkg/bgp/bgp-base-attributes.go
@@ -134,16 +134,21 @@ func (ba *BaseAttributes) Equal(oba *BaseAttributes) (bool, []string) {
 
 }
 
-// UnmarshalBGPBaseAttributes discovers all present Base Attributes in BGP Update
-// and instantiates BaseAttributes object. It is a convenience wrapper that parses
-// the raw byte slice via UnmarshalBGPPathAttributes and then populates BaseAttributes.
-// The optional as4 argument is the derived 4-byte-ASN indicator (typically
-// PeerHeader.Is4ByteASN() per RFC 7854 §4.2, i.e. !A): true = 4-byte, false = 2-byte.
-// When provided it overrides the internal heuristic for AS_PATH encoding.
-// Do not pass the raw A bit.
-func UnmarshalBGPBaseAttributes(b []byte, as4 ...bool) (*BaseAttributes, error) {
-	attrs, baseAttrs, err := UnmarshalBGPPathAttributes(b, as4...)
-	_ = attrs // raw slice not needed by this call-path
+// UnmarshalBGPBaseAttributes discovers all present Base Attributes in a BGP
+// Update and instantiates a BaseAttributes object. AS_PATH width is inferred
+// by heuristic; use UnmarshalBGPBaseAttributesWithAS4Hint when the caller has
+// an authoritative indicator.
+func UnmarshalBGPBaseAttributes(b []byte) (*BaseAttributes, error) {
+	_, baseAttrs, err := unmarshalBGPPathAttributes(b, nil)
+	return baseAttrs, err
+}
+
+// UnmarshalBGPBaseAttributesWithAS4Hint is UnmarshalBGPBaseAttributes with an
+// authoritative 4-byte-ASN indicator (typically PeerHeader.Is4ByteASN() per
+// RFC 7854 §4.2, i.e. !A): true = 4-byte, false = 2-byte. Do not pass the
+// raw A bit.
+func UnmarshalBGPBaseAttributesWithAS4Hint(b []byte, as4 bool) (*BaseAttributes, error) {
+	_, baseAttrs, err := unmarshalBGPPathAttributes(b, &as4)
 	return baseAttrs, err
 }
 

--- a/pkg/bgp/bgp-base-attributes_test.go
+++ b/pkg/bgp/bgp-base-attributes_test.go
@@ -175,14 +175,35 @@ func TestUnmarshalBGPBaseAttributesAs4Hint(t *testing.T) {
 		0x40, 0x01, 0x01, 0x00,
 		0x40, 0x02, 0x0a, 0x02, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02,
 	}
-	as4hint := true
-	got, err := UnmarshalBGPBaseAttributes(raw, as4hint)
+	got, err := UnmarshalBGPBaseAttributesWithAS4Hint(raw, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	want := []uint32{1, 2}
 	if !reflect.DeepEqual(got.ASPath, want) {
 		t.Errorf("ASPath: got %v, want %v", got.ASPath, want)
+	}
+}
+
+// TestUnmarshalBGPPathAttributesWithAS4Hint verifies the hinted variant
+// overrides the AS_PATH-width heuristic and returns both the raw attribute
+// slice and the populated BaseAttributes. 4-byte hint per RFC 7854 §4.2.
+func TestUnmarshalBGPPathAttributesWithAS4Hint(t *testing.T) {
+	// ORIGIN(igp) + AS_PATH AS4 with two ASNs [1, 2]
+	raw := []byte{
+		0x40, 0x01, 0x01, 0x00,
+		0x40, 0x02, 0x0a, 0x02, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02,
+	}
+	attrs, base, err := UnmarshalBGPPathAttributesWithAS4Hint(raw, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(attrs) != 2 {
+		t.Errorf("len(attrs) = %d, want 2", len(attrs))
+	}
+	want := []uint32{1, 2}
+	if !reflect.DeepEqual(base.ASPath, want) {
+		t.Errorf("ASPath: got %v, want %v", base.ASPath, want)
 	}
 }
 

--- a/pkg/bgp/bgp-base-attributes_test.go
+++ b/pkg/bgp/bgp-base-attributes_test.go
@@ -157,7 +157,7 @@ func TestUnmarshalASPath(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		r, err := unmarshalAttrASPath(tt.input)
+		r, err := unmarshalAttrASPath(tt.input, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -165,4 +165,95 @@ func TestUnmarshalASPath(t *testing.T) {
 			t.Fatalf("expected %+v and result %+v as path do not match", tt.asPath, r)
 		}
 	}
+}
+
+func TestUnmarshalBGPBaseAttributesAs4Hint(t *testing.T) {
+	// ORIGIN(igp) + AS_PATH AS4 with two ASNs [1, 2]
+	// flags=0x40, type=0x01, len=0x01, val=0x00
+	// flags=0x40, type=0x02, len=0x0a, val={AS_SEQ, count=2, 0x00000001, 0x00000002}
+	raw := []byte{
+		0x40, 0x01, 0x01, 0x00,
+		0x40, 0x02, 0x0a, 0x02, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02,
+	}
+	as4hint := true
+	got, err := UnmarshalBGPBaseAttributes(raw, as4hint)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []uint32{1, 2}
+	if !reflect.DeepEqual(got.ASPath, want) {
+		t.Errorf("ASPath: got %v, want %v", got.ASPath, want)
+	}
+}
+
+func TestUnmarshalAttrASPathAs4Hint(t *testing.T) {
+	// AS_SEQUENCE with two 4-byte ASNs: [0x02 type, 0x02 count, 0x00000001, 0x00000002]
+	as4bytes := []byte{0x02, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02}
+	// AS_SEQUENCE with two 2-byte ASNs: [0x02 type, 0x02 count, 0x0001, 0x0002]
+	as2bytes := []byte{0x02, 0x02, 0x00, 0x01, 0x00, 0x02}
+
+	t.Run("as4=true hint parses 4-byte ASNs correctly", func(t *testing.T) {
+		hint := true
+		got, err := unmarshalAttrASPath(as4bytes, &hint)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []uint32{1, 2}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("as4=false hint parses 2-byte ASNs correctly", func(t *testing.T) {
+		hint := false
+		got, err := unmarshalAttrASPath(as2bytes, &hint)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []uint32{1, 2}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("nil hint falls back to heuristic for 4-byte input", func(t *testing.T) {
+		got, err := unmarshalAttrASPath(as4bytes, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []uint32{1, 2}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	// Ambiguous 6 bytes: parses as either one 4-byte ASN or one 2-byte ASN
+	// depending on the hint. The second segment in 2-byte mode has count=0 so
+	// it is consumed cleanly by the loop.
+	// Byte layout: {AS_SEQ=0x02, count=0x01, 0xAA, 0xBB, 0xCC, 0x00}
+	ambiguous := []byte{0x02, 0x01, 0xAA, 0xBB, 0xCC, 0x00}
+
+	t.Run("as4=true on ambiguous data yields single 4-byte ASN", func(t *testing.T) {
+		hint := true
+		got, err := unmarshalAttrASPath(ambiguous, &hint)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []uint32{0xAABBCC00}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("as4=false on ambiguous data yields single 2-byte ASN", func(t *testing.T) {
+		hint := false
+		got, err := unmarshalAttrASPath(ambiguous, &hint)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []uint32{0xAABB}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
 }

--- a/pkg/bgp/bgp-base-attributes_test.go
+++ b/pkg/bgp/bgp-base-attributes_test.go
@@ -228,10 +228,11 @@ func TestUnmarshalAttrASPathAs4Hint(t *testing.T) {
 	})
 
 	// Ambiguous 6 bytes: parses as either one 4-byte ASN or one 2-byte ASN
-	// depending on the hint. The second segment in 2-byte mode has count=0 so
-	// it is consumed cleanly by the loop.
-	// Byte layout: {AS_SEQ=0x02, count=0x01, 0xAA, 0xBB, 0xCC, 0x00}
-	ambiguous := []byte{0x02, 0x01, 0xAA, 0xBB, 0xCC, 0x00}
+	// depending on the hint. The trailing {0x02, 0x00} is a valid empty AS_SEQ
+	// segment so 2-byte mode consumes cleanly without tripping segment-type
+	// validation.
+	// Byte layout: {AS_SEQ=0x02, count=0x01, 0xAA, 0xBB, AS_SEQ=0x02, count=0x00}
+	ambiguous := []byte{0x02, 0x01, 0xAA, 0xBB, 0x02, 0x00}
 
 	t.Run("as4=true on ambiguous data yields single 4-byte ASN", func(t *testing.T) {
 		hint := true
@@ -239,7 +240,7 @@ func TestUnmarshalAttrASPathAs4Hint(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		want := []uint32{0xAABBCC00}
+		want := []uint32{0xAABB0200}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
 		}

--- a/pkg/bgp/bgp-path-attribute.go
+++ b/pkg/bgp/bgp-path-attribute.go
@@ -21,8 +21,10 @@ type PathAttribute struct {
 // Per RFC 4271 §4.3, TotalPathAttributeLength may be zero (pure withdrawal or
 // End-of-RIB marker per RFC 4724 §2); in that case an empty but non-nil
 // BaseAttributes is returned so callers can dereference it safely.
-// The optional as4 argument is the BMP Per-Peer Header A flag (RFC 7854 §4.2):
-// when provided it overrides the heuristic for 2-byte vs 4-byte AS_PATH encoding.
+// The optional as4 argument is the derived 4-byte-ASN indicator (typically
+// the result of PeerHeader.Is4ByteASN() per RFC 7854 §4.2, i.e. !A):
+// true = 4-byte ASNs, false = 2-byte. When provided it overrides the
+// heuristic for 2-byte vs 4-byte AS_PATH encoding. Do not pass the raw A bit.
 func UnmarshalBGPPathAttributes(b []byte, as4 ...bool) ([]PathAttribute, *BaseAttributes, error) {
 	attrs, err := unmarshalRawPathAttributes(b)
 	if err != nil {

--- a/pkg/bgp/bgp-path-attribute.go
+++ b/pkg/bgp/bgp-path-attribute.go
@@ -16,31 +16,35 @@ type PathAttribute struct {
 	Attribute          []byte
 }
 
-// UnmarshalBGPPathAttributes builds BGP Path attributes slice and populates
+// UnmarshalBGPPathAttributes builds a BGP Path attributes slice and populates
 // BaseAttributes in a single pass over the byte buffer.
 // Per RFC 4271 §4.3, TotalPathAttributeLength may be zero (pure withdrawal or
 // End-of-RIB marker per RFC 4724 §2); in that case an empty but non-nil
 // BaseAttributes is returned so callers can dereference it safely.
-// The optional as4 argument is the derived 4-byte-ASN indicator (typically
-// the result of PeerHeader.Is4ByteASN() per RFC 7854 §4.2, i.e. !A):
-// true = 4-byte ASNs, false = 2-byte. When provided it overrides the
-// heuristic for 2-byte vs 4-byte AS_PATH encoding. Do not pass the raw A bit.
-func UnmarshalBGPPathAttributes(b []byte, as4 ...bool) ([]PathAttribute, *BaseAttributes, error) {
+// AS_PATH width (2-byte vs 4-byte) is inferred by heuristic; use
+// UnmarshalBGPPathAttributesWithAS4Hint when the caller has an authoritative
+// indicator.
+func UnmarshalBGPPathAttributes(b []byte) ([]PathAttribute, *BaseAttributes, error) {
+	return unmarshalBGPPathAttributes(b, nil)
+}
+
+// UnmarshalBGPPathAttributesWithAS4Hint is UnmarshalBGPPathAttributes with an
+// authoritative 4-byte-ASN indicator (typically PeerHeader.Is4ByteASN() per
+// RFC 7854 §4.2, i.e. !A): true = 4-byte, false = 2-byte. Do not pass the
+// raw A bit.
+func UnmarshalBGPPathAttributesWithAS4Hint(b []byte, as4 bool) ([]PathAttribute, *BaseAttributes, error) {
+	return unmarshalBGPPathAttributes(b, &as4)
+}
+
+func unmarshalBGPPathAttributes(b []byte, as4hint *bool) ([]PathAttribute, *BaseAttributes, error) {
 	attrs, err := unmarshalRawPathAttributes(b)
 	if err != nil {
 		return nil, nil, err
-	}
-
-	var as4hint *bool
-	if len(as4) > 0 {
-		v := as4[0]
-		as4hint = &v
 	}
 	baseAttrs, err := unmarshalBaseAttrsFromSlice(attrs, as4hint)
 	if err != nil {
 		return nil, nil, err
 	}
-
 	return attrs, baseAttrs, nil
 }
 

--- a/pkg/bgp/bgp-path-attribute.go
+++ b/pkg/bgp/bgp-path-attribute.go
@@ -21,13 +21,20 @@ type PathAttribute struct {
 // Per RFC 4271 §4.3, TotalPathAttributeLength may be zero (pure withdrawal or
 // End-of-RIB marker per RFC 4724 §2); in that case an empty but non-nil
 // BaseAttributes is returned so callers can dereference it safely.
-func UnmarshalBGPPathAttributes(b []byte) ([]PathAttribute, *BaseAttributes, error) {
+// The optional as4 argument is the BMP Per-Peer Header A flag (RFC 7854 §4.2):
+// when provided it overrides the heuristic for 2-byte vs 4-byte AS_PATH encoding.
+func UnmarshalBGPPathAttributes(b []byte, as4 ...bool) ([]PathAttribute, *BaseAttributes, error) {
 	attrs, err := unmarshalRawPathAttributes(b)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	baseAttrs, err := unmarshalBaseAttrsFromSlice(attrs)
+	var as4hint *bool
+	if len(as4) > 0 {
+		v := as4[0]
+		as4hint = &v
+	}
+	baseAttrs, err := unmarshalBaseAttrsFromSlice(attrs, as4hint)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/bgp/bgp-update.go
+++ b/pkg/bgp/bgp-update.go
@@ -103,8 +103,10 @@ func (up *Update) GetNLRIType() (uint8, int) {
 	return BGP4_NLRI, 0
 }
 
-// UnmarshalBGPUpdate build BGP Update object from the byte slice provided
-func UnmarshalBGPUpdate(b []byte) (*Update, error) {
+// UnmarshalBGPUpdate build BGP Update object from the byte slice provided.
+// The optional as4 argument is the BMP Per-Peer Header A flag (RFC 7854 §4.2):
+// when provided it overrides the heuristic for 2-byte vs 4-byte AS_PATH encoding.
+func UnmarshalBGPUpdate(b []byte, as4 ...bool) (*Update, error) {
 	if glog.V(6) {
 		glog.Infof("BGPUpdate Raw: %s", tools.MessageHex(b))
 	}
@@ -130,7 +132,7 @@ func UnmarshalBGPUpdate(b []byte) (*Update, error) {
 		return nil, fmt.Errorf("not enough bytes to unmarshal Path Attributes: need %d bytes, have %d", u.TotalPathAttributeLength, len(b)-p)
 	}
 	// Single pass: parse path attributes and populate base attributes simultaneously
-	attrs, baseAttrs, err := UnmarshalBGPPathAttributes(b[p : p+int(u.TotalPathAttributeLength)])
+	attrs, baseAttrs, err := UnmarshalBGPPathAttributes(b[p:p+int(u.TotalPathAttributeLength)], as4...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bgp/bgp-update.go
+++ b/pkg/bgp/bgp-update.go
@@ -104,8 +104,10 @@ func (up *Update) GetNLRIType() (uint8, int) {
 }
 
 // UnmarshalBGPUpdate build BGP Update object from the byte slice provided.
-// The optional as4 argument is the BMP Per-Peer Header A flag (RFC 7854 §4.2):
-// when provided it overrides the heuristic for 2-byte vs 4-byte AS_PATH encoding.
+// The optional as4 argument is the derived 4-byte-ASN indicator (typically
+// PeerHeader.Is4ByteASN() per RFC 7854 §4.2, i.e. !A): true = 4-byte,
+// false = 2-byte. When provided it overrides the heuristic for AS_PATH
+// encoding. Do not pass the raw A bit.
 func UnmarshalBGPUpdate(b []byte, as4 ...bool) (*Update, error) {
 	if glog.V(6) {
 		glog.Infof("BGPUpdate Raw: %s", tools.MessageHex(b))

--- a/pkg/bgp/bgp-update.go
+++ b/pkg/bgp/bgp-update.go
@@ -103,12 +103,21 @@ func (up *Update) GetNLRIType() (uint8, int) {
 	return BGP4_NLRI, 0
 }
 
-// UnmarshalBGPUpdate build BGP Update object from the byte slice provided.
-// The optional as4 argument is the derived 4-byte-ASN indicator (typically
-// PeerHeader.Is4ByteASN() per RFC 7854 §4.2, i.e. !A): true = 4-byte,
-// false = 2-byte. When provided it overrides the heuristic for AS_PATH
-// encoding. Do not pass the raw A bit.
-func UnmarshalBGPUpdate(b []byte, as4 ...bool) (*Update, error) {
+// UnmarshalBGPUpdate builds a BGP Update object from the byte slice provided.
+// AS_PATH width (2-byte vs 4-byte) is inferred by heuristic; use
+// UnmarshalBGPUpdateWithAS4Hint when the caller has an authoritative indicator.
+func UnmarshalBGPUpdate(b []byte) (*Update, error) {
+	return unmarshalBGPUpdate(b, nil)
+}
+
+// UnmarshalBGPUpdateWithAS4Hint is UnmarshalBGPUpdate with an authoritative
+// 4-byte-ASN indicator (typically PeerHeader.Is4ByteASN() per RFC 7854 §4.2,
+// i.e. !A): true = 4-byte, false = 2-byte. Do not pass the raw A bit.
+func UnmarshalBGPUpdateWithAS4Hint(b []byte, as4 bool) (*Update, error) {
+	return unmarshalBGPUpdate(b, &as4)
+}
+
+func unmarshalBGPUpdate(b []byte, as4hint *bool) (*Update, error) {
 	if glog.V(6) {
 		glog.Infof("BGPUpdate Raw: %s", tools.MessageHex(b))
 	}
@@ -134,7 +143,7 @@ func UnmarshalBGPUpdate(b []byte, as4 ...bool) (*Update, error) {
 		return nil, fmt.Errorf("not enough bytes to unmarshal Path Attributes: need %d bytes, have %d", u.TotalPathAttributeLength, len(b)-p)
 	}
 	// Single pass: parse path attributes and populate base attributes simultaneously
-	attrs, baseAttrs, err := UnmarshalBGPPathAttributes(b[p:p+int(u.TotalPathAttributeLength)], as4...)
+	attrs, baseAttrs, err := unmarshalBGPPathAttributes(b[p:p+int(u.TotalPathAttributeLength)], as4hint)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bgp/bgp-update_test.go
+++ b/pkg/bgp/bgp-update_test.go
@@ -24,7 +24,7 @@ func TestUnmarshalBGPUpdate_AS4Hint(t *testing.T) {
 	update4 := append([]byte{0x00, 0x00, 0x00, byte(len(attrs4))}, attrs4...)
 
 	t.Run("hint=false forces 2-byte parsing", func(t *testing.T) {
-		u, err := UnmarshalBGPUpdate(update2, false)
+		u, err := UnmarshalBGPUpdateWithAS4Hint(update2, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -35,7 +35,7 @@ func TestUnmarshalBGPUpdate_AS4Hint(t *testing.T) {
 	})
 
 	t.Run("hint=true forces 4-byte parsing", func(t *testing.T) {
-		u, err := UnmarshalBGPUpdate(update4, true)
+		u, err := UnmarshalBGPUpdateWithAS4Hint(update4, true)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -48,7 +48,7 @@ func TestUnmarshalBGPUpdate_AS4Hint(t *testing.T) {
 	t.Run("hint=true on 2-byte payload fails", func(t *testing.T) {
 		// 2-byte payload under 4-byte interpretation needs 8 bytes per segment
 		// but only has 4 -> truncation error.
-		_, err := UnmarshalBGPUpdate(update2, true)
+		_, err := UnmarshalBGPUpdateWithAS4Hint(update2, true)
 		if err == nil {
 			t.Fatal("expected truncation error under 4-byte hint, got nil")
 		}

--- a/pkg/bgp/bgp-update_test.go
+++ b/pkg/bgp/bgp-update_test.go
@@ -7,6 +7,54 @@ import (
 	"github.com/go-test/deep"
 )
 
+// TestUnmarshalBGPUpdate_AS4Hint verifies the optional as4 hint forces
+// AS_PATH to parse as 2-byte or 4-byte ASNs, overriding the heuristic.
+func TestUnmarshalBGPUpdate_AS4Hint(t *testing.T) {
+	// 2-byte AS_PATH: segType=0x02 (AS_SEQUENCE), segLen=0x02, ASNs [64512, 64513].
+	// Attr: flags=0x40, type=2 (AS_PATH), len=6, segment (6 bytes).
+	as2Attr := []byte{0x40, 0x02, 0x06, 0x02, 0x02, 0xFC, 0x00, 0xFC, 0x01}
+	originAttr := []byte{0x40, 0x01, 0x01, 0x00} // Origin=IGP
+	attrs2 := append(append([]byte{}, originAttr...), as2Attr...)
+	update2 := append([]byte{0x00, 0x00, 0x00, byte(len(attrs2))}, attrs2...)
+
+	// 4-byte AS_PATH: segType=0x02, segLen=0x02, ASNs [131072, 131073].
+	// Attr: flags=0x40, type=2, len=10, segment (10 bytes).
+	as4Attr := []byte{0x40, 0x02, 0x0A, 0x02, 0x02, 0x00, 0x02, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01}
+	attrs4 := append(append([]byte{}, originAttr...), as4Attr...)
+	update4 := append([]byte{0x00, 0x00, 0x00, byte(len(attrs4))}, attrs4...)
+
+	t.Run("hint=false forces 2-byte parsing", func(t *testing.T) {
+		u, err := UnmarshalBGPUpdate(update2, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []uint32{64512, 64513}
+		if !reflect.DeepEqual(u.BaseAttributes.ASPath, want) {
+			t.Errorf("ASPath=%v, want %v", u.BaseAttributes.ASPath, want)
+		}
+	})
+
+	t.Run("hint=true forces 4-byte parsing", func(t *testing.T) {
+		u, err := UnmarshalBGPUpdate(update4, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []uint32{131072, 131073}
+		if !reflect.DeepEqual(u.BaseAttributes.ASPath, want) {
+			t.Errorf("ASPath=%v, want %v", u.BaseAttributes.ASPath, want)
+		}
+	})
+
+	t.Run("hint=true on 2-byte payload fails", func(t *testing.T) {
+		// 2-byte payload under 4-byte interpretation needs 8 bytes per segment
+		// but only has 4 -> truncation error.
+		_, err := UnmarshalBGPUpdate(update2, true)
+		if err == nil {
+			t.Fatal("expected truncation error under 4-byte hint, got nil")
+		}
+	})
+}
+
 func TestUnmarshalBGPUpdate(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/pkg/bgp/bgp_base_attributes_extra_test.go
+++ b/pkg/bgp/bgp_base_attributes_extra_test.go
@@ -322,7 +322,7 @@ func TestUnmarshalAttrASPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := unmarshalAttrASPath(tt.input)
+			got, err := unmarshalAttrASPath(tt.input, nil)
 			if tt.wantErr != "" {
 				if err == nil {
 					t.Fatalf("expected error containing %q, got nil", tt.wantErr)

--- a/pkg/bmp/per-peer-header.go
+++ b/pkg/bmp/per-peer-header.go
@@ -172,11 +172,13 @@ func (p *PerPeerHeader) IsPostPolicy() (bool, error) {
 	return false, ErrInvFlagRequestForPeerType
 }
 
-// Is4ByteASN returns true if AS_PATH uses 4-byte ASNs, false for 2-byte ASNs
-// Per RFC 7854: A flag (bit 5) indicates 2-byte AS (0) or 4-byte AS (1)
+// Is4ByteASN returns true if AS_PATH uses 4-byte ASNs, false for 2-byte ASNs.
+// Per RFC 7854 §4.2: A flag set to 1 indicates legacy 2-byte AS_PATH format;
+// A flag set to 0 indicates 4-byte AS_PATH format (RFC 6793). Returns
+// ErrInvFlagRequestForPeerType for PeerType3 where the flag is not defined.
 func (p *PerPeerHeader) Is4ByteASN() (bool, error) {
 	if p.PeerType != PeerType3 {
-		return p.flagA, nil
+		return !p.flagA, nil
 	}
 
 	return false, ErrInvFlagRequestForPeerType

--- a/pkg/bmp/per-peer-header_test.go
+++ b/pkg/bmp/per-peer-header_test.go
@@ -24,11 +24,11 @@ func TestPerPeerHeaderFlags(t *testing.T) {
 		expectRIBOutPost bool
 	}{
 		{
-			name:             "RFC 7854: Adj-RIB-In Pre-Policy, IPv4, 2-byte AS (V=0, L=0, A=0, O=0)",
+			name:             "RFC 7854: Adj-RIB-In Pre-Policy, IPv4, 4-byte AS (V=0, L=0, A=0, O=0)",
 			flagsByte:        0x00, // 0000 0000
 			peerType:         0,
 			expectIPv6:       false,
-			expect4ByteASN:   false,
+			expect4ByteASN:   true,
 			expectAdjRIBIn:   true,
 			expectAdjRIBOut:  false,
 			expectPrePolicy:  true,
@@ -39,11 +39,11 @@ func TestPerPeerHeaderFlags(t *testing.T) {
 			expectRIBOutPost: false,
 		},
 		{
-			name:             "RFC 8671: Adj-RIB-Out Pre-Policy, IPv4, 2-byte AS (V=0, L=0, A=0, O=1)",
+			name:             "RFC 8671: Adj-RIB-Out Pre-Policy, IPv4, 4-byte AS (V=0, L=0, A=0, O=1)",
 			flagsByte:        0x10, // 0001 0000
 			peerType:         0,
 			expectIPv6:       false,
-			expect4ByteASN:   false,
+			expect4ByteASN:   true,
 			expectAdjRIBIn:   false,
 			expectAdjRIBOut:  true,
 			expectPrePolicy:  true,
@@ -54,11 +54,11 @@ func TestPerPeerHeaderFlags(t *testing.T) {
 			expectRIBOutPost: false,
 		},
 		{
-			name:             "RFC 7854: Adj-RIB-In Post-Policy, IPv4, 2-byte AS (V=0, L=1, A=0, O=0)",
+			name:             "RFC 7854: Adj-RIB-In Post-Policy, IPv4, 4-byte AS (V=0, L=1, A=0, O=0)",
 			flagsByte:        0x40, // 0100 0000
 			peerType:         0,
 			expectIPv6:       false,
-			expect4ByteASN:   false,
+			expect4ByteASN:   true,
 			expectAdjRIBIn:   true,
 			expectAdjRIBOut:  false,
 			expectPrePolicy:  false,
@@ -69,11 +69,11 @@ func TestPerPeerHeaderFlags(t *testing.T) {
 			expectRIBOutPost: false,
 		},
 		{
-			name:             "RFC 8671: Adj-RIB-Out Post-Policy, IPv4, 2-byte AS (V=0, L=1, A=0, O=1) - ORIGINAL ISSUE",
+			name:             "RFC 8671: Adj-RIB-Out Post-Policy, IPv4, 4-byte AS (V=0, L=1, A=0, O=1) - ORIGINAL ISSUE",
 			flagsByte:        0x50, // 0101 0000
 			peerType:         0,
 			expectIPv6:       false,
-			expect4ByteASN:   false,
+			expect4ByteASN:   true,
 			expectAdjRIBIn:   false,
 			expectAdjRIBOut:  true,
 			expectPrePolicy:  false,
@@ -84,11 +84,11 @@ func TestPerPeerHeaderFlags(t *testing.T) {
 			expectRIBOutPost: true,
 		},
 		{
-			name:             "RFC 7854: IPv6 peer, 4-byte AS, Adj-RIB-In Pre-Policy (V=1, L=0, A=1, O=0)",
+			name:             "RFC 7854: IPv6 peer, 2-byte AS, Adj-RIB-In Pre-Policy (V=1, L=0, A=1, O=0)",
 			flagsByte:        0xA0, // 1010 0000
 			peerType:         0,
 			expectIPv6:       true,
-			expect4ByteASN:   true,
+			expect4ByteASN:   false,
 			expectAdjRIBIn:   true,
 			expectAdjRIBOut:  false,
 			expectPrePolicy:  true,
@@ -99,11 +99,11 @@ func TestPerPeerHeaderFlags(t *testing.T) {
 			expectRIBOutPost: false,
 		},
 		{
-			name:             "RFC 8671: IPv6 peer, 4-byte AS, Adj-RIB-Out Post-Policy (V=1, L=1, A=1, O=1)",
+			name:             "RFC 8671: IPv6 peer, 2-byte AS, Adj-RIB-Out Post-Policy (V=1, L=1, A=1, O=1)",
 			flagsByte:        0xF0, // 1111 0000
 			peerType:         0,
 			expectIPv6:       true,
-			expect4ByteASN:   true,
+			expect4ByteASN:   false,
 			expectAdjRIBIn:   false,
 			expectAdjRIBOut:  true,
 			expectPrePolicy:  false,
@@ -372,8 +372,8 @@ func TestUnmarshalPerPeerHeader(t *testing.T) {
 		t.Errorf("IsRemotePeerIPv6() = %v, want false (V=0)", gotIPv6)
 	}
 
-	if got4Byte, _ := pph.Is4ByteASN(); got4Byte != false {
-		t.Errorf("Is4ByteASN() = %v, want false (A=0)", got4Byte)
+	if got4Byte, _ := pph.Is4ByteASN(); got4Byte != true {
+		t.Errorf("Is4ByteASN() = %v, want true (A=0 means 4-byte per RFC 7854)", got4Byte)
 	}
 
 	if gotRIBIn, _ := pph.IsAdjRIBIn(); gotRIBIn != false {

--- a/pkg/bmp/route-monitor.go
+++ b/pkg/bmp/route-monitor.go
@@ -20,8 +20,10 @@ type RouteMonitor struct {
 	Update *bgp.Update
 }
 
-// UnmarshalBMPRouteMonitorMessage builds BMP Route Monitor object
-func UnmarshalBMPRouteMonitorMessage(b []byte) (*RouteMonitor, error) {
+// UnmarshalBMPRouteMonitorMessage builds BMP Route Monitor object.
+// The optional as4 argument is the BMP Per-Peer Header A flag (RFC 7854 §4.2):
+// when provided it overrides the heuristic for 2-byte vs 4-byte AS_PATH encoding.
+func UnmarshalBMPRouteMonitorMessage(b []byte, as4 ...bool) (*RouteMonitor, error) {
 	if glog.V(6) {
 		glog.Infof("BMP Route Monitor Message Raw: %s length: %d", tools.MessageHex(b), len(b))
 	}
@@ -46,7 +48,7 @@ func UnmarshalBMPRouteMonitorMessage(b []byte) (*RouteMonitor, error) {
 	p++
 	switch t {
 	case 2:
-		u, err := bgp.UnmarshalBGPUpdate(b[p:])
+		u, err := bgp.UnmarshalBGPUpdate(b[p:], as4...)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/bmp/route-monitor.go
+++ b/pkg/bmp/route-monitor.go
@@ -20,12 +20,23 @@ type RouteMonitor struct {
 	Update *bgp.Update
 }
 
-// UnmarshalBMPRouteMonitorMessage builds BMP Route Monitor object.
-// The optional as4 argument is the derived 4-byte-ASN indicator (typically
-// PeerHeader.Is4ByteASN() per RFC 7854 §4.2, i.e. !A): true = 4-byte,
-// false = 2-byte. When provided it overrides the heuristic for AS_PATH
-// encoding. Do not pass the raw A bit.
-func UnmarshalBMPRouteMonitorMessage(b []byte, as4 ...bool) (*RouteMonitor, error) {
+// UnmarshalBMPRouteMonitorMessage builds a BMP Route Monitor object. AS_PATH
+// width in the embedded BGP Update is inferred by heuristic; use
+// UnmarshalBMPRouteMonitorMessageWithAS4Hint when the caller has an
+// authoritative indicator (typically from the BMP Per-Peer Header).
+func UnmarshalBMPRouteMonitorMessage(b []byte) (*RouteMonitor, error) {
+	return unmarshalBMPRouteMonitorMessage(b, nil)
+}
+
+// UnmarshalBMPRouteMonitorMessageWithAS4Hint is
+// UnmarshalBMPRouteMonitorMessage with an authoritative 4-byte-ASN indicator
+// (typically PeerHeader.Is4ByteASN() per RFC 7854 §4.2, i.e. !A): true =
+// 4-byte, false = 2-byte. Do not pass the raw A bit.
+func UnmarshalBMPRouteMonitorMessageWithAS4Hint(b []byte, as4 bool) (*RouteMonitor, error) {
+	return unmarshalBMPRouteMonitorMessage(b, &as4)
+}
+
+func unmarshalBMPRouteMonitorMessage(b []byte, as4hint *bool) (*RouteMonitor, error) {
 	if glog.V(6) {
 		glog.Infof("BMP Route Monitor Message Raw: %s length: %d", tools.MessageHex(b), len(b))
 	}
@@ -50,7 +61,15 @@ func UnmarshalBMPRouteMonitorMessage(b []byte, as4 ...bool) (*RouteMonitor, erro
 	p++
 	switch t {
 	case 2:
-		u, err := bgp.UnmarshalBGPUpdate(b[p:], as4...)
+		var (
+			u   *bgp.Update
+			err error
+		)
+		if as4hint != nil {
+			u, err = bgp.UnmarshalBGPUpdateWithAS4Hint(b[p:], *as4hint)
+		} else {
+			u, err = bgp.UnmarshalBGPUpdate(b[p:])
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/bmp/route-monitor.go
+++ b/pkg/bmp/route-monitor.go
@@ -21,8 +21,10 @@ type RouteMonitor struct {
 }
 
 // UnmarshalBMPRouteMonitorMessage builds BMP Route Monitor object.
-// The optional as4 argument is the BMP Per-Peer Header A flag (RFC 7854 §4.2):
-// when provided it overrides the heuristic for 2-byte vs 4-byte AS_PATH encoding.
+// The optional as4 argument is the derived 4-byte-ASN indicator (typically
+// PeerHeader.Is4ByteASN() per RFC 7854 §4.2, i.e. !A): true = 4-byte,
+// false = 2-byte. When provided it overrides the heuristic for AS_PATH
+// encoding. Do not pass the raw A bit.
 func UnmarshalBMPRouteMonitorMessage(b []byte, as4 ...bool) (*RouteMonitor, error) {
 	if glog.V(6) {
 		glog.Infof("BMP Route Monitor Message Raw: %s length: %d", tools.MessageHex(b), len(b))

--- a/pkg/bmp/stats_route_test.go
+++ b/pkg/bmp/stats_route_test.go
@@ -192,3 +192,44 @@ func TestRouteMonitor_ErrNotAnUpdate(t *testing.T) {
 		t.Errorf("error %v does not wrap ErrNotAnUpdate", err)
 	}
 }
+
+// TestUnmarshalBMPRouteMonitorMessageWithAS4Hint_EmbeddedUpdate verifies the
+// hinted variant delegates to UnmarshalBGPUpdateWithAS4Hint by exercising a
+// 2-byte AS_PATH payload that only decodes correctly under the 2-byte hint.
+// Per RFC 7854 §4.2: Is4ByteASN()==false (A=1) means the 2-byte legacy format.
+func TestUnmarshalBMPRouteMonitorMessageWithAS4Hint_EmbeddedUpdate(t *testing.T) {
+	// BGP UPDATE body (without the 16-byte marker / 2-byte length / 1-byte type):
+	// WithdrawnRoutesLength=0, TotalPathAttributeLength=13,
+	// attrs: ORIGIN(0x40,0x01,0x01,0x00) + AS_PATH 2-byte (0x40,0x02,0x06,0x02,0x02,0xFC,0x00,0xFC,0x01)
+	bgpPayload := []byte{
+		0x00, 0x00, // WithdrawnRoutesLength
+		0x00, 0x0D, // TotalPathAttributeLength = 13
+		0x40, 0x01, 0x01, 0x00, // ORIGIN
+		0x40, 0x02, 0x06, 0x02, 0x02, 0xFC, 0x00, 0xFC, 0x01, // AS_PATH 2-byte [64512, 64513]
+	}
+	// 16-byte marker + 2-byte length + 1-byte type(=2 UPDATE) + bgpPayload.
+	bgpLen := 19 + len(bgpPayload)
+	rm := make([]byte, 0, bgpLen)
+	for i := 0; i < 16; i++ {
+		rm = append(rm, 0xFF)
+	}
+	rm = append(rm, byte(bgpLen>>8), byte(bgpLen&0xFF), 0x02)
+	rm = append(rm, bgpPayload...)
+
+	// as4=false forces 2-byte parsing (A=1 in BMP, RFC 7854 §4.2).
+	got, err := UnmarshalBMPRouteMonitorMessageWithAS4Hint(rm, false)
+	if err != nil {
+		t.Fatalf("UnmarshalBMPRouteMonitorMessageWithAS4Hint(as4=false): %v", err)
+	}
+	want := []uint32{64512, 64513}
+	if len(got.Update.BaseAttributes.ASPath) != len(want) ||
+		got.Update.BaseAttributes.ASPath[0] != want[0] ||
+		got.Update.BaseAttributes.ASPath[1] != want[1] {
+		t.Errorf("ASPath = %v, want %v", got.Update.BaseAttributes.ASPath, want)
+	}
+
+	// as4=true on a 2-byte payload must fail (segment needs 8 bytes but only 4 remain).
+	if _, err := UnmarshalBMPRouteMonitorMessageWithAS4Hint(rm, true); err == nil {
+		t.Error("UnmarshalBMPRouteMonitorMessageWithAS4Hint(as4=true) on 2-byte payload: want error, got nil")
+	}
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -121,12 +121,15 @@ func (p *parser) parsingWorker(b []byte) {
 			perPerHeaderLen = bmp.PerPeerHeaderLength
 			// Pass the BMP A flag (RFC 7854 §4.2) so AS_PATH width is authoritative
 			// rather than heuristic. Is4ByteASN returns an error for PeerType3 — fall
-			// back to the heuristic in that case by passing no argument.
-			var as4opt []bool
+			// back to the heuristic in that case by passing no argument. Branching
+			// avoids per-message slice allocation for the variadic parameter.
+			rmBody := b[pos+perPerHeaderLen : pos+msgLen-bmp.CommonHeaderLength]
+			var rm *bmp.RouteMonitor
 			if is4, e := bmpMsg.PeerHeader.Is4ByteASN(); e == nil {
-				as4opt = []bool{is4}
+				rm, err = bmp.UnmarshalBMPRouteMonitorMessage(rmBody, is4)
+			} else {
+				rm, err = bmp.UnmarshalBMPRouteMonitorMessage(rmBody)
 			}
-			rm, err := bmp.UnmarshalBMPRouteMonitorMessage(b[pos+perPerHeaderLen:pos+msgLen-bmp.CommonHeaderLength], as4opt...)
 			if err != nil {
 				if errors.Is(err, bmp.ErrNotAnUpdate) {
 					glog.V(5).Infof("skipping non-Update BGP message in route monitor: %+v", err)

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -119,10 +119,11 @@ func (p *parser) parsingWorker(b []byte) {
 				return
 			}
 			perPerHeaderLen = bmp.PerPeerHeaderLength
-			// Pass the BMP A flag (RFC 7854 §4.2) so AS_PATH width is authoritative
-			// rather than heuristic. Is4ByteASN returns an error for PeerType3 — fall
-			// back to the heuristic in that case by passing no argument. Branching
-			// avoids per-message slice allocation for the variadic parameter.
+			// Pass the interpreted 4-byte-ASN setting derived from the BMP per-peer
+			// header per RFC 7854 §4.2 so AS_PATH width is authoritative rather than
+			// heuristic. Is4ByteASN returns an error for PeerType3 — fall back to the
+			// heuristic in that case by passing no argument. Branching avoids
+			// per-message slice allocation for the variadic parameter.
 			rmBody := b[pos+perPerHeaderLen : pos+msgLen-bmp.CommonHeaderLength]
 			var rm *bmp.RouteMonitor
 			if is4, e := bmpMsg.PeerHeader.Is4ByteASN(); e == nil {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -119,7 +119,14 @@ func (p *parser) parsingWorker(b []byte) {
 				return
 			}
 			perPerHeaderLen = bmp.PerPeerHeaderLength
-			rm, err := bmp.UnmarshalBMPRouteMonitorMessage(b[pos+perPerHeaderLen : pos+msgLen-bmp.CommonHeaderLength])
+			// Pass the BMP A flag (RFC 7854 §4.2) so AS_PATH width is authoritative
+			// rather than heuristic. Is4ByteASN returns an error for PeerType3 — fall
+			// back to the heuristic in that case by passing no argument.
+			var as4opt []bool
+			if is4, e := bmpMsg.PeerHeader.Is4ByteASN(); e == nil {
+				as4opt = []bool{is4}
+			}
+			rm, err := bmp.UnmarshalBMPRouteMonitorMessage(b[pos+perPerHeaderLen:pos+msgLen-bmp.CommonHeaderLength], as4opt...)
 			if err != nil {
 				if errors.Is(err, bmp.ErrNotAnUpdate) {
 					glog.V(5).Infof("skipping non-Update BGP message in route monitor: %+v", err)

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -121,13 +121,12 @@ func (p *parser) parsingWorker(b []byte) {
 			perPerHeaderLen = bmp.PerPeerHeaderLength
 			// Pass the interpreted 4-byte-ASN setting derived from the BMP per-peer
 			// header per RFC 7854 §4.2 so AS_PATH width is authoritative rather than
-			// heuristic. Is4ByteASN returns an error for PeerType3 — fall back to the
-			// heuristic in that case by passing no argument. Branching avoids
-			// per-message slice allocation for the variadic parameter.
+			// heuristic. Is4ByteASN returns an error for PeerType3 — fall back to
+			// the heuristic in that case via the no-hint variant.
 			rmBody := b[pos+perPerHeaderLen : pos+msgLen-bmp.CommonHeaderLength]
 			var rm *bmp.RouteMonitor
 			if is4, e := bmpMsg.PeerHeader.Is4ByteASN(); e == nil {
-				rm, err = bmp.UnmarshalBMPRouteMonitorMessage(rmBody, is4)
+				rm, err = bmp.UnmarshalBMPRouteMonitorMessageWithAS4Hint(rmBody, is4)
 			} else {
 				rm, err = bmp.UnmarshalBMPRouteMonitorMessage(rmBody)
 			}


### PR DESCRIPTION
Thread RFC 7854 §4.2 A flag from `PerPeerHeader.Is4ByteASN()` through `UnmarshalBMPRouteMonitorMessage` → `UnmarshalBGPUpdate` → `UnmarshalBGPPathAttributes` → `unmarshalAttrASPath`. When provided, skips the heuristic and uses the authoritative value from BMP peer negotiation.