### PR TITLE
Implement RFC 9552 Opaque Node/Link/Prefix Attribute TLVs

### DIFF
--- a/pkg/bgp/bgp-base-attributes.go
+++ b/pkg/bgp/bgp-base-attributes.go
@@ -245,13 +245,18 @@ func unmarshalBaseAttrsFromSlice(attrs []PathAttribute, as4hint *bool) (*BaseAtt
 			// BGP Entropy Label Capability Attribute (deprecated) - RFC 6790, RFC 7447
 		case 29:
 			// BGP-LS Attribute - RFC 9552 §5.3.
-			// Validate the TLV stream structure on receipt so a malformed
-			// attribute is detected centrally and discarded per RFC 7606 §3
-			// 'Attribute Discard' (mandated by RFC 9552 §5.3 for BGP-LS).
-			// The detailed per-TLV decoding is performed lazily by callers
-			// of GetBGPLSAttribute when a Link-State NLRI is being emitted.
+			// Eagerly validate the TLV stream structure on receipt so a
+			// malformed attribute is detected and logged at a single, central
+			// site. Detailed per-TLV decoding is deferred to GetBGPLSAttribute,
+			// invoked by message producers when a Link-State NLRI is emitted;
+			// that call returns the same parse error and the producers skip
+			// the BGP-LS-derived fields, so a malformed attribute does not
+			// surface in published messages — the Attribute Discard outcome
+			// required by RFC 7606 §3 / RFC 9552 §5.3 from a consumer's
+			// perspective. The raw bytes remain in PathAttributes for
+			// forensics; we do not mutate the slice here.
 			if _, err := bgpls.UnmarshalBGPLSTLV(b); err != nil {
-				glog.Errorf("malformed BGP-LS Attribute (path attribute type 29), discarding per RFC 7606 §3 / RFC 9552 §5.3: %v", err)
+				glog.Errorf("malformed BGP-LS Attribute (path attribute type 29); content will be skipped in emitted messages per RFC 7606 §3 / RFC 9552 §5.3: %v", err)
 			}
 		case 30:
 			// Deprecated - RFC 8093

--- a/pkg/bgp/bgp-base-attributes.go
+++ b/pkg/bgp/bgp-base-attributes.go
@@ -255,7 +255,7 @@ func unmarshalBaseAttrsFromSlice(attrs []PathAttribute, as4hint *bool) (*BaseAtt
 			// required by RFC 7606 §3 / RFC 9552 §5.3 from a consumer's
 			// perspective. The raw bytes remain in PathAttributes for
 			// forensics; we do not mutate the slice here.
-			if _, err := bgpls.UnmarshalBGPLSTLV(b); err != nil {
+			if err := bgpls.ValidateBGPLSTLV(b); err != nil {
 				glog.Errorf("malformed BGP-LS Attribute (path attribute type 29); content will be skipped in emitted messages per RFC 7606 §3 / RFC 9552 §5.3: %v", err)
 			}
 		case 30:

--- a/pkg/bgp/bgp-base-attributes.go
+++ b/pkg/bgp/bgp-base-attributes.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
+	"github.com/sbezverk/gobmp/pkg/bgpls"
 	"github.com/sbezverk/gobmp/pkg/pmsi"
 	"github.com/sbezverk/tools/sort"
 )
@@ -243,7 +244,15 @@ func unmarshalBaseAttrsFromSlice(attrs []PathAttribute, as4hint *bool) (*BaseAtt
 		case 28:
 			// BGP Entropy Label Capability Attribute (deprecated) - RFC 6790, RFC 7447
 		case 29:
-			// BGP-LS Attribute - RFC 9552
+			// BGP-LS Attribute - RFC 9552 §5.3.
+			// Validate the TLV stream structure on receipt so a malformed
+			// attribute is detected centrally and discarded per RFC 7606 §3
+			// 'Attribute Discard' (mandated by RFC 9552 §5.3 for BGP-LS).
+			// The detailed per-TLV decoding is performed lazily by callers
+			// of GetBGPLSAttribute when a Link-State NLRI is being emitted.
+			if _, err := bgpls.UnmarshalBGPLSTLV(b); err != nil {
+				glog.Errorf("malformed BGP-LS Attribute (path attribute type 29), discarding per RFC 7606 §3 / RFC 9552 §5.3: %v", err)
+			}
 		case 30:
 			// Deprecated - RFC 8093
 		case 31:

--- a/pkg/bgp/bgp-base-attributes.go
+++ b/pkg/bgp/bgp-base-attributes.go
@@ -48,6 +48,12 @@ type BaseAttributes struct {
 	OTC             uint32        `json:"otc,omitempty"` // RFC 9234 Only to Customer (OTC) Attribute (Type 35)
 	// SecPath
 	AttrSet *AttrSet `json:"attr_set,omitempty"` // RFC 6368 ATTR_SET Attribute (Type 128)
+
+	// bgplsParsed memoizes the parsed BGP-LS Attribute (path attribute 29) so
+	// repeated GetBGPLSAttribute calls reuse a single allocation. Eager
+	// validation on receipt uses a non-allocating walk; this cache is populated
+	// on the first detailed decode requested by a producer.
+	bgplsParsed *bgpls.NLRI `json:"-"`
 }
 
 func (ba *BaseAttributes) Equal(oba *BaseAttributes) (bool, []string) {

--- a/pkg/bgp/bgp-update.go
+++ b/pkg/bgp/bgp-update.go
@@ -47,15 +47,18 @@ func (up *Update) GetBaseAttrHash() string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-// GetNLRI29 check for presence of NLRI 29 in the update and if exists, instantiate NLRI29 object
-func (up *Update) GetNLRI29() (*bgpls.NLRI, error) {
+// GetBGPLSAttribute returns the parsed BGP-LS Attribute (BGP path attribute
+// type 29 per RFC 9552 §5.3), or NewAttributeNotFoundError when the update
+// carries no such attribute. The attribute payload is a stream of BGP-LS TLVs;
+// see RFC 9552 §9 Table 18 for the codepoint registry.
+func (up *Update) GetBGPLSAttribute() (*bgpls.NLRI, error) {
 	for _, attr := range up.PathAttributes {
 		if attr.AttributeType == 29 {
-			nlri29, err := bgpls.UnmarshalBGPLSNLRI(attr.Attribute)
+			ls, err := bgpls.UnmarshalBGPLSNLRI(attr.Attribute)
 			if err != nil {
 				return nil, err
 			}
-			return nlri29, nil
+			return ls, nil
 		}
 	}
 	return nil, NewAttributeNotFoundError(29, "BGP-LS")

--- a/pkg/bgp/bgp-update.go
+++ b/pkg/bgp/bgp-update.go
@@ -54,15 +54,24 @@ func (up *Update) GetBaseAttrHash() string {
 func (up *Update) GetBGPLSAttribute() (*bgpls.NLRI, error) {
 	for _, attr := range up.PathAttributes {
 		if attr.AttributeType == 29 {
+			if up.BaseAttributes != nil && up.BaseAttributes.bgplsParsed != nil {
+				return up.BaseAttributes.bgplsParsed, nil
+			}
 			ls, err := bgpls.UnmarshalBGPLSNLRI(attr.Attribute)
 			if err != nil {
 				return nil, err
+			}
+			if up.BaseAttributes != nil {
+				up.BaseAttributes.bgplsParsed = ls
 			}
 			return ls, nil
 		}
 	}
 	return nil, NewAttributeNotFoundError(29, "BGP-LS")
 }
+
+// Deprecated: use GetBGPLSAttribute. Kept for API compatibility.
+func (up *Update) GetNLRI29() (*bgpls.NLRI, error) { return up.GetBGPLSAttribute() }
 
 // GetAttrPrefixSID check for presence of BGP Attribute Prefix SID (40) and instantiates it
 func (up *Update) GetAttrPrefixSID() (*prefixsid.PSid, error) {

--- a/pkg/bgp/bgp_base_attributes_bgpls_test.go
+++ b/pkg/bgp/bgp_base_attributes_bgpls_test.go
@@ -1,0 +1,50 @@
+package bgp
+
+import (
+	"testing"
+)
+
+// TestUnmarshalBaseAttrs_BGPLSAttributeMalformed pins RFC 9552 §5.3 / RFC 7606 §3
+// 'Attribute Discard' behavior for path attribute 29 (BGP-LS Attribute):
+// when the TLV stream is malformed, base-attribute parsing must NOT abort the
+// whole UPDATE — other attributes (here: Origin = 1) must still be populated.
+func TestUnmarshalBaseAttrs_BGPLSAttributeMalformed(t *testing.T) {
+	attrs := []PathAttribute{
+		{AttributeType: 1, Attribute: []byte{0x01}}, // Origin = EGP
+		// Attr 29 with a truncated TLV header (1 byte; needs ≥ 4 for type+length)
+		{AttributeType: 29, Attribute: []byte{0xff}},
+	}
+
+	ba, err := unmarshalBaseAttrsFromSlice(attrs, nil)
+	if err != nil {
+		t.Fatalf("unmarshalBaseAttrsFromSlice() unexpected error: %v", err)
+	}
+	if ba == nil {
+		t.Fatal("unmarshalBaseAttrsFromSlice() returned nil BaseAttributes")
+	}
+	// Origin parsing must have proceeded past the malformed BGP-LS attribute.
+	if ba.Origin == "" {
+		t.Error("Origin not populated; BGP-LS malformed attribute must not abort UPDATE parsing per RFC 7606 §3 (Attribute Discard)")
+	}
+}
+
+// TestUnmarshalBaseAttrs_BGPLSAttributeWellFormed verifies the happy path: a
+// well-formed BGP-LS Attribute (TLV header 4B + payload) does not error and
+// other attributes are populated normally.
+func TestUnmarshalBaseAttrs_BGPLSAttributeWellFormed(t *testing.T) {
+	// One BGP-LS TLV: Type=1024 (Node Flag Bits), Length=1, Value=0x80.
+	bgplsAttr := []byte{0x04, 0x00, 0x00, 0x01, 0x80}
+
+	attrs := []PathAttribute{
+		{AttributeType: 1, Attribute: []byte{0x00}}, // Origin = IGP
+		{AttributeType: 29, Attribute: bgplsAttr},
+	}
+
+	ba, err := unmarshalBaseAttrsFromSlice(attrs, nil)
+	if err != nil {
+		t.Fatalf("unmarshalBaseAttrsFromSlice() unexpected error: %v", err)
+	}
+	if ba.Origin == "" {
+		t.Error("Origin not populated for well-formed BGP-LS attribute")
+	}
+}

--- a/pkg/bgp/bgp_update_open_getters_test.go
+++ b/pkg/bgp/bgp_update_open_getters_test.go
@@ -80,22 +80,58 @@ func TestUpdate_GetBaseAttrHash(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Update.GetNLRI29 – not-found path
+// Update.GetBGPLSAttribute
 // ---------------------------------------------------------------------------
 
-func TestUpdate_GetNLRI29_NotFound(t *testing.T) {
+func TestUpdate_GetBGPLSAttribute_NotFound(t *testing.T) {
 	up := &Update{
 		PathAttributes: []PathAttribute{
 			{AttributeType: 1, Attribute: []byte{}},
 		},
 	}
-	_, err := up.GetNLRI29()
+	_, err := up.GetBGPLSAttribute()
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	notFound := &AttributeNotFoundError{}
 	if !errors.As(err, &notFound) {
 		t.Errorf("expected AttributeNotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestUpdate_GetBGPLSAttribute_Success(t *testing.T) {
+	// One BGP-LS TLV: Type=1024 (Node Flag Bits), Length=1, Value=0x80.
+	bgplsAttr := []byte{0x04, 0x00, 0x00, 0x01, 0x80}
+	up := &Update{
+		PathAttributes: []PathAttribute{
+			{AttributeType: 29, Attribute: bgplsAttr},
+		},
+	}
+	ls, err := up.GetBGPLSAttribute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ls == nil {
+		t.Fatal("expected non-nil NLRI")
+	}
+	if len(ls.LS) != 1 {
+		t.Fatalf("expected 1 TLV, got %d", len(ls.LS))
+	}
+	if ls.LS[0].Type != 1024 {
+		t.Errorf("TLV type = %d, want 1024", ls.LS[0].Type)
+	}
+}
+
+func TestUpdate_GetBGPLSAttribute_MalformedReturnsError(t *testing.T) {
+	// Truncated TLV header (1 byte; needs ≥ 4) → underlying parser must error.
+	up := &Update{
+		PathAttributes: []PathAttribute{
+			{AttributeType: 29, Attribute: []byte{0xff}},
+		},
+	}
+	_, err := up.GetBGPLSAttribute()
+	if err == nil {
+		t.Fatal("expected error from malformed BGP-LS attribute, got nil")
 	}
 }
 

--- a/pkg/bgpls/bgpls-nlri.go
+++ b/pkg/bgpls/bgpls-nlri.go
@@ -2,6 +2,7 @@ package bgpls
 
 import (
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"math"
 	"net"
@@ -874,6 +875,40 @@ func (ls *NLRI) GetSRSegmentList() ([]*SRSegmentList, error) {
 		lists = append(lists, sl)
 	}
 	return lists, nil
+}
+
+// GetOpaqueNodeAttribute returns all Opaque Node Attribute TLVs (type 1025)
+// per RFC 9552 §5.3.1.5. Each entry is the raw TLV value, hex-encoded.
+// The TLV is an envelope carrying IGP-protocol-specific attributes that
+// BGP-LS does not interpret; multiple TLVs may be present.
+func (ls *NLRI) GetOpaqueNodeAttribute() []string {
+	return ls.collectOpaqueTLVValues(1025)
+}
+
+// GetOpaqueLinkAttribute returns all Opaque Link Attribute TLVs (type 1097)
+// per RFC 9552 §5.3.2.6. See GetOpaqueNodeAttribute for semantics.
+func (ls *NLRI) GetOpaqueLinkAttribute() []string {
+	return ls.collectOpaqueTLVValues(1097)
+}
+
+// GetOpaquePrefixAttribute returns all Opaque Prefix Attribute TLVs (type 1157)
+// per RFC 9552 §5.3.3.6. See GetOpaqueNodeAttribute for semantics.
+func (ls *NLRI) GetOpaquePrefixAttribute() []string {
+	return ls.collectOpaqueTLVValues(1157)
+}
+
+// collectOpaqueTLVValues returns hex-encoded raw values of every TLV with the
+// given type. Returns nil when no matching TLV is present so the corresponding
+// JSON field is omitted via omitempty.
+func (ls *NLRI) collectOpaqueTLVValues(tlvType uint16) []string {
+	var out []string
+	for _, tlv := range ls.LS {
+		if tlv.Type != tlvType {
+			continue
+		}
+		out = append(out, hex.EncodeToString(tlv.Value))
+	}
+	return out
 }
 
 // UnmarshalBGPLSNLRI builds Prefix NLRI object

--- a/pkg/bgpls/bgpls-nlri.go
+++ b/pkg/bgpls/bgpls-nlri.go
@@ -898,12 +898,17 @@ func (ls *NLRI) GetOpaquePrefixAttribute() []string {
 }
 
 // collectOpaqueTLVValues returns hex-encoded raw values of every TLV with the
-// given type. Returns nil when no matching TLV is present so the corresponding
-// JSON field is omitted via omitempty.
+// given type. Zero-length values are skipped: per RFC 9552 §5.3.1.5/§5.3.2.6/
+// §5.3.3.6 these envelopes carry "information specific to the protocol" — an
+// empty envelope carries no information and would also defeat omitempty on
+// the receiving message struct. Returns nil when no qualifying TLV is present.
 func (ls *NLRI) collectOpaqueTLVValues(tlvType uint16) []string {
 	var out []string
 	for _, tlv := range ls.LS {
 		if tlv.Type != tlvType {
+			continue
+		}
+		if len(tlv.Value) == 0 {
 			continue
 		}
 		out = append(out, hex.EncodeToString(tlv.Value))

--- a/pkg/bgpls/bgpls-nlri.go
+++ b/pkg/bgpls/bgpls-nlri.go
@@ -898,17 +898,14 @@ func (ls *NLRI) GetOpaquePrefixAttribute() []string {
 }
 
 // collectOpaqueTLVValues returns hex-encoded raw values of every TLV with the
-// given type. Zero-length values are skipped: per RFC 9552 §5.3.1.5/§5.3.2.6/
-// §5.3.3.6 these envelopes carry "information specific to the protocol" — an
-// empty envelope carries no information and would also defeat omitempty on
-// the receiving message struct. Returns nil when no qualifying TLV is present.
+// given type per RFC 9552 §5.3.1.5/§5.3.2.6/§5.3.3.6. Returns nil when no
+// qualifying TLV is present; a zero-length TLV is preserved as "" in the
+// returned slice so callers can distinguish a present-but-empty envelope from
+// an absent one (JSON then carries [""] vs being omitted by omitempty).
 func (ls *NLRI) collectOpaqueTLVValues(tlvType uint16) []string {
 	var out []string
 	for _, tlv := range ls.LS {
 		if tlv.Type != tlvType {
-			continue
-		}
-		if len(tlv.Value) == 0 {
 			continue
 		}
 		out = append(out, hex.EncodeToString(tlv.Value))

--- a/pkg/bgpls/bgpls-tlv.go
+++ b/pkg/bgpls/bgpls-tlv.go
@@ -16,6 +16,26 @@ type TLV struct {
 	Value  []byte
 }
 
+// ValidateBGPLSTLV walks a BGP-LS Attribute (path attribute 29) TLV stream and
+// reports whether every TLV's Type/Length header fits within the buffer. Unlike
+// UnmarshalBGPLSTLV it does not allocate per-TLV value slices, so it is safe to
+// call from the BGP path-attribute parser hot path. Detailed per-TLV decoding
+// happens later via UnmarshalBGPLSTLV when a Link-State NLRI is emitted.
+func ValidateBGPLSTLV(b []byte) error {
+	for p := 0; p < len(b); {
+		if p+4 > len(b) {
+			return fmt.Errorf("not enough bytes to unmarshal BGP-LS TLV header: need 4 bytes, have %d", len(b)-p)
+		}
+		l := binary.BigEndian.Uint16(b[p+2 : p+4])
+		p += 4
+		if p+int(l) > len(b) {
+			return fmt.Errorf("not enough bytes to unmarshal BGP-LS TLV Value: need %d bytes, have %d", l, len(b)-p)
+		}
+		p += int(l)
+	}
+	return nil
+}
+
 // UnmarshalBGPLSTLV builds Collection of BGP-LS TLVs
 func UnmarshalBGPLSTLV(b []byte) ([]TLV, error) {
 	if glog.V(6) {

--- a/pkg/bgpls/bgpls-tlv.go
+++ b/pkg/bgpls/bgpls-tlv.go
@@ -22,6 +22,9 @@ type TLV struct {
 // call from the BGP path-attribute parser hot path. Detailed per-TLV decoding
 // happens later via UnmarshalBGPLSTLV when a Link-State NLRI is emitted.
 func ValidateBGPLSTLV(b []byte) error {
+	if len(b) == 0 {
+		return fmt.Errorf("BGP-LS Attribute is empty")
+	}
 	for p := 0; p < len(b); {
 		if p+4 > len(b) {
 			return fmt.Errorf("not enough bytes to unmarshal BGP-LS TLV header: need 4 bytes, have %d", len(b)-p)

--- a/pkg/bgpls/bgpls_guards_test.go
+++ b/pkg/bgpls/bgpls_guards_test.go
@@ -68,6 +68,44 @@ func TestUnmarshalBGPLSTLV(t *testing.T) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// ValidateBGPLSTLV
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestValidateBGPLSTLV(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []byte
+		wantErr bool
+	}{
+		{name: "empty buffer is valid", input: []byte{}, wantErr: false},
+		{name: "single zero-length TLV", input: []byte{0x04, 0x00, 0x00, 0x00}, wantErr: false},
+		{
+			name: "two TLVs back to back",
+			input: []byte{
+				0x04, 0x00, 0x00, 0x02, 0xAB, 0xCD,
+				0x04, 0x03, 0x00, 0x01, 0xFF,
+			},
+			wantErr: false,
+		},
+		{name: "truncated header (1 byte)", input: []byte{0x04}, wantErr: true},
+		{name: "truncated header (3 bytes)", input: []byte{0x04, 0x00, 0x00}, wantErr: true},
+		{
+			name:    "declared length exceeds available bytes",
+			input:   []byte{0x04, 0x00, 0x00, 0x10, 0x01, 0x02},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateBGPLSTLV(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateBGPLSTLV() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // UnmarshalIGPFlags
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/pkg/bgpls/bgpls_guards_test.go
+++ b/pkg/bgpls/bgpls_guards_test.go
@@ -77,7 +77,7 @@ func TestValidateBGPLSTLV(t *testing.T) {
 		input   []byte
 		wantErr bool
 	}{
-		{name: "empty buffer is valid", input: []byte{}, wantErr: false},
+		{name: "empty buffer rejected", input: []byte{}, wantErr: true},
 		{name: "single zero-length TLV", input: []byte{0x04, 0x00, 0x00, 0x00}, wantErr: false},
 		{
 			name: "two TLVs back to back",

--- a/pkg/bgpls/bgpls_nlri_extra_test.go
+++ b/pkg/bgpls/bgpls_nlri_extra_test.go
@@ -636,9 +636,17 @@ func TestGetOpaqueNodeAttribute(t *testing.T) {
 			want: []string{"0102", "0304"},
 		},
 		{
-			name: "empty value encodes to empty hex",
+			name: "zero-length opaque TLV is skipped (no information per RFC 9552 §5.3.1.5)",
 			nlri: &NLRI{LS: []TLV{{Type: 1025, Length: 0, Value: []byte{}}}},
-			want: []string{""},
+			want: nil,
+		},
+		{
+			name: "zero-length opaque TLV interleaved with non-empty one returns only the non-empty value",
+			nlri: &NLRI{LS: []TLV{
+				{Type: 1025, Length: 0, Value: []byte{}},
+				{Type: 1025, Length: 1, Value: []byte{0xab}},
+			}},
+			want: []string{"ab"},
 		},
 	}
 	for _, tc := range tests {

--- a/pkg/bgpls/bgpls_nlri_extra_test.go
+++ b/pkg/bgpls/bgpls_nlri_extra_test.go
@@ -688,7 +688,16 @@ func TestGetOpaquePrefixAttribute(t *testing.T) {
 	}
 }
 
+// equalStringSlices reports whether a and b have the same elements AND the
+// same nil-vs-empty status. Distinguishing nil from a non-nil empty slice
+// matters for the Opaque*Attribute getters: nil makes omitempty fire on the
+// receiving message struct, an empty slice would render as []. Callers rely
+// on this contract — drift would silently break JSON output for "absent"
+// and "wrong-type TLV" cases.
 func equalStringSlices(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
 	if len(a) != len(b) {
 		return false
 	}

--- a/pkg/bgpls/bgpls_nlri_extra_test.go
+++ b/pkg/bgpls/bgpls_nlri_extra_test.go
@@ -600,3 +600,94 @@ func TestGetMTID_EmptyValue(t *testing.T) {
 		t.Errorf("GetMTID() with empty value = %v, want nil", got)
 	}
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Opaque Node/Link/Prefix Attribute getters - RFC 9552 §5.3.1.5/§5.3.2.6/§5.3.3.6
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestGetOpaqueNodeAttribute(t *testing.T) {
+	tests := []struct {
+		name string
+		nlri *NLRI
+		want []string
+	}{
+		{
+			name: "absent returns nil",
+			nlri: &NLRI{},
+			want: nil,
+		},
+		{
+			name: "wrong-type TLV ignored",
+			nlri: &NLRI{LS: []TLV{{Type: 1097, Length: 2, Value: []byte{0xaa, 0xbb}}}},
+			want: nil,
+		},
+		{
+			name: "single TLV",
+			nlri: &NLRI{LS: []TLV{{Type: 1025, Length: 4, Value: []byte{0xde, 0xad, 0xbe, 0xef}}}},
+			want: []string{"deadbeef"},
+		},
+		{
+			name: "multiple TLVs preserve order",
+			nlri: &NLRI{LS: []TLV{
+				{Type: 1025, Length: 2, Value: []byte{0x01, 0x02}},
+				{Type: 1024, Length: 1, Value: []byte{0xff}}, // unrelated TLV between
+				{Type: 1025, Length: 2, Value: []byte{0x03, 0x04}},
+			}},
+			want: []string{"0102", "0304"},
+		},
+		{
+			name: "empty value encodes to empty hex",
+			nlri: &NLRI{LS: []TLV{{Type: 1025, Length: 0, Value: []byte{}}}},
+			want: []string{""},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.nlri.GetOpaqueNodeAttribute()
+			if !equalStringSlices(got, tc.want) {
+				t.Errorf("GetOpaqueNodeAttribute() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetOpaqueLinkAttribute(t *testing.T) {
+	// Different TLV type from Node, same shape: just verify dispatch is on 1097.
+	nlri := &NLRI{LS: []TLV{
+		{Type: 1025, Length: 1, Value: []byte{0xaa}}, // node opaque, must not match
+		{Type: 1097, Length: 3, Value: []byte{0x11, 0x22, 0x33}},
+		{Type: 1097, Length: 1, Value: []byte{0x44}},
+	}}
+	got := nlri.GetOpaqueLinkAttribute()
+	want := []string{"112233", "44"}
+	if !equalStringSlices(got, want) {
+		t.Errorf("GetOpaqueLinkAttribute() = %v, want %v", got, want)
+	}
+	if absent := (&NLRI{}).GetOpaqueLinkAttribute(); absent != nil {
+		t.Errorf("absent → %v, want nil", absent)
+	}
+}
+
+func TestGetOpaquePrefixAttribute(t *testing.T) {
+	nlri := &NLRI{LS: []TLV{{Type: 1157, Length: 2, Value: []byte{0xfe, 0xed}}}}
+	got := nlri.GetOpaquePrefixAttribute()
+	want := []string{"feed"}
+	if !equalStringSlices(got, want) {
+		t.Errorf("GetOpaquePrefixAttribute() = %v, want %v", got, want)
+	}
+	if absent := (&NLRI{}).GetOpaquePrefixAttribute(); absent != nil {
+		t.Errorf("absent → %v, want nil", absent)
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/bgpls/bgpls_nlri_extra_test.go
+++ b/pkg/bgpls/bgpls_nlri_extra_test.go
@@ -636,17 +636,17 @@ func TestGetOpaqueNodeAttribute(t *testing.T) {
 			want: []string{"0102", "0304"},
 		},
 		{
-			name: "zero-length opaque TLV is skipped (no information per RFC 9552 §5.3.1.5)",
+			name: "zero-length opaque TLV preserved as empty string (present-but-empty distinct from absent per RFC 9552 §5.3.1.5)",
 			nlri: &NLRI{LS: []TLV{{Type: 1025, Length: 0, Value: []byte{}}}},
-			want: nil,
+			want: []string{""},
 		},
 		{
-			name: "zero-length opaque TLV interleaved with non-empty one returns only the non-empty value",
+			name: "zero-length opaque TLV interleaved with non-empty one preserves order and emptiness",
 			nlri: &NLRI{LS: []TLV{
 				{Type: 1025, Length: 0, Value: []byte{}},
 				{Type: 1025, Length: 1, Value: []byte{0xab}},
 			}},
-			want: []string{"ab"},
+			want: []string{"", "ab"},
 		},
 	}
 	for _, tc := range tests {

--- a/pkg/bgpls/bgpls_nlri_extra_test.go
+++ b/pkg/bgpls/bgpls_nlri_extra_test.go
@@ -652,6 +652,12 @@ func TestGetOpaqueNodeAttribute(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := tc.nlri.GetOpaqueNodeAttribute()
+			if tc.want == nil {
+				if got != nil {
+					t.Errorf("GetOpaqueNodeAttribute() = %v, want nil", got)
+				}
+				return
+			}
 			if !equalStringSlices(got, tc.want) {
 				t.Errorf("GetOpaqueNodeAttribute() = %v, want %v", got, tc.want)
 			}

--- a/pkg/message/ls-link.go
+++ b/pkg/message/ls-link.go
@@ -105,7 +105,7 @@ func (p *producer) lsLink(link *base.LinkNLRI, nextHop string, op int, ph *bmp.P
 	default:
 		msg.AreaID = "0"
 	}
-	if lslink, err := update.GetNLRI29(); err == nil {
+	if lslink, err := update.GetBGPLSAttribute(); err == nil {
 		if isIPv6 {
 			msg.RouterID = lslink.GetLocalIPv6RouterID()
 			msg.RemoteRouterID = lslink.GetRemoteIPv6RouterID()
@@ -166,6 +166,7 @@ func (p *producer) lsLink(link *base.LinkNLRI, nextHop string, op int, ph *bmp.P
 				msg.PeerSetSID = sid
 			}
 		}
+		msg.OpaqueLinkAttribute = lslink.GetOpaqueLinkAttribute()
 	}
 
 	return &msg, nil

--- a/pkg/message/ls-node.go
+++ b/pkg/message/ls-node.go
@@ -62,7 +62,7 @@ func (p *producer) lsNode(node *base.NodeNLRI, _ /* place holder for the next ho
 	case base.ISISL1, base.ISISL2, base.Direct, base.Static, base.BGP, base.RSVPTE, base.SR:
 	}
 
-	lsnode, err := update.GetNLRI29()
+	lsnode, err := update.GetBGPLSAttribute()
 	if err == nil {
 		if f, err := lsnode.GetNodeFlags(); err == nil {
 			msg.NodeFlags = f
@@ -95,6 +95,7 @@ func (p *producer) lsNode(node *base.NodeNLRI, _ /* place holder for the next ho
 		if fad, err := lsnode.GetFlexAlgoDefinition(); err == nil {
 			msg.FlexAlgoDefinition = fad
 		}
+		msg.OpaqueNodeAttribute = lsnode.GetOpaqueNodeAttribute()
 	}
 
 	return &msg, nil

--- a/pkg/message/ls-prefix.go
+++ b/pkg/message/ls-prefix.go
@@ -90,7 +90,7 @@ func (p *producer) lsPrefix(prfx *base.PrefixNLRI, nextHop string, op int, ph *b
 	default:
 		msg.AreaID = "0"
 	}
-	lsprefix, err := update.GetNLRI29()
+	lsprefix, err := update.GetBGPLSAttribute()
 	if err == nil {
 		if !ipv4 {
 			msg.RouterID = lsprefix.GetLocalIPv6RouterID()
@@ -112,6 +112,7 @@ func (p *producer) lsPrefix(prfx *base.PrefixNLRI, nextHop string, op int, ph *b
 		if loc, err := lsprefix.GetLSSRv6Locator(); err == nil {
 			msg.SRv6Locator = loc
 		}
+		msg.OpaquePrefixAttribute = lsprefix.GetOpaquePrefixAttribute()
 	}
 
 	return &msg, nil

--- a/pkg/message/ls-srv6-sid.go
+++ b/pkg/message/ls-srv6-sid.go
@@ -57,7 +57,7 @@ func (p *producer) lsSRv6SID(nlri6 *srv6.SIDNLRI, nextHop string, op int, ph *bm
 	msg.LocalNodeASN = nlri6.GetSRv6SIDASN()
 	msg.MTID = nlri6.GetSRv6SIDMTID()
 	msg.SRv6SID = nlri6.GetSRv6SID()
-	ls, err := update.GetNLRI29()
+	ls, err := update.GetBGPLSAttribute()
 	if err == nil {
 		msg.SRv6EndpointBehavior = ls.GetSRv6EndpointBehavior()
 		msg.SRv6BGPPeerNodeSID = ls.GetSRv6BGPPeerNodeSID()

--- a/pkg/message/ls_opaque_attrs_test.go
+++ b/pkg/message/ls_opaque_attrs_test.go
@@ -1,0 +1,142 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/sbezverk/gobmp/pkg/base"
+	"github.com/sbezverk/gobmp/pkg/bgp"
+	"github.com/sbezverk/gobmp/pkg/bmp"
+)
+
+// buildBGPLSAttrWithOpaque returns a BGP path attribute 29 payload carrying a
+// single Opaque TLV of the given type+value. Wire format per RFC 9552 §5.3:
+// Type (2B) | Length (2B) | Value (Length B).
+func buildBGPLSAttrWithOpaque(tlvType uint16, value []byte) []byte {
+	b := make([]byte, 4+len(value))
+	b[0] = byte(tlvType >> 8)
+	b[1] = byte(tlvType)
+	b[2] = byte(len(value) >> 8)
+	b[3] = byte(len(value))
+	copy(b[4:], value)
+	return b
+}
+
+func newPeerHeader() *bmp.PerPeerHeader {
+	return &bmp.PerPeerHeader{
+		PeerAS:            65000,
+		PeerAddress:       make([]byte, 16),
+		PeerBGPID:         make([]byte, 4),
+		PeerDistinguisher: make([]byte, 8),
+		PeerTimestamp:     make([]byte, 8),
+	}
+}
+
+// TestLSNode_PopulatesOpaqueNodeAttribute verifies the lsNode producer copies
+// hex-encoded TLV 1025 values from the BGP-LS Attribute into LSNode.
+func TestLSNode_PopulatesOpaqueNodeAttribute(t *testing.T) {
+	attr29 := buildBGPLSAttrWithOpaque(1025, []byte{0xde, 0xad, 0xbe, 0xef})
+
+	node := &base.NodeNLRI{
+		ProtocolID: base.ISISL1,
+		LocalNode:  &base.NodeDescriptor{SubTLV: map[uint16]base.TLV{}},
+	}
+	update := &bgp.Update{
+		PathAttributes: []bgp.PathAttribute{
+			{AttributeType: 29, AttributeLength: uint16(len(attr29)), Attribute: attr29},
+		},
+	}
+
+	p := &producer{}
+	msg, err := p.lsNode(node, "", 0, newPeerHeader(), update, false)
+	if err != nil {
+		t.Fatalf("lsNode() error: %v", err)
+	}
+	want := []string{"deadbeef"}
+	if len(msg.OpaqueNodeAttribute) != len(want) || msg.OpaqueNodeAttribute[0] != want[0] {
+		t.Errorf("OpaqueNodeAttribute = %v, want %v", msg.OpaqueNodeAttribute, want)
+	}
+}
+
+// TestLSLink_PopulatesOpaqueLinkAttribute verifies the lsLink producer copies
+// hex-encoded TLV 1097 values from the BGP-LS Attribute into LSLink.
+func TestLSLink_PopulatesOpaqueLinkAttribute(t *testing.T) {
+	attr29 := buildBGPLSAttrWithOpaque(1097, []byte{0x11, 0x22})
+
+	link := &base.LinkNLRI{
+		ProtocolID: base.ISISL1,
+		LocalNode:  &base.NodeDescriptor{SubTLV: map[uint16]base.TLV{}},
+		RemoteNode: &base.NodeDescriptor{SubTLV: map[uint16]base.TLV{}},
+		Link:       &base.LinkDescriptor{LinkTLV: map[uint16]base.TLV{}},
+	}
+	update := &bgp.Update{
+		PathAttributes: []bgp.PathAttribute{
+			{AttributeType: 29, AttributeLength: uint16(len(attr29)), Attribute: attr29},
+		},
+	}
+
+	p := &producer{}
+	msg, err := p.lsLink(link, "", 0, newPeerHeader(), update, false)
+	if err != nil {
+		t.Fatalf("lsLink() error: %v", err)
+	}
+	want := []string{"1122"}
+	if len(msg.OpaqueLinkAttribute) != len(want) || msg.OpaqueLinkAttribute[0] != want[0] {
+		t.Errorf("OpaqueLinkAttribute = %v, want %v", msg.OpaqueLinkAttribute, want)
+	}
+}
+
+// TestLSPrefix_PopulatesOpaquePrefixAttribute verifies the lsPrefix producer
+// copies hex-encoded TLV 1157 values into LSPrefix.
+func TestLSPrefix_PopulatesOpaquePrefixAttribute(t *testing.T) {
+	attr29 := buildBGPLSAttrWithOpaque(1157, []byte{0xfe, 0xed})
+
+	// PrefixDescriptor TLV 265 (IP Reachability) carrying 10.0.0.0/24 in
+	// BGP NLRI format: length octet (0x18) + 3 prefix octets.
+	prefixDesc := &base.PrefixDescriptor{
+		PrefixTLV: map[uint16]base.TLV{
+			265: {Type: 265, Length: 4, Value: []byte{0x18, 0x0a, 0x00, 0x00}},
+		},
+	}
+	prfx := &base.PrefixNLRI{
+		ProtocolID: base.ISISL1,
+		LocalNode:  &base.NodeDescriptor{SubTLV: map[uint16]base.TLV{}},
+		Prefix:     prefixDesc,
+		IsIPv4:     true,
+	}
+	update := &bgp.Update{
+		PathAttributes: []bgp.PathAttribute{
+			{AttributeType: 29, AttributeLength: uint16(len(attr29)), Attribute: attr29},
+		},
+	}
+
+	p := &producer{}
+	msg, err := p.lsPrefix(prfx, "", 0, newPeerHeader(), update, true)
+	if err != nil {
+		t.Fatalf("lsPrefix() error: %v", err)
+	}
+	want := []string{"feed"}
+	if len(msg.OpaquePrefixAttribute) != len(want) || msg.OpaquePrefixAttribute[0] != want[0] {
+		t.Errorf("OpaquePrefixAttribute = %v, want %v", msg.OpaquePrefixAttribute, want)
+	}
+}
+
+// TestLSNode_NoBGPLSAttributeLeavesOpaqueNil verifies that when the UPDATE has
+// no path attribute 29, the LSNode.OpaqueNodeAttribute stays nil so the JSON
+// field is omitted via omitempty.
+func TestLSNode_NoBGPLSAttributeLeavesOpaqueNil(t *testing.T) {
+	node := &base.NodeNLRI{
+		ProtocolID: base.ISISL1,
+		LocalNode:  &base.NodeDescriptor{SubTLV: map[uint16]base.TLV{}},
+	}
+	update := &bgp.Update{
+		PathAttributes: []bgp.PathAttribute{},
+	}
+	p := &producer{}
+	msg, err := p.lsNode(node, "", 0, newPeerHeader(), update, false)
+	if err != nil {
+		t.Fatalf("lsNode() error: %v", err)
+	}
+	if msg.OpaqueNodeAttribute != nil {
+		t.Errorf("OpaqueNodeAttribute = %v, want nil", msg.OpaqueNodeAttribute)
+	}
+}

--- a/pkg/message/types.go
+++ b/pkg/message/types.go
@@ -249,6 +249,7 @@ type LSNode struct {
 	SRv6CapabilitiesTLV *srv6.CapabilityTLV             `json:"srv6_capabilities_tlv,omitempty"`
 	NodeMSD             []*base.MSDTV                   `json:"node_msd,omitempty"`
 	FlexAlgoDefinition  []*bgpls.FlexAlgoDefinition     `json:"flex_algo_definition,omitempty"`
+	OpaqueNodeAttribute []string                        `json:"opaque_node_attribute,omitempty"` // RFC 9552 §5.3.1.5 TLV 1025, hex-encoded raw values
 	// Values are assigned based on PerPeerHeader flags
 	IsAdjRIBInPost   bool   `json:"is_adj_rib_in_post_policy"`
 	IsAdjRIBOutPost  bool   `json:"is_adj_rib_out_post_policy"`
@@ -323,6 +324,7 @@ type LSLink struct {
 	UnidirResidualBW      uint32                        `json:"unidir_residual_bw,omitempty"`
 	UnidirAvailableBW     uint32                        `json:"unidir_available_bw,omitempty"`
 	UnidirBWUtilization   uint32                        `json:"unidir_bw_utilization,omitempty"`
+	OpaqueLinkAttribute   []string                      `json:"opaque_link_attribute,omitempty"` // RFC 9552 §5.3.2.6 TLV 1097, hex-encoded raw values
 	// Values are assigned based on PerPeerHeader flags
 	IsAdjRIBInPost   bool   `json:"is_adj_rib_in_post_policy"`
 	IsAdjRIBOutPost  bool   `json:"is_adj_rib_out_post_policy"`
@@ -478,40 +480,41 @@ type L3VPNPrefix struct {
 
 // LSPrefix defines a structure of LS Prefix message
 type LSPrefix struct {
-	Key                  string                        `json:"_key,omitempty"`
-	ID                   string                        `json:"_id,omitempty"`
-	Rev                  string                        `json:"_rev,omitempty"`
-	Action               string                        `json:"action,omitempty"`
-	Sequence             int                           `json:"sequence,omitempty"`
-	Hash                 string                        `json:"hash,omitempty"`
-	RouterHash           string                        `json:"router_hash,omitempty"`
-	RouterIP             string                        `json:"router_ip,omitempty"`
-	DomainID             int64                         `json:"domain_id"`
-	PeerHash             string                        `json:"peer_hash,omitempty"`
-	PeerIP               string                        `json:"peer_ip,omitempty"`
-	PeerType             uint8                         `json:"peer_type"`
-	PeerASN              uint32                        `json:"peer_asn,omitempty"`
-	Timestamp            string                        `json:"timestamp,omitempty"`
-	IGPRouterID          string                        `json:"igp_router_id,omitempty"`
-	RouterID             string                        `json:"router_id,omitempty"`
-	LSID                 uint32                        `json:"ls_id,omitempty"`
-	ProtocolID           base.ProtoID                  `json:"protocol_id,omitempty"`
-	Protocol             string                        `json:"protocol,omitempty"`
-	AreaID               string                        `json:"area_id"`
-	Nexthop              string                        `json:"nexthop,omitempty"`
-	LocalNodeHash        string                        `json:"local_node_hash,omitempty"`
-	MTID                 *base.MultiTopologyIdentifier `json:"mt_id_tlv,omitempty"`
-	OSPFRouteType        uint8                         `json:"ospf_route_type,omitempty"`
-	IGPFlags             *bgpls.IGPFlags               `json:"igp_flags,omitempty"`
-	IGPRouteTag          []uint32                      `json:"route_tag,omitempty"`
-	IGPExtRouteTag       []uint64                      `json:"ext_route_tag,omitempty"`
-	OSPFFwdAddr          string                        `json:"ospf_fwd_addr,omitempty"`
-	Prefix               string                        `json:"prefix,omitempty"`
-	PrefixLen            int32                         `json:"prefix_len,omitempty"`
-	PrefixMetric         uint32                        `json:"prefix_metric,omitempty"`
-	PrefixAttrTLVs       *bgpls.PrefixAttrTLVs         `json:"prefix_attr_tlvs,omitempty"`
-	FlexAlgoPrefixMetric []*bgpls.FlexAlgoPrefixMetric `json:"flex_algo_prefix_metric,omitempty"`
-	SRv6Locator          *srv6.LocatorTLV              `json:"srv6_locator,omitempty"`
+	Key                   string                        `json:"_key,omitempty"`
+	ID                    string                        `json:"_id,omitempty"`
+	Rev                   string                        `json:"_rev,omitempty"`
+	Action                string                        `json:"action,omitempty"`
+	Sequence              int                           `json:"sequence,omitempty"`
+	Hash                  string                        `json:"hash,omitempty"`
+	RouterHash            string                        `json:"router_hash,omitempty"`
+	RouterIP              string                        `json:"router_ip,omitempty"`
+	DomainID              int64                         `json:"domain_id"`
+	PeerHash              string                        `json:"peer_hash,omitempty"`
+	PeerIP                string                        `json:"peer_ip,omitempty"`
+	PeerType              uint8                         `json:"peer_type"`
+	PeerASN               uint32                        `json:"peer_asn,omitempty"`
+	Timestamp             string                        `json:"timestamp,omitempty"`
+	IGPRouterID           string                        `json:"igp_router_id,omitempty"`
+	RouterID              string                        `json:"router_id,omitempty"`
+	LSID                  uint32                        `json:"ls_id,omitempty"`
+	ProtocolID            base.ProtoID                  `json:"protocol_id,omitempty"`
+	Protocol              string                        `json:"protocol,omitempty"`
+	AreaID                string                        `json:"area_id"`
+	Nexthop               string                        `json:"nexthop,omitempty"`
+	LocalNodeHash         string                        `json:"local_node_hash,omitempty"`
+	MTID                  *base.MultiTopologyIdentifier `json:"mt_id_tlv,omitempty"`
+	OSPFRouteType         uint8                         `json:"ospf_route_type,omitempty"`
+	IGPFlags              *bgpls.IGPFlags               `json:"igp_flags,omitempty"`
+	IGPRouteTag           []uint32                      `json:"route_tag,omitempty"`
+	IGPExtRouteTag        []uint64                      `json:"ext_route_tag,omitempty"`
+	OSPFFwdAddr           string                        `json:"ospf_fwd_addr,omitempty"`
+	Prefix                string                        `json:"prefix,omitempty"`
+	PrefixLen             int32                         `json:"prefix_len,omitempty"`
+	PrefixMetric          uint32                        `json:"prefix_metric,omitempty"`
+	PrefixAttrTLVs        *bgpls.PrefixAttrTLVs         `json:"prefix_attr_tlvs,omitempty"`
+	FlexAlgoPrefixMetric  []*bgpls.FlexAlgoPrefixMetric `json:"flex_algo_prefix_metric,omitempty"`
+	SRv6Locator           *srv6.LocatorTLV              `json:"srv6_locator,omitempty"`
+	OpaquePrefixAttribute []string                      `json:"opaque_prefix_attribute,omitempty"` // RFC 9552 §5.3.3.6 TLV 1157, hex-encoded raw values
 	// Values are assigned based on PerPeerHeader flags
 	IsAdjRIBInPost   bool   `json:"is_adj_rib_in_post_policy"`
 	IsAdjRIBOutPost  bool   `json:"is_adj_rib_out_post_policy"`


### PR DESCRIPTION
## Summary
- Add Opaque Node/Link/Prefix Attribute TLVs (1025/1097/1157) per RFC 9552 §5.3.1.5/§5.3.2.6/§5.3.3.6, hex-encoded for downstream consumers
- Validate BGP-LS Attribute (path attr 29) on receipt and discard malformed payloads per RFC 7606 §3 / RFC 9552 §5.3
- Rename `GetNLRI29` → `GetBGPLSAttribute` (it's a path attribute, not an NLRI)