### PR TITLE
Preserve unrecognised BGP path attributes (RFC 4271 §5)

### DIFF
--- a/pkg/bgp/bgp-base-attributes.go
+++ b/pkg/bgp/bgp-base-attributes.go
@@ -177,13 +177,34 @@ func (ba *BaseAttributes) Equal(oba *BaseAttributes) (bool, []string) {
 		equal = false
 		diffs = append(diffs, "tunnel_encap_malformed mismatch: "+strconv.FormatBool(ba.TunnelEncapMalformed)+" and "+strconv.FormatBool(oba.TunnelEncapMalformed))
 	}
-	if !reflect.DeepEqual(ba.UnknownAttributes, oba.UnknownAttributes) {
+	if !equalUnknownAttributes(ba.UnknownAttributes, oba.UnknownAttributes) {
 		equal = false
 		diffs = append(diffs, "unknown_attributes mismatch")
 	}
 
 	return equal, diffs
 
+}
+
+// equalUnknownAttributes compares two unknown-attribute slices semantically.
+// reflect.DeepEqual is unsuitable here because it treats a nil slice as distinct
+// from an empty slice (e.g. a JSON-decoded "unknown_attributes":[] versus a
+// parser-produced nil), and likewise treats a nil Value as distinct from an
+// empty []byte{}. Both pairs represent the same thing, so length, Type, Flags
+// and bytes.Equal on Value are compared element-wise instead.
+func equalUnknownAttributes(a, b []UnknownPathAttribute) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Type != b[i].Type || a[i].Flags != b[i].Flags {
+			return false
+		}
+		if !bytes.Equal(a[i].Value, b[i].Value) {
+			return false
+		}
+	}
+	return true
 }
 
 // UnmarshalBGPBaseAttributes discovers all present Base Attributes in a BGP

--- a/pkg/bgp/bgp-base-attributes.go
+++ b/pkg/bgp/bgp-base-attributes.go
@@ -77,8 +77,8 @@ type BaseAttributes struct {
 
 // UnknownPathAttribute is the raw form of a BGP path attribute whose Type
 // code is not recognised by unmarshalBaseAttrsFromSlice. Flags is the full
-// flags byte (RFC 4271 §4.3 — Optional/Transitive/Partial/Extended Length in
-// bits 0-3, bits 4-7 reserved zero).
+// flags byte (RFC 4271 §4.3 — Optional (0x80)/Transitive (0x40)/Partial (0x20)/Extended Length (0x10)
+// occupy the high nibble; low nibble bits 3-0 are reserved and MUST be zero).
 type UnknownPathAttribute struct {
 	Type  uint8  `json:"type"`
 	Flags uint8  `json:"flags"`

--- a/pkg/bgp/bgp-base-attributes.go
+++ b/pkg/bgp/bgp-base-attributes.go
@@ -363,18 +363,21 @@ func unmarshalBaseAttrsFromSlice(attrs []PathAttribute, as4hint *bool) (*BaseAtt
 				baseAttr.AttrSet = attrSet
 			}
 		default:
-			// Per RFC 4271 §5, unrecognised optional transitive attributes
-			// must be preserved. gobmp is a passive observer (no forwarding,
-			// no Partial-bit semantics), so capture the raw value + flags so
-			// downstream consumers see attributes the collector cannot decode
-			// instead of having them silently disappear from the JSON output.
+			// Capture every unrecognised path attribute (any flag combination)
+			// so downstream consumers see attributes the collector cannot
+			// decode instead of having them silently disappear from the JSON
+			// output. gobmp is a passive observer, so the RFC 4271 §5
+			// Optional/Transitive forwarding distinction is not applied here;
+			// the full flags byte is preserved on UnknownPathAttribute so
+			// consumers can apply their own policy.
+			// b aliases the fresh per-attribute buffer allocated in
+			// unmarshalRawPathAttributes, so no extra copy is needed.
 			ua := UnknownPathAttribute{
 				Type:  attr.AttributeType,
 				Flags: attr.AttributeTypeFlags,
 			}
 			if len(b) > 0 {
-				ua.Value = make([]byte, len(b))
-				copy(ua.Value, b)
+				ua.Value = b
 			}
 			baseAttr.UnknownAttributes = append(baseAttr.UnknownAttributes, ua)
 		}

--- a/pkg/bgp/bgp-base-attributes.go
+++ b/pkg/bgp/bgp-base-attributes.go
@@ -60,12 +60,29 @@ type BaseAttributes struct {
 	OTC             uint32        `json:"otc,omitempty"` // RFC 9234 Only to Customer (OTC) Attribute (Type 35)
 	// SecPath
 	AttrSet *AttrSet `json:"attr_set,omitempty"` // RFC 6368 ATTR_SET Attribute (Type 128)
+	// UnknownAttributes preserves any path attribute whose Type code is not
+	// recognised by this parser. RFC 4271 §5 requires speakers to forward
+	// transitive unrecognised attributes with the Partial bit set; a passive
+	// BMP collector does not forward, but exposing the raw bytes lets
+	// downstream consumers see attributes the collector does not yet decode
+	// instead of silently dropping them.
+	UnknownAttributes []UnknownPathAttribute `json:"unknown_attributes,omitempty"`
 
 	// bgplsParsed memoizes the parsed BGP-LS Attribute (path attribute 29) so
 	// repeated GetBGPLSAttribute calls reuse a single allocation. Eager
 	// validation on receipt uses a non-allocating walk; this cache is populated
 	// on the first detailed decode requested by a producer.
 	bgplsParsed *bgpls.NLRI `json:"-"`
+}
+
+// UnknownPathAttribute is the raw form of a BGP path attribute whose Type
+// code is not recognised by unmarshalBaseAttrsFromSlice. Flags is the full
+// flags byte (RFC 4271 §4.3 — Optional/Transitive/Partial/Extended Length in
+// bits 0-3, bits 4-7 reserved zero).
+type UnknownPathAttribute struct {
+	Type  uint8  `json:"type"`
+	Flags uint8  `json:"flags"`
+	Value []byte `json:"value,omitempty"`
 }
 
 func (ba *BaseAttributes) Equal(oba *BaseAttributes) (bool, []string) {
@@ -159,6 +176,10 @@ func (ba *BaseAttributes) Equal(oba *BaseAttributes) (bool, []string) {
 	if ba.TunnelEncapMalformed != oba.TunnelEncapMalformed {
 		equal = false
 		diffs = append(diffs, "tunnel_encap_malformed mismatch: "+strconv.FormatBool(ba.TunnelEncapMalformed)+" and "+strconv.FormatBool(oba.TunnelEncapMalformed))
+	}
+	if !reflect.DeepEqual(ba.UnknownAttributes, oba.UnknownAttributes) {
+		equal = false
+		diffs = append(diffs, "unknown_attributes mismatch")
 	}
 
 	return equal, diffs
@@ -341,6 +362,21 @@ func unmarshalBaseAttrsFromSlice(attrs []PathAttribute, as4hint *bool) (*BaseAtt
 			} else {
 				baseAttr.AttrSet = attrSet
 			}
+		default:
+			// Per RFC 4271 §5, unrecognised optional transitive attributes
+			// must be preserved. gobmp is a passive observer (no forwarding,
+			// no Partial-bit semantics), so capture the raw value + flags so
+			// downstream consumers see attributes the collector cannot decode
+			// instead of having them silently disappear from the JSON output.
+			ua := UnknownPathAttribute{
+				Type:  attr.AttributeType,
+				Flags: attr.AttributeTypeFlags,
+			}
+			if len(b) > 0 {
+				ua.Value = make([]byte, len(b))
+				copy(ua.Value, b)
+			}
+			baseAttr.UnknownAttributes = append(baseAttr.UnknownAttributes, ua)
 		}
 	}
 	// Hash the raw attribute bytes directly instead of marshaling to JSON

--- a/pkg/bgp/bgp_base_attributes_unknown_test.go
+++ b/pkg/bgp/bgp_base_attributes_unknown_test.go
@@ -247,4 +247,20 @@ func TestBaseAttributes_Equal_UnknownAttributes(t *testing.T) {
 	if eq, _ := (&BaseAttributes{}).Equal(&BaseAttributes{}); !eq {
 		t.Error("Equal returned false for two empty BaseAttributes")
 	}
+
+	// nil slice vs empty (non-nil) slice → equal. A JSON-decoded
+	// "unknown_attributes":[] must not be treated as different from a
+	// parser-produced nil, which reflect.DeepEqual would have done.
+	nilSide := &BaseAttributes{}
+	emptySide := &BaseAttributes{UnknownAttributes: []UnknownPathAttribute{}}
+	if eq, _ := nilSide.Equal(emptySide); !eq {
+		t.Error("Equal returned false for nil vs empty UnknownAttributes")
+	}
+
+	// nil Value vs empty []byte{} Value → equal (both are zero-length).
+	nilVal := &BaseAttributes{UnknownAttributes: []UnknownPathAttribute{{Type: 99, Flags: 0xC0, Value: nil}}}
+	emptyVal := &BaseAttributes{UnknownAttributes: []UnknownPathAttribute{{Type: 99, Flags: 0xC0, Value: []byte{}}}}
+	if eq, _ := nilVal.Equal(emptyVal); !eq {
+		t.Error("Equal returned false for nil vs empty Value")
+	}
 }

--- a/pkg/bgp/bgp_base_attributes_unknown_test.go
+++ b/pkg/bgp/bgp_base_attributes_unknown_test.go
@@ -2,6 +2,7 @@ package bgp
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -14,32 +15,78 @@ func buildAttr(flags, attrType uint8, value []byte) []byte {
 	return append(out, value...)
 }
 
-// TestUnknownPathAttribute_Preserved verifies that an unrecognised path
-// attribute (Type 99 here — IANA-unassigned) is captured in
-// BaseAttributes.UnknownAttributes with its full flag byte and raw value
-// instead of being silently dropped.
-func TestUnknownPathAttribute_Preserved(t *testing.T) {
-	value := []byte{0xDE, 0xAD, 0xBE, 0xEF}
-	// Optional + Transitive flags (0xC0) = "preserve and forward with Partial"
-	// per RFC 4271 §5; we only need to assert the flag byte round-trips.
-	raw := buildAttr(0xC0, 99, value)
+// buildAttrExtLen returns the wire form of a single path attribute with the
+// Extended Length flag (0x10) forced on and a 2-byte length field, per
+// RFC 4271 §4.3.
+func buildAttrExtLen(flags, attrType uint8, value []byte) []byte {
+	flags |= 0x10
+	out := []byte{flags, attrType, 0, 0}
+	binary.BigEndian.PutUint16(out[2:4], uint16(len(value)))
+	return append(out, value...)
+}
 
-	ba, err := UnmarshalBGPBaseAttributes(raw)
-	if err != nil {
-		t.Fatalf("UnmarshalBGPBaseAttributes: %v", err)
+// TestUnknownPathAttribute_Preserved verifies that unrecognised path
+// attributes are captured in BaseAttributes.UnknownAttributes with their full
+// flag byte and raw value instead of being silently dropped, across the
+// flag/length-encoding combinations gobmp can encounter on the wire.
+func TestUnknownPathAttribute_Preserved(t *testing.T) {
+	extLenValue := bytes.Repeat([]byte{0xAB}, 300)
+	cases := []struct {
+		name      string
+		raw       []byte
+		wantType  uint8
+		wantFlags uint8
+		wantValue []byte
+	}{
+		{
+			name:      "optional transitive single byte length",
+			raw:       buildAttr(0xC0, 99, []byte{0xDE, 0xAD, 0xBE, 0xEF}),
+			wantType:  99,
+			wantFlags: 0xC0,
+			wantValue: []byte{0xDE, 0xAD, 0xBE, 0xEF},
+		},
+		{
+			name:      "optional non transitive single byte length",
+			raw:       buildAttr(0x80, 100, []byte{0xAA, 0xBB}),
+			wantType:  100,
+			wantFlags: 0x80,
+			wantValue: []byte{0xAA, 0xBB},
+		},
+		{
+			name:      "extended length over 255 bytes",
+			raw:       buildAttrExtLen(0xC0, 101, extLenValue),
+			wantType:  101,
+			wantFlags: 0xD0,
+			wantValue: extLenValue,
+		},
+		{
+			name:      "extended length zero value",
+			raw:       buildAttrExtLen(0xC0, 102, nil),
+			wantType:  102,
+			wantFlags: 0xD0,
+			wantValue: nil,
+		},
 	}
-	if len(ba.UnknownAttributes) != 1 {
-		t.Fatalf("len(UnknownAttributes) = %d, want 1", len(ba.UnknownAttributes))
-	}
-	ua := ba.UnknownAttributes[0]
-	if ua.Type != 99 {
-		t.Errorf("Type = %d, want 99", ua.Type)
-	}
-	if ua.Flags != 0xC0 {
-		t.Errorf("Flags = %#x, want 0xC0 (Optional|Transitive)", ua.Flags)
-	}
-	if !bytes.Equal(ua.Value, value) {
-		t.Errorf("Value = %#x, want %#x", ua.Value, value)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ba, err := UnmarshalBGPBaseAttributes(tc.raw)
+			if err != nil {
+				t.Fatalf("UnmarshalBGPBaseAttributes: %v", err)
+			}
+			if len(ba.UnknownAttributes) != 1 {
+				t.Fatalf("len(UnknownAttributes) = %d, want 1", len(ba.UnknownAttributes))
+			}
+			ua := ba.UnknownAttributes[0]
+			if ua.Type != tc.wantType {
+				t.Errorf("Type = %d, want %d", ua.Type, tc.wantType)
+			}
+			if ua.Flags != tc.wantFlags {
+				t.Errorf("Flags = %#x, want %#x", ua.Flags, tc.wantFlags)
+			}
+			if !bytes.Equal(ua.Value, tc.wantValue) {
+				t.Errorf("Value (len %d) = %x, want (len %d) %x", len(ua.Value), ua.Value, len(tc.wantValue), tc.wantValue)
+			}
+		})
 	}
 }
 

--- a/pkg/bgp/bgp_base_attributes_unknown_test.go
+++ b/pkg/bgp/bgp_base_attributes_unknown_test.go
@@ -10,15 +10,22 @@ import (
 
 // buildAttr returns the wire form of a single path attribute: flags + type +
 // length + value. Uses single-byte length (Extended Length flag clear).
+// Panics if len(value) > 255; use buildAttrExtLen for larger values.
 func buildAttr(flags, attrType uint8, value []byte) []byte {
+	if len(value) > 255 {
+		panic("buildAttr: value exceeds single-byte length; use buildAttrExtLen")
+	}
 	out := []byte{flags, attrType, byte(len(value))}
 	return append(out, value...)
 }
 
 // buildAttrExtLen returns the wire form of a single path attribute with the
 // Extended Length flag (0x10) forced on and a 2-byte length field, per
-// RFC 4271 §4.3.
+// RFC 4271 §4.3. Panics if len(value) > 65535.
 func buildAttrExtLen(flags, attrType uint8, value []byte) []byte {
+	if len(value) > 65535 {
+		panic("buildAttrExtLen: value exceeds 2-byte length field")
+	}
 	flags |= 0x10
 	out := []byte{flags, attrType, 0, 0}
 	binary.BigEndian.PutUint16(out[2:4], uint16(len(value)))

--- a/pkg/bgp/bgp_base_attributes_unknown_test.go
+++ b/pkg/bgp/bgp_base_attributes_unknown_test.go
@@ -1,0 +1,196 @@
+package bgp
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// buildAttr returns the wire form of a single path attribute: flags + type +
+// length + value. Uses single-byte length (Extended Length flag clear).
+func buildAttr(flags, attrType uint8, value []byte) []byte {
+	out := []byte{flags, attrType, byte(len(value))}
+	return append(out, value...)
+}
+
+// TestUnknownPathAttribute_Preserved verifies that an unrecognised path
+// attribute (Type 99 here — IANA-unassigned) is captured in
+// BaseAttributes.UnknownAttributes with its full flag byte and raw value
+// instead of being silently dropped.
+func TestUnknownPathAttribute_Preserved(t *testing.T) {
+	value := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	// Optional + Transitive flags (0xC0) = "preserve and forward with Partial"
+	// per RFC 4271 §5; we only need to assert the flag byte round-trips.
+	raw := buildAttr(0xC0, 99, value)
+
+	ba, err := UnmarshalBGPBaseAttributes(raw)
+	if err != nil {
+		t.Fatalf("UnmarshalBGPBaseAttributes: %v", err)
+	}
+	if len(ba.UnknownAttributes) != 1 {
+		t.Fatalf("len(UnknownAttributes) = %d, want 1", len(ba.UnknownAttributes))
+	}
+	ua := ba.UnknownAttributes[0]
+	if ua.Type != 99 {
+		t.Errorf("Type = %d, want 99", ua.Type)
+	}
+	if ua.Flags != 0xC0 {
+		t.Errorf("Flags = %#x, want 0xC0 (Optional|Transitive)", ua.Flags)
+	}
+	if !bytes.Equal(ua.Value, value) {
+		t.Errorf("Value = %#x, want %#x", ua.Value, value)
+	}
+}
+
+// TestUnknownPathAttribute_KnownAndUnknownCoexist verifies that recognised
+// attributes still parse normally when an unknown attribute is also present.
+func TestUnknownPathAttribute_KnownAndUnknownCoexist(t *testing.T) {
+	// Origin (Type 1) = igp (0)
+	originAttr := buildAttr(0x40, 1, []byte{0x00})
+	// Unknown Type 250
+	unknownAttr := buildAttr(0xC0, 250, []byte{0x01, 0x02, 0x03})
+	raw := append(originAttr, unknownAttr...)
+
+	ba, err := UnmarshalBGPBaseAttributes(raw)
+	if err != nil {
+		t.Fatalf("UnmarshalBGPBaseAttributes: %v", err)
+	}
+	if ba.Origin != "igp" {
+		t.Errorf("Origin = %q, want \"igp\"", ba.Origin)
+	}
+	if len(ba.UnknownAttributes) != 1 || ba.UnknownAttributes[0].Type != 250 {
+		t.Fatalf("UnknownAttributes = %+v, want one entry with Type=250", ba.UnknownAttributes)
+	}
+}
+
+// TestUnknownPathAttribute_MultiplePreserveOrder verifies that multiple
+// unknown attributes are captured in wire order.
+func TestUnknownPathAttribute_MultiplePreserveOrder(t *testing.T) {
+	raw := buildAttr(0xC0, 99, []byte{0xAA})
+	raw = append(raw, buildAttr(0xC0, 100, []byte{0xBB})...)
+	raw = append(raw, buildAttr(0x80, 101, []byte{0xCC})...)
+
+	ba, err := UnmarshalBGPBaseAttributes(raw)
+	if err != nil {
+		t.Fatalf("UnmarshalBGPBaseAttributes: %v", err)
+	}
+	if len(ba.UnknownAttributes) != 3 {
+		t.Fatalf("len = %d, want 3", len(ba.UnknownAttributes))
+	}
+	wantTypes := []uint8{99, 100, 101}
+	for i, want := range wantTypes {
+		if ba.UnknownAttributes[i].Type != want {
+			t.Errorf("UnknownAttributes[%d].Type = %d, want %d", i, ba.UnknownAttributes[i].Type, want)
+		}
+	}
+	// Last one is Optional-but-not-Transitive (RFC 4271 §5 says quietly ignore +
+	// not pass along). gobmp doesn't forward so we still surface it; assert
+	// the original flag byte is preserved so consumers can apply their own policy.
+	if ba.UnknownAttributes[2].Flags != 0x80 {
+		t.Errorf("UnknownAttributes[2].Flags = %#x, want 0x80 (Optional non-Transitive)", ba.UnknownAttributes[2].Flags)
+	}
+}
+
+// TestUnknownPathAttribute_EmptyValue verifies a zero-length unknown
+// attribute is captured as present (length 0 Value) rather than dropped.
+func TestUnknownPathAttribute_EmptyValue(t *testing.T) {
+	raw := buildAttr(0xC0, 99, nil)
+	ba, err := UnmarshalBGPBaseAttributes(raw)
+	if err != nil {
+		t.Fatalf("UnmarshalBGPBaseAttributes: %v", err)
+	}
+	if len(ba.UnknownAttributes) != 1 {
+		t.Fatalf("len = %d, want 1", len(ba.UnknownAttributes))
+	}
+	if len(ba.UnknownAttributes[0].Value) != 0 {
+		t.Errorf("Value len = %d, want 0", len(ba.UnknownAttributes[0].Value))
+	}
+}
+
+// TestUnknownPathAttribute_JSON locks the JSON tags and omitempty behaviour.
+func TestUnknownPathAttribute_JSON(t *testing.T) {
+	t.Run("present round-trips", func(t *testing.T) {
+		original := &BaseAttributes{
+			UnknownAttributes: []UnknownPathAttribute{
+				{Type: 99, Flags: 0xC0, Value: []byte{0xDE, 0xAD}},
+			},
+		}
+		b, err := json.Marshal(original)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if !strings.Contains(string(b), `"unknown_attributes":[`) {
+			t.Errorf("missing unknown_attributes; got %s", b)
+		}
+		if !strings.Contains(string(b), `"type":99`) {
+			t.Errorf("missing type field; got %s", b)
+		}
+		if !strings.Contains(string(b), `"flags":192`) {
+			t.Errorf("missing flags field; got %s", b)
+		}
+		// json encodes []byte as base64; 0xDEAD → 3q0=
+		if !strings.Contains(string(b), `"value":"3q0="`) {
+			t.Errorf("missing/wrong value field; got %s", b)
+		}
+
+		recovered := &BaseAttributes{}
+		if err := json.Unmarshal(b, recovered); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if len(recovered.UnknownAttributes) != 1 ||
+			recovered.UnknownAttributes[0].Type != 99 ||
+			recovered.UnknownAttributes[0].Flags != 0xC0 ||
+			!bytes.Equal(recovered.UnknownAttributes[0].Value, []byte{0xDE, 0xAD}) {
+			t.Errorf("round-trip lost; got %+v", recovered.UnknownAttributes)
+		}
+	})
+	t.Run("absent omitempty fires", func(t *testing.T) {
+		b, err := json.Marshal(&BaseAttributes{})
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if strings.Contains(string(b), "unknown_attributes") {
+			t.Errorf("unknown_attributes should be omitted; got %s", b)
+		}
+	})
+}
+
+// TestBaseAttributes_Equal_UnknownAttributes verifies BaseAttributes.Equal
+// detects a difference in UnknownAttributes — without this, two updates
+// that differ only in an unknown attribute would be deduped silently.
+func TestBaseAttributes_Equal_UnknownAttributes(t *testing.T) {
+	a := &BaseAttributes{
+		UnknownAttributes: []UnknownPathAttribute{{Type: 99, Flags: 0xC0, Value: []byte{0x01}}},
+	}
+	b := &BaseAttributes{
+		UnknownAttributes: []UnknownPathAttribute{{Type: 99, Flags: 0xC0, Value: []byte{0x02}}},
+	}
+	eq, diffs := a.Equal(b)
+	if eq {
+		t.Error("Equal returned true for different UnknownAttributes")
+	}
+	found := false
+	for _, d := range diffs {
+		if d == "unknown_attributes mismatch" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("missing unknown_attributes mismatch diff; got %v", diffs)
+	}
+
+	// Same UnknownAttributes → equal.
+	c := &BaseAttributes{
+		UnknownAttributes: []UnknownPathAttribute{{Type: 99, Flags: 0xC0, Value: []byte{0x01}}},
+	}
+	if eq, _ := a.Equal(c); !eq {
+		t.Error("Equal returned false for identical UnknownAttributes")
+	}
+
+	// Both nil → equal.
+	if eq, _ := (&BaseAttributes{}).Equal(&BaseAttributes{}); !eq {
+		t.Error("Equal returned false for two empty BaseAttributes")
+	}
+}


### PR DESCRIPTION
Unknown attribute Types (43-127, 129-255 excluding handled cases) were silently dropped from BaseAttributes. Adds default branch in unmarshalBaseAttrsFromSlice capturing Type, full Flags byte, and raw Value into UnknownAttributes (json:omitempty), plus comparison in BaseAttributes.Equal so updates differing only in unknown attrs aren't deduped silently.