### PR TITLE
Expose Tunnel Encapsulation Attribute (RFC 9012) in JSON

### DIFF
--- a/pkg/bgp/bgp-base-attributes.go
+++ b/pkg/bgp/bgp-base-attributes.go
@@ -43,6 +43,11 @@ type BaseAttributes struct {
 	// Raw bytes are retained in TunnelEncapAttr for the SR Policy consumer in
 	// pkg/message/srpolicy.go which decodes its own RFC 9256 view of the same TLVs.
 	TunnelEncap *tunnel.TunnelEncapsulation `json:"tunnel_encap,omitempty"`
+	// TunnelEncapMalformed is set when path attribute 23 was present on the wire
+	// but UnmarshalTunnelEncapsulation rejected it. Lets downstream consumers
+	// distinguish "attribute absent" (field omitted) from "attribute present but
+	// undecodable" (field true) without exposing raw bytes in JSON.
+	TunnelEncapMalformed bool `json:"tunnel_encap_malformed,omitempty"`
 	// TraficEng
 	IPv6ExtCommunityList []string `json:"ipv6_ext_community_list,omitempty"` // RFC 5701
 	AIGP                 *AIGP    `json:"aigp,omitempty"`                    // RFC 7311 AIGP Attribute (Type 26)
@@ -133,6 +138,14 @@ func (ba *BaseAttributes) Equal(oba *BaseAttributes) (bool, []string) {
 	if asEqual, asDiffs := ba.AttrSet.Equal(oba.AttrSet); !asEqual {
 		equal = false
 		diffs = append(diffs, asDiffs...)
+	}
+	if !reflect.DeepEqual(ba.TunnelEncap, oba.TunnelEncap) {
+		equal = false
+		diffs = append(diffs, "tunnel_encap mismatch")
+	}
+	if ba.TunnelEncapMalformed != oba.TunnelEncapMalformed {
+		equal = false
+		diffs = append(diffs, "tunnel_encap_malformed mismatch: "+strconv.FormatBool(ba.TunnelEncapMalformed)+" and "+strconv.FormatBool(oba.TunnelEncapMalformed))
 	}
 
 	return equal, diffs
@@ -238,6 +251,7 @@ func unmarshalBaseAttrsFromSlice(attrs []PathAttribute, as4hint *bool) (*BaseAtt
 			te, err := tunnel.UnmarshalTunnelEncapsulation(b)
 			if err != nil {
 				glog.Errorf("failed to parse Tunnel Encapsulation attribute (path attribute type 23) per RFC 9012: %v", err)
+				baseAttr.TunnelEncapMalformed = true
 			} else {
 				baseAttr.TunnelEncap = te
 			}

--- a/pkg/bgp/bgp-base-attributes.go
+++ b/pkg/bgp/bgp-base-attributes.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/sbezverk/gobmp/pkg/pmsi"
+	"github.com/sbezverk/gobmp/pkg/tunnel"
 	"github.com/sbezverk/tools/sort"
 )
 
@@ -38,6 +39,10 @@ type BaseAttributes struct {
 	AS4Aggregator    []byte           `json:"as4_aggregator,omitempty"`
 	PMSITunnel       *pmsi.PMSITunnel `json:"pmsi_tunnel,omitempty"` // RFC 6514 PMSI Tunnel Attribute (Type 22)
 	TunnelEncapAttr  []byte           `json:"-"`
+	// TunnelEncap is the decoded RFC 9012 Tunnel Encapsulation Attribute (Type 23).
+	// Raw bytes are retained in TunnelEncapAttr for the SR Policy consumer in
+	// pkg/message/srpolicy.go which decodes its own RFC 9256 view of the same TLVs.
+	TunnelEncap *tunnel.TunnelEncapsulation `json:"tunnel_encap,omitempty"`
 	// TraficEng
 	IPv6ExtCommunityList []string `json:"ipv6_ext_community_list,omitempty"` // RFC 5701
 	AIGP                 *AIGP    `json:"aigp,omitempty"`                    // RFC 7311 AIGP Attribute (Type 26)
@@ -222,9 +227,20 @@ func unmarshalBaseAttrsFromSlice(attrs []PathAttribute, as4hint *bool) (*BaseAtt
 				baseAttr.PMSITunnel = tunnel
 			}
 		case 23:
-			// Tunnel Encapsulation Attribute - RFC 9012
+			// Tunnel Encapsulation Attribute - RFC 9012.
+			// Retain the raw bytes for the SR Policy consumer in
+			// pkg/message/srpolicy.go (it decodes RFC 9256 SR Policy TLVs from
+			// the same payload), and additionally publish a decoded view via
+			// TunnelEncap so generic consumers receive the parsed tunnel TLVs
+			// without re-implementing the wire format.
 			baseAttr.TunnelEncapAttr = make([]byte, len(b))
 			copy(baseAttr.TunnelEncapAttr, b)
+			te, err := tunnel.UnmarshalTunnelEncapsulation(b)
+			if err != nil {
+				glog.Errorf("failed to parse Tunnel Encapsulation attribute (path attribute type 23) per RFC 9012: %v", err)
+			} else {
+				baseAttr.TunnelEncap = te
+			}
 		case 24:
 			// Traffic Engineering - RFC 5543
 		case 25:

--- a/pkg/bgp/bgp-base-attributes.go
+++ b/pkg/bgp/bgp-base-attributes.go
@@ -38,15 +38,17 @@ type BaseAttributes struct {
 	AS4PathCount     int32            `json:"as4_path_count,omitempty"`
 	AS4Aggregator    []byte           `json:"as4_aggregator,omitempty"`
 	PMSITunnel       *pmsi.PMSITunnel `json:"pmsi_tunnel,omitempty"` // RFC 6514 PMSI Tunnel Attribute (Type 22)
-	TunnelEncapAttr  []byte           `json:"-"`
+	// TunnelEncapAttr retains the raw RFC 9012 Tunnel Encapsulation Attribute
+	// (path attribute type 23) bytes. Exposed in JSON so downstream consumers
+	// can recover the original payload when UnmarshalTunnelEncapsulation
+	// rejects the encoding and TunnelEncap is left nil. Also consumed in-process
+	// by the SR Policy decoder in pkg/message/srpolicy.go (RFC 9256 view).
+	TunnelEncapAttr []byte `json:"tunnel_encap_attr,omitempty"`
 	// TunnelEncap is the decoded RFC 9012 Tunnel Encapsulation Attribute (Type 23).
-	// Raw bytes are retained in TunnelEncapAttr for the SR Policy consumer in
-	// pkg/message/srpolicy.go which decodes its own RFC 9256 view of the same TLVs.
 	TunnelEncap *tunnel.TunnelEncapsulation `json:"tunnel_encap,omitempty"`
 	// TunnelEncapMalformed is set when path attribute 23 was present on the wire
 	// but UnmarshalTunnelEncapsulation rejected it. Lets downstream consumers
-	// distinguish "attribute absent" (field omitted) from "attribute present but
-	// undecodable" (field true) without exposing raw bytes in JSON.
+	// distinguish "attribute absent" from "attribute present but undecodable".
 	TunnelEncapMalformed bool `json:"tunnel_encap_malformed,omitempty"`
 	// TraficEng
 	IPv6ExtCommunityList []string `json:"ipv6_ext_community_list,omitempty"` // RFC 5701
@@ -138,6 +140,10 @@ func (ba *BaseAttributes) Equal(oba *BaseAttributes) (bool, []string) {
 	if asEqual, asDiffs := ba.AttrSet.Equal(oba.AttrSet); !asEqual {
 		equal = false
 		diffs = append(diffs, asDiffs...)
+	}
+	if !bytes.Equal(ba.TunnelEncapAttr, oba.TunnelEncapAttr) {
+		equal = false
+		diffs = append(diffs, "tunnel_encap_attr mismatch")
 	}
 	if !reflect.DeepEqual(ba.TunnelEncap, oba.TunnelEncap) {
 		equal = false

--- a/pkg/bgp/bgp_base_attributes_extra_test.go
+++ b/pkg/bgp/bgp_base_attributes_extra_test.go
@@ -3,6 +3,8 @@ package bgp
 import (
 	"strings"
 	"testing"
+
+	"github.com/sbezverk/gobmp/pkg/tunnel"
 )
 
 // TestUnmarshalBGPBaseAttributes_AllAttrTypes exercises the zero-coverage private
@@ -162,6 +164,41 @@ func TestBaseAttributes_Equal(t *testing.T) {
 		equal, _ := base.Equal(&other)
 		if equal {
 			t.Error("Equal() = true for different CommunityList, want false")
+		}
+	})
+
+	t.Run("different TunnelEncap", func(t *testing.T) {
+		// Two updates that differ only in attribute 23 must not compare equal,
+		// otherwise validators silently miss real Tunnel Encapsulation changes.
+		a := *base
+		b := *base
+		a.TunnelEncap = &tunnel.TunnelEncapsulation{
+			Tunnels: []tunnel.Tunnel{{Type: uint16(tunnel.TypeSRPolicy)}},
+		}
+		b.TunnelEncap = nil
+		equal, diffs := a.Equal(&b)
+		if equal {
+			t.Error("Equal() = true for different TunnelEncap, want false")
+		}
+		found := false
+		for _, d := range diffs {
+			if d == "tunnel_encap mismatch" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected tunnel_encap mismatch in diffs, got %v", diffs)
+		}
+	})
+
+	t.Run("different TunnelEncapMalformed", func(t *testing.T) {
+		a := *base
+		b := *base
+		a.TunnelEncapMalformed = true
+		equal, _ := a.Equal(&b)
+		if equal {
+			t.Error("Equal() = true for different TunnelEncapMalformed, want false")
 		}
 	})
 }

--- a/pkg/bgp/bgp_base_attributes_tunnel_encap_test.go
+++ b/pkg/bgp/bgp_base_attributes_tunnel_encap_test.go
@@ -57,6 +57,9 @@ func TestBaseAttrs_TunnelEncap_WellFormed(t *testing.T) {
 	if !bytes.Equal(ba.TunnelEncapAttr, tlv) {
 		t.Errorf("TunnelEncapAttr = %x, want %x (raw bytes must remain for SR Policy consumer)", ba.TunnelEncapAttr, tlv)
 	}
+	if ba.TunnelEncapMalformed {
+		t.Error("TunnelEncapMalformed = true on well-formed attribute; want false")
+	}
 
 	out, err := json.Marshal(ba)
 	if err != nil {
@@ -64,6 +67,9 @@ func TestBaseAttrs_TunnelEncap_WellFormed(t *testing.T) {
 	}
 	if !strings.Contains(string(out), `"tunnel_encap":`) {
 		t.Errorf("json output missing tunnel_encap field: %s", out)
+	}
+	if strings.Contains(string(out), `"tunnel_encap_malformed":`) {
+		t.Errorf("json output should omit tunnel_encap_malformed when false: %s", out)
 	}
 }
 
@@ -86,6 +92,9 @@ func TestBaseAttrs_TunnelEncap_Malformed(t *testing.T) {
 	if !bytes.Equal(ba.TunnelEncapAttr, tlv) {
 		t.Errorf("TunnelEncapAttr = %x, want raw %x preserved on parse failure", ba.TunnelEncapAttr, tlv)
 	}
+	if !ba.TunnelEncapMalformed {
+		t.Error("TunnelEncapMalformed = false; want true so consumers can distinguish present-but-broken from absent")
+	}
 
 	out, err := json.Marshal(ba)
 	if err != nil {
@@ -93,6 +102,9 @@ func TestBaseAttrs_TunnelEncap_Malformed(t *testing.T) {
 	}
 	if strings.Contains(string(out), `"tunnel_encap":`) {
 		t.Errorf("json output should omit tunnel_encap when nil: %s", out)
+	}
+	if !strings.Contains(string(out), `"tunnel_encap_malformed":true`) {
+		t.Errorf("json output missing tunnel_encap_malformed=true on broken attr 23: %s", out)
 	}
 }
 
@@ -112,6 +124,9 @@ func TestBaseAttrs_TunnelEncap_Absent(t *testing.T) {
 	if len(ba.TunnelEncapAttr) != 0 {
 		t.Errorf("TunnelEncapAttr len = %d, want 0", len(ba.TunnelEncapAttr))
 	}
+	if ba.TunnelEncapMalformed {
+		t.Error("TunnelEncapMalformed = true when attribute absent; want false")
+	}
 
 	out, err := json.Marshal(ba)
 	if err != nil {
@@ -119,5 +134,8 @@ func TestBaseAttrs_TunnelEncap_Absent(t *testing.T) {
 	}
 	if strings.Contains(string(out), `"tunnel_encap":`) {
 		t.Errorf("json output should omit tunnel_encap when attribute absent: %s", out)
+	}
+	if strings.Contains(string(out), `"tunnel_encap_malformed":`) {
+		t.Errorf("json output should omit tunnel_encap_malformed when attribute absent: %s", out)
 	}
 }

--- a/pkg/bgp/bgp_base_attributes_tunnel_encap_test.go
+++ b/pkg/bgp/bgp_base_attributes_tunnel_encap_test.go
@@ -1,0 +1,123 @@
+package bgp
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/sbezverk/gobmp/pkg/tunnel"
+)
+
+// buildPathAttr23 wraps a Tunnel Encapsulation Attribute value in the BGP
+// path-attribute envelope per RFC 4271 §4.3 / RFC 9012 §2: flags 0xC0
+// (optional transitive), type 23, 1-octet length.
+func buildPathAttr23(value []byte) []byte {
+	if len(value) > 255 {
+		t := make([]byte, 4+len(value))
+		t[0] = 0xD0 // optional transitive + extended length
+		t[1] = 23
+		t[2] = byte(len(value) >> 8)
+		t[3] = byte(len(value))
+		copy(t[4:], value)
+		return t
+	}
+	t := make([]byte, 3+len(value))
+	t[0] = 0xC0
+	t[1] = 23
+	t[2] = byte(len(value))
+	copy(t[3:], value)
+	return t
+}
+
+// TestBaseAttrs_TunnelEncap_WellFormed verifies that a parseable RFC 9012
+// Tunnel Encapsulation Attribute populates BaseAttributes.TunnelEncap with the
+// decoded TLV view, retains the raw bytes in TunnelEncapAttr (still consumed
+// by pkg/message/srpolicy.go), and emits the new tunnel_encap JSON field.
+func TestBaseAttrs_TunnelEncap_WellFormed(t *testing.T) {
+	// Single SR Policy tunnel (type 13, length 6) with Preference sub-TLV
+	// (type 12, length 4, value 0x00000064 = 100). Mirrors the existing
+	// pkg/tunnel/tunnel_test.go fixture.
+	tlv := []byte{0x00, 0x0d, 0x00, 0x06, 0x0c, 0x04, 0x00, 0x00, 0x00, 0x64}
+	raw := buildPathAttr23(tlv)
+
+	ba, err := UnmarshalBGPBaseAttributes(raw)
+	if err != nil {
+		t.Fatalf("UnmarshalBGPBaseAttributes() error: %v", err)
+	}
+	if ba.TunnelEncap == nil {
+		t.Fatal("TunnelEncap is nil; want decoded TunnelEncapsulation")
+	}
+	if got := len(ba.TunnelEncap.Tunnels); got != 1 {
+		t.Fatalf("TunnelEncap.Tunnels len = %d, want 1", got)
+	}
+	if got, want := ba.TunnelEncap.Tunnels[0].Type, uint16(tunnel.TypeSRPolicy); got != want {
+		t.Errorf("tunnel type = %d, want %d", got, want)
+	}
+	if !bytes.Equal(ba.TunnelEncapAttr, tlv) {
+		t.Errorf("TunnelEncapAttr = %x, want %x (raw bytes must remain for SR Policy consumer)", ba.TunnelEncapAttr, tlv)
+	}
+
+	out, err := json.Marshal(ba)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if !strings.Contains(string(out), `"tunnel_encap":`) {
+		t.Errorf("json output missing tunnel_encap field: %s", out)
+	}
+}
+
+// TestBaseAttrs_TunnelEncap_Malformed verifies that an unparseable RFC 9012
+// attribute logs and leaves TunnelEncap nil, while TunnelEncapAttr still
+// carries the raw bytes so the SR Policy consumer's own decoder can attempt
+// recovery and the operator can inspect the payload off-line.
+func TestBaseAttrs_TunnelEncap_Malformed(t *testing.T) {
+	// Tunnel TLV header claims Length=100 but only 2 value bytes follow.
+	tlv := []byte{0x00, 0x0d, 0x00, 0x64, 0xaa, 0xbb}
+	raw := buildPathAttr23(tlv)
+
+	ba, err := UnmarshalBGPBaseAttributes(raw)
+	if err != nil {
+		t.Fatalf("UnmarshalBGPBaseAttributes() error: %v", err)
+	}
+	if ba.TunnelEncap != nil {
+		t.Errorf("TunnelEncap = %+v, want nil for malformed attribute", ba.TunnelEncap)
+	}
+	if !bytes.Equal(ba.TunnelEncapAttr, tlv) {
+		t.Errorf("TunnelEncapAttr = %x, want raw %x preserved on parse failure", ba.TunnelEncapAttr, tlv)
+	}
+
+	out, err := json.Marshal(ba)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if strings.Contains(string(out), `"tunnel_encap":`) {
+		t.Errorf("json output should omit tunnel_encap when nil: %s", out)
+	}
+}
+
+// TestBaseAttrs_TunnelEncap_Absent verifies the omitempty guard: when no
+// path attribute 23 is present, TunnelEncap stays nil and the JSON field is
+// suppressed.
+func TestBaseAttrs_TunnelEncap_Absent(t *testing.T) {
+	// Origin only (type 1, IGP).
+	raw := []byte{0x40, 0x01, 0x01, 0x00}
+	ba, err := UnmarshalBGPBaseAttributes(raw)
+	if err != nil {
+		t.Fatalf("UnmarshalBGPBaseAttributes() error: %v", err)
+	}
+	if ba.TunnelEncap != nil {
+		t.Errorf("TunnelEncap = %+v, want nil when attribute 23 is absent", ba.TunnelEncap)
+	}
+	if len(ba.TunnelEncapAttr) != 0 {
+		t.Errorf("TunnelEncapAttr len = %d, want 0", len(ba.TunnelEncapAttr))
+	}
+
+	out, err := json.Marshal(ba)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if strings.Contains(string(out), `"tunnel_encap":`) {
+		t.Errorf("json output should omit tunnel_encap when attribute absent: %s", out)
+	}
+}

--- a/pkg/bgp/bgp_base_attributes_tunnel_encap_test.go
+++ b/pkg/bgp/bgp_base_attributes_tunnel_encap_test.go
@@ -2,7 +2,9 @@ package bgp
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -137,5 +139,36 @@ func TestBaseAttrs_TunnelEncap_Absent(t *testing.T) {
 	}
 	if strings.Contains(string(out), `"tunnel_encap_malformed":`) {
 		t.Errorf("json output should omit tunnel_encap_malformed when attribute absent: %s", out)
+	}
+	if strings.Contains(string(out), `"tunnel_encap_attr":`) {
+		t.Errorf("json output should omit tunnel_encap_attr when attribute absent: %s", out)
+	}
+}
+
+// TestBaseAttrs_TunnelEncapAttr_JSON locks the JSON encoding of
+// BaseAttributes.TunnelEncapAttr: the field is emitted as standard
+// base64-encoded bytes under the key "tunnel_encap_attr". Pins the wire
+// contract so downstream consumers can recover the raw RFC 9012 payload
+// even when the structured TunnelEncap view is nil (parse failure).
+func TestBaseAttrs_TunnelEncapAttr_JSON(t *testing.T) {
+	raw := []byte{0x00, 0x0d, 0x00, 0x06, 0x0c, 0x04, 0x00, 0x00, 0x00, 0x64}
+	ba := &BaseAttributes{TunnelEncapAttr: raw}
+
+	out, err := json.Marshal(ba)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	want := fmt.Sprintf(`"tunnel_encap_attr":%q`, base64.StdEncoding.EncodeToString(raw))
+	if !strings.Contains(string(out), want) {
+		t.Errorf("json output missing %s: %s", want, out)
+	}
+
+	// Empty/nil slice must be omitted under omitempty.
+	empty, err := json.Marshal(&BaseAttributes{})
+	if err != nil {
+		t.Fatalf("json.Marshal empty: %v", err)
+	}
+	if strings.Contains(string(empty), `"tunnel_encap_attr":`) {
+		t.Errorf("tunnel_encap_attr should be omitted when nil: %s", empty)
 	}
 }


### PR DESCRIPTION
## Summary
- Wire pkg/tunnel decoder into BGP path attribute 23 so the parsed
  Tunnel Encapsulation Attribute reaches downstream consumers.
- Add `TunnelEncap *tunnel.TunnelEncapsulation` (json `tunnel_encap`,
  omitempty) on BaseAttributes; raw bytes remain in TunnelEncapAttr so
  the SR Policy producer in pkg/message/srpolicy.go is unchanged.
- On parse failure, log and leave TunnelEncap nil; raw bytes are still
  preserved for off-line inspection.

## Why
ATTR-02 from the gobmp gaps audit: type 23 was captured into a byte
slice tagged `json:"-"`, hiding the parsed payload from every consumer
except the SR Policy producer that decoded its own RFC 9256 view of the
same TLVs. The pkg/tunnel decoder already exists per RFC 9012 but was
never wired in.