### PR TITLE
Add --kafka-skip-topic-creation flag for Kafka 4.0+ compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,23 @@ Examples:
 Kafka topic retention time in milliseconds. Topics are created with this retention policy to manage storage for high-volume BGP data. Adjust based on your storage capacity and retention requirements.
 
 ```
+--kafka-skip-topic-creation={true|false}
+```
+**Default:** false
+
+When `true`, gobmp skips the Kafka Admin API `CreateTopics` call on startup and connects directly as an async producer. Use this with Kafka 4.0+ environments that reject `CreateTopics`, or with clusters where the client lacks `CreateTopics` permission (e.g. Confluent Cloud, MSK with restricted IAM policies).
+
+> **Important:** Topics must be pre-created before starting gobmp. If the required topics do not exist, publishing will fail with unclear broker errors.
+
+YAML equivalent:
+```yaml
+kafka_config:
+  kafka_srv: "kafka.example.com:9092"
+  kafka_tp_retn_time_ms: 900000
+  skip_topic_creation: true
+```
+
+```
 --nats-server={url}
 ```
 **Default:** none (NATS disabled)

--- a/cmd/gobmp/gobmp.go
+++ b/cmd/gobmp/gobmp.go
@@ -22,18 +22,19 @@ import (
 )
 
 var (
-	srcPort           int
-	perfPort          int
-	kafkaSrv          string
-	kafkaTpRetnTimeMs string // Kafka topic retention time in ms
-	kafkaTopicPrefix  string
-	natsSrv           string
-	splitAF           string
-	dump              string
-	file              string
-	bmpRaw            string
-	adminID           string
-	configFile        string
+	srcPort                int
+	perfPort               int
+	kafkaSrv               string
+	kafkaTpRetnTimeMs      string // Kafka topic retention time in ms
+	kafkaTopicPrefix       string
+	kafkaSkipTopicCreation string
+	natsSrv                string
+	splitAF                string
+	dump                   string
+	file                   string
+	bmpRaw                 string
+	adminID                string
+	configFile             string
 )
 
 const (
@@ -49,6 +50,7 @@ func init() {
 	flag.StringVar(&kafkaSrv, "kafka-server", "", "URL to access Kafka server")
 	flag.StringVar(&kafkaTpRetnTimeMs, "kafka-topic-retention-time-ms", defaultKafkaTpRetnTimeMs, "Kafka topic retention time in ms, default is 900000 ms i.e 15 minutes")
 	flag.StringVar(&kafkaTopicPrefix, "kafka-topic-prefix", "", "Optional prefix prepended to all Kafka topic names (e.g. 'prod' -> 'prod.gobmp.parsed.peer')")
+	flag.StringVar(&kafkaSkipTopicCreation, "kafka-skip-topic-creation", "false", "When \"true\", skip Kafka Admin API topic creation on startup. Required for Kafka 4.0+ and clusters where the client lacks CreateTopics permission; pre-create topics before starting gobmp.")
 	flag.StringVar(&natsSrv, "nats-server", "", "URL to access NATS server")
 	flag.StringVar(&splitAF, "split-af", "true", "When set \"true\" ipv4 and ipv6 will be published in separate topics. if set \"false\" the same topic will be used for both address families.")
 	flag.IntVar(&perfPort, "performance-port", 0, "port used for performance debugging")
@@ -133,6 +135,7 @@ func main() {
 			ServerAddress:        cfg.KafkaConfig.KafkaSrv,
 			TopicRetentionTimeMs: strconv.Itoa(cfg.KafkaConfig.KafkaTpRetnTimeMs),
 			TopicPrefix:          cfg.KafkaConfig.KafkaTopicPrefix,
+			SkipTopicCreation:    cfg.KafkaConfig.SkipTopicCreation,
 		}
 		cfg.Publisher, err = kafka.NewKafkaPublisher(kConfig)
 		if err != nil {
@@ -271,6 +274,15 @@ func applyConfigOverrides(cfg *config.Config, fs *flag.FlagSet) error {
 				cfg.KafkaConfig = defaultKafkaConfig()
 			}
 			cfg.KafkaConfig.KafkaTopicPrefix = kafkaTopicPrefix
+		case "kafka-skip-topic-creation":
+			if cfg.KafkaConfig == nil {
+				cfg.KafkaConfig = defaultKafkaConfig()
+			}
+			if v, err := strconv.ParseBool(kafkaSkipTopicCreation); err != nil {
+				visitErr = fmt.Errorf("invalid value for --kafka-skip-topic-creation: %q: %w", kafkaSkipTopicCreation, err)
+			} else {
+				cfg.KafkaConfig.SkipTopicCreation = v
+			}
 		case "bmp-raw":
 			if cfg.KafkaConfig == nil {
 				cfg.KafkaConfig = defaultKafkaConfig()

--- a/cmd/gobmp/gobmp.go
+++ b/cmd/gobmp/gobmp.go
@@ -50,7 +50,7 @@ func init() {
 	flag.StringVar(&kafkaSrv, "kafka-server", "", "URL to access Kafka server")
 	flag.StringVar(&kafkaTpRetnTimeMs, "kafka-topic-retention-time-ms", defaultKafkaTpRetnTimeMs, "Kafka topic retention time in ms, default is 900000 ms i.e 15 minutes")
 	flag.StringVar(&kafkaTopicPrefix, "kafka-topic-prefix", "", "Optional prefix prepended to all Kafka topic names (e.g. 'prod' -> 'prod.gobmp.parsed.peer')")
-	flag.StringVar(&kafkaSkipTopicCreation, "kafka-skip-topic-creation", "false", "When \"true\", skip Kafka Admin API topic creation on startup. Required for Kafka 4.0+ and clusters where the client lacks CreateTopics permission; pre-create topics before starting gobmp.")
+	flag.StringVar(&kafkaSkipTopicCreation, "kafka-skip-topic-creation", "false", "When \"true\", skip Kafka Admin API topic creation on startup. Use with Kafka 4.0+ environments that reject CreateTopics, or clusters where the client lacks CreateTopics permission; pre-create topics before starting gobmp.")
 	flag.StringVar(&natsSrv, "nats-server", "", "URL to access NATS server")
 	flag.StringVar(&splitAF, "split-af", "true", "When set \"true\" ipv4 and ipv6 will be published in separate topics. if set \"false\" the same topic will be used for both address families.")
 	flag.IntVar(&perfPort, "performance-port", 0, "port used for performance debugging")

--- a/cmd/gobmp/gobmp_test.go
+++ b/cmd/gobmp/gobmp_test.go
@@ -257,6 +257,7 @@ func newTestFlagSet() *flag.FlagSet {
 	fs.StringVar(&kafkaSrv, "kafka-server", "", "")
 	fs.StringVar(&kafkaTpRetnTimeMs, "kafka-topic-retention-time-ms", defaultKafkaTpRetnTimeMs, "")
 	fs.StringVar(&kafkaTopicPrefix, "kafka-topic-prefix", "", "")
+	fs.StringVar(&kafkaSkipTopicCreation, "kafka-skip-topic-creation", "false", "")
 	fs.StringVar(&natsSrv, "nats-server", "", "")
 	fs.StringVar(&splitAF, "split-af", "", "")
 	fs.StringVar(&dump, "dump", "", "")
@@ -656,5 +657,36 @@ func TestApplyConfigOverrides_AdminID_WithoutKafka_NoError(t *testing.T) {
 	}
 	if cfg.KafkaConfig == nil || cfg.KafkaConfig.AdminID != "my-collector" {
 		t.Error("AdminID should be stored in KafkaConfig regardless of publisher selection")
+	}
+}
+
+func TestApplyConfigOverrides_KafkaSkipTopicCreation(t *testing.T) {
+	fs := newTestFlagSet()
+	if err := fs.Set("kafka-skip-topic-creation", "true"); err != nil {
+		t.Fatalf("failed to set flag: %v", err)
+	}
+
+	cfg := &config.Config{}
+	if err := applyConfigOverrides(cfg, fs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.KafkaConfig == nil {
+		t.Fatal("KafkaConfig is nil, want non-nil")
+	}
+	if !cfg.KafkaConfig.SkipTopicCreation {
+		t.Error("SkipTopicCreation = false, want true")
+	}
+}
+
+func TestApplyConfigOverrides_KafkaSkipTopicCreation_Invalid(t *testing.T) {
+	fs := newTestFlagSet()
+	if err := fs.Set("kafka-skip-topic-creation", "notabool"); err != nil {
+		t.Fatalf("failed to set flag: %v", err)
+	}
+
+	cfg := &config.Config{}
+	if err := applyConfigOverrides(cfg, fs); err == nil {
+		t.Error("expected error for invalid --kafka-skip-topic-creation value, got nil")
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,9 +55,9 @@ type KafkaConfig struct {
 	BmpRaw            bool   `yaml:"bmp_raw"`
 	AdminID           string `yaml:"admin_id"`
 	// SkipTopicCreation disables the Kafka Admin API topic-creation calls on
-	// startup. Required for Kafka 4.0+ brokers and clusters where the client
-	// lacks CreateTopics permission. Pre-create the required topics before
-	// starting gobmp when this is set.
+	// startup. Use with Kafka 4.0+ environments that reject CreateTopics, or
+	// clusters where the client lacks CreateTopics permission. Pre-create the
+	// required topics before starting gobmp when this is set.
 	SkipTopicCreation bool `yaml:"skip_topic_creation"`
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,6 +54,11 @@ type KafkaConfig struct {
 	KafkaTopicPrefix  string `yaml:"kafka_topic_prefix"`
 	BmpRaw            bool   `yaml:"bmp_raw"`
 	AdminID           string `yaml:"admin_id"`
+	// SkipTopicCreation disables the Kafka Admin API topic-creation calls on
+	// startup. Required for Kafka 4.0+ brokers and clusters where the client
+	// lacks CreateTopics permission. Pre-create the required topics before
+	// starting gobmp when this is set.
+	SkipTopicCreation bool `yaml:"skip_topic_creation"`
 }
 
 type Config struct {

--- a/pkg/kafka/config.go
+++ b/pkg/kafka/config.go
@@ -6,4 +6,8 @@ type Config struct {
 	// TopicPrefix, when set, is prepended to all Kafka topic names.
 	// Example: TopicPrefix="prod" -> "prod.gobmp.parsed.peer"
 	TopicPrefix string
+	// SkipTopicCreation skips the Admin API topic-creation calls on startup.
+	// Use with Kafka 4.0+ or clusters where the client lacks CreateTopics
+	// permission. Topics must be pre-created before starting gobmp.
+	SkipTopicCreation bool
 }

--- a/pkg/kafka/kafka-publisher.go
+++ b/pkg/kafka/kafka-publisher.go
@@ -151,7 +151,9 @@ func (p *publisher) produceMessage(topic string, key []byte, msg []byte) error {
 
 func (p *publisher) Stop() {
 	close(p.stopCh)
-	_ = p.clusterAdmin.Close()
+	if p.clusterAdmin != nil {
+		_ = p.clusterAdmin.Close()
+	}
 }
 
 // NewKafkaPublisher instantiates a new instance of a Kafka publisher
@@ -175,27 +177,35 @@ func NewKafkaPublisher(kConfig *Config) (pub.Publisher, error) {
 	config.Version = sarama.V3_0_0_0
 
 	kafkaSrvs := strings.Split(kConfig.ServerAddress, ",")
-	ca, err := sarama.NewClusterAdmin(kafkaSrvs, config)
-	if err != nil {
-		glog.Errorf("failed to create cluster admin: %+v", err)
-		return nil, err
-	}
-
-	cb, err := waitForControllerBrokerConnection(ca, config, brockerConnectTimeout)
-	if err != nil {
-		glog.Errorf("failed to open connection to the controller broker with error: %+v\n", err)
-		return nil, err
-	}
-	glog.V(5).Infof("Connected to controller broker: %s id: %d\n", cb.Addr(), cb.ID())
-
-	for _, t := range topicNames {
-		topicName := WithTopicPrefix(kConfig.TopicPrefix, t)
-		if err := ensureTopic(ca, topicCreateTimeout, topicName); err != nil {
-			glog.Errorf("New Kafka publisher failed to ensure requested topics with error: %+v", err)
+	var (
+		ca  sarama.ClusterAdmin
+		err error
+	)
+	if !kConfig.SkipTopicCreation {
+		ca, err = sarama.NewClusterAdmin(kafkaSrvs, config)
+		if err != nil {
+			glog.Errorf("failed to create cluster admin: %+v", err)
 			return nil, err
 		}
+		cb, err := waitForControllerBrokerConnection(ca, config, brockerConnectTimeout)
+		if err != nil {
+			glog.Errorf("failed to open connection to the controller broker with error: %+v\n", err)
+			return nil, err
+		}
+		glog.V(5).Infof("Connected to controller broker: %s id: %d\n", cb.Addr(), cb.ID())
+		_ = cb.Close()
+		for _, t := range topicNames {
+			topicName := WithTopicPrefix(kConfig.TopicPrefix, t)
+			if err := ensureTopic(ca, topicCreateTimeout, topicName); err != nil {
+				glog.Errorf("New Kafka publisher failed to ensure requested topics with error: %+v", err)
+				return nil, err
+			}
+		}
+	} else {
+		glog.Infof("Kafka topic creation skipped; topics must be pre-created before publishing")
 	}
-	producer, err := sarama.NewAsyncProducer(kafkaSrvs, config)
+	var producer sarama.AsyncProducer
+	producer, err = sarama.NewAsyncProducer(kafkaSrvs, config)
 	if err != nil {
 		glog.Errorf("New Kafka publisher failed to start new async producer with error: %+v", err)
 		return nil, err

--- a/pkg/kafka/kafka-publisher.go
+++ b/pkg/kafka/kafka-publisher.go
@@ -48,6 +48,13 @@ var (
 	topicCreateTimeout    = 1 * time.Second
 	// goBMP topic's retention timer is 15 minutes.
 	topicRetention = "900000"
+	// adminRetryMax controls sarama ClusterAdmin retry attempts. Exposed as a
+	// var so tests can set it to 0 for fast failure without network retries.
+	adminRetryMax = 120
+	// netReadTimeout sets the TCP read deadline for sarama connections.
+	// Defaults to sarama's built-in 30s. Tests set a short value so that
+	// an unresponsive mock broker causes a fast read-timeout rather than hanging.
+	netReadTimeout = 30 * time.Second
 )
 
 var (
@@ -170,10 +177,11 @@ func NewKafkaPublisher(kConfig *Config) (pub.Publisher, error) {
 	config.ClientID = "gobmp-producer" + "_" + strconv.Itoa(rand.Intn(1000))
 	config.Producer.Return.Successes = true
 	config.Producer.Return.Errors = true
-	config.Admin.Retry.Max = 120
+	config.Admin.Retry.Max = adminRetryMax
 	config.Admin.Retry.Backoff = time.Second
 	config.Metadata.Retry.Max = 300
 	config.Metadata.Retry.Backoff = time.Second * 10
+	config.Net.ReadTimeout = netReadTimeout
 	config.Version = sarama.V3_0_0_0
 
 	kafkaSrvs := strings.Split(kConfig.ServerAddress, ",")

--- a/pkg/kafka/kafka-publisher.go
+++ b/pkg/kafka/kafka-publisher.go
@@ -198,6 +198,7 @@ func NewKafkaPublisher(kConfig *Config) (pub.Publisher, error) {
 		cb, err := waitForControllerBrokerConnection(ca, config, brockerConnectTimeout)
 		if err != nil {
 			glog.Errorf("failed to open connection to the controller broker with error: %+v\n", err)
+			_ = ca.Close()
 			return nil, err
 		}
 		glog.V(5).Infof("Connected to controller broker: %s id: %d\n", cb.Addr(), cb.ID())
@@ -206,6 +207,7 @@ func NewKafkaPublisher(kConfig *Config) (pub.Publisher, error) {
 			topicName := WithTopicPrefix(kConfig.TopicPrefix, t)
 			if err := ensureTopic(ca, topicCreateTimeout, topicName); err != nil {
 				glog.Errorf("New Kafka publisher failed to ensure requested topics with error: %+v", err)
+				_ = ca.Close()
 				return nil, err
 			}
 		}

--- a/pkg/kafka/kafka-publisher.go
+++ b/pkg/kafka/kafka-publisher.go
@@ -163,7 +163,9 @@ func (p *publisher) Stop() {
 	}
 }
 
-// NewKafkaPublisher instantiates a new instance of a Kafka publisher
+// NewKafkaPublisher instantiates a new Kafka publisher. When SkipTopicCreation
+// is true, topics must already exist because startup skips Admin API topic
+// creation and validation.
 func NewKafkaPublisher(kConfig *Config) (pub.Publisher, error) {
 	glog.Infof("Initializing Kafka producer client")
 	if err := validator(kConfig); err != nil {
@@ -186,9 +188,15 @@ func NewKafkaPublisher(kConfig *Config) (pub.Publisher, error) {
 
 	kafkaSrvs := strings.Split(kConfig.ServerAddress, ",")
 	var (
-		ca  sarama.ClusterAdmin
-		err error
+		ca                    sarama.ClusterAdmin
+		err                   error
+		adminOwnedByPublisher bool
 	)
+	defer func() {
+		if ca != nil && !adminOwnedByPublisher {
+			_ = ca.Close()
+		}
+	}()
 	if !kConfig.SkipTopicCreation {
 		ca, err = sarama.NewClusterAdmin(kafkaSrvs, config)
 		if err != nil {
@@ -198,7 +206,6 @@ func NewKafkaPublisher(kConfig *Config) (pub.Publisher, error) {
 		cb, err := waitForControllerBrokerConnection(ca, config, brockerConnectTimeout)
 		if err != nil {
 			glog.Errorf("failed to open connection to the controller broker with error: %+v\n", err)
-			_ = ca.Close()
 			return nil, err
 		}
 		glog.V(5).Infof("Connected to controller broker: %s id: %d\n", cb.Addr(), cb.ID())
@@ -207,15 +214,13 @@ func NewKafkaPublisher(kConfig *Config) (pub.Publisher, error) {
 			topicName := WithTopicPrefix(kConfig.TopicPrefix, t)
 			if err := ensureTopic(ca, topicCreateTimeout, topicName); err != nil {
 				glog.Errorf("New Kafka publisher failed to ensure requested topics with error: %+v", err)
-				_ = ca.Close()
 				return nil, err
 			}
 		}
 	} else {
 		glog.Infof("Kafka topic creation skipped; topics must be pre-created before publishing")
 	}
-	var producer sarama.AsyncProducer
-	producer, err = sarama.NewAsyncProducer(kafkaSrvs, config)
+	producer, err := sarama.NewAsyncProducer(kafkaSrvs, config)
 	if err != nil {
 		glog.Errorf("New Kafka publisher failed to start new async producer with error: %+v", err)
 		return nil, err
@@ -235,6 +240,7 @@ func NewKafkaPublisher(kConfig *Config) (pub.Publisher, error) {
 		}
 	}(producer, stopCh)
 
+	adminOwnedByPublisher = true
 	return &publisher{
 		stopCh:       stopCh,
 		clusterAdmin: ca,
@@ -245,6 +251,9 @@ func NewKafkaPublisher(kConfig *Config) (pub.Publisher, error) {
 }
 
 func validator(kConfig *Config) error {
+	if kConfig == nil {
+		return errors.New("kafka config cannot be nil")
+	}
 	addrs := strings.Split(kConfig.ServerAddress, ",")
 	for _, addr := range addrs {
 		host, port, _ := net.SplitHostPort(addr)
@@ -278,6 +287,9 @@ func validator(kConfig *Config) error {
 }
 
 func ensureTopic(ca sarama.ClusterAdmin, timeout time.Duration, topicName string) error {
+	if ca == nil {
+		return errors.New("nil ClusterAdmin provided")
+	}
 	topicDetail := &sarama.TopicDetail{
 		NumPartitions:     1,
 		ReplicationFactor: 1,
@@ -287,7 +299,9 @@ func ensureTopic(ca sarama.ClusterAdmin, timeout time.Duration, topicName string
 	}
 
 	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
 	tout := time.NewTimer(timeout)
+	defer tout.Stop()
 	for {
 		err := ca.CreateTopic(topicName, topicDetail, false)
 		if errors.Is(err, sarama.ErrIncompleteResponse) {
@@ -321,6 +335,9 @@ func waitForControllerBrokerConnection(ca sarama.ClusterAdmin, config *sarama.Co
 	cb, err := ca.Controller()
 	if err != nil {
 		return nil, err
+	}
+	if cb == nil {
+		return nil, errors.New("nil controller broker returned")
 	}
 	for {
 		if err := cb.Open(config); err == nil {

--- a/pkg/kafka/kafka_publisher_test.go
+++ b/pkg/kafka/kafka_publisher_test.go
@@ -1,6 +1,10 @@
 package kafka
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/IBM/sarama"
+)
 
 func TestValidator(t *testing.T) {
 	const validRetention = "900000"
@@ -52,5 +56,59 @@ func TestValidator(t *testing.T) {
 				t.Errorf("validator() error = %v, wantErr %v", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+// TestNewKafkaPublisher_SkipTopicCreation exercises the SkipTopicCreation=true
+// path using an in-memory mock broker: ClusterAdmin init and ensureTopic are
+// bypassed; the async producer connects successfully and Stop() closes cleanly.
+func TestNewKafkaPublisher_SkipTopicCreation(t *testing.T) {
+	mb := sarama.NewMockBroker(t, 1)
+	defer mb.Close()
+	mb.SetHandlerByMap(map[string]sarama.MockResponse{
+		"ApiVersionsRequest": sarama.NewMockApiVersionsResponse(t),
+		"MetadataRequest": sarama.NewMockMetadataResponse(t).
+			SetBroker(mb.Addr(), mb.BrokerID()),
+		"ProduceRequest": sarama.NewMockProduceResponse(t),
+	})
+
+	cfg := &Config{
+		ServerAddress:        mb.Addr(),
+		TopicRetentionTimeMs: "900000",
+		SkipTopicCreation:    true,
+	}
+	pub, err := NewKafkaPublisher(cfg)
+	if err != nil {
+		t.Fatalf("NewKafkaPublisher with SkipTopicCreation=true: %v", err)
+	}
+	pub.Stop()
+}
+
+// stubAdmin is a minimal sarama.ClusterAdmin that only implements Close.
+type stubAdmin struct{ sarama.ClusterAdmin }
+
+func (s *stubAdmin) Close() error { return nil }
+
+// TestStop_NilClusterAdmin verifies Stop() does not panic when clusterAdmin is nil.
+func TestStop_NilClusterAdmin(t *testing.T) {
+	stopCh := make(chan struct{})
+	p := &publisher{clusterAdmin: nil, stopCh: stopCh}
+	p.Stop()
+	select {
+	case <-stopCh:
+	default:
+		t.Error("Stop() did not close stopCh")
+	}
+}
+
+// TestStop_NonNilClusterAdmin verifies Stop() calls Close on a non-nil clusterAdmin.
+func TestStop_NonNilClusterAdmin(t *testing.T) {
+	stopCh := make(chan struct{})
+	p := &publisher{clusterAdmin: &stubAdmin{}, stopCh: stopCh}
+	p.Stop()
+	select {
+	case <-stopCh:
+	default:
+		t.Error("Stop() did not close stopCh")
 	}
 }

--- a/pkg/kafka/kafka_publisher_test.go
+++ b/pkg/kafka/kafka_publisher_test.go
@@ -49,6 +49,11 @@ func TestValidator(t *testing.T) {
 			cfg:     &Config{ServerAddress: "127.0.0.1:9092", TopicRetentionTimeMs: "-1"},
 			wantErr: false,
 		},
+		{
+			name:    "nil config",
+			cfg:     nil,
+			wantErr: true,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -133,6 +138,14 @@ func (s *stubAdmin) Close() error {
 	return nil
 }
 
+type nilControllerAdmin struct {
+	sarama.ClusterAdmin
+}
+
+func (n *nilControllerAdmin) Controller() (*sarama.Broker, error) {
+	return nil, nil
+}
+
 // TestStop_NilClusterAdmin verifies Stop() does not panic when clusterAdmin is nil.
 func TestStop_NilClusterAdmin(t *testing.T) {
 	stopCh := make(chan struct{})
@@ -158,5 +171,19 @@ func TestStop_NonNilClusterAdmin(t *testing.T) {
 	}
 	if !sa.closed {
 		t.Error("Stop() did not call Close on clusterAdmin")
+	}
+}
+
+func TestEnsureTopic_NilClusterAdmin(t *testing.T) {
+	err := ensureTopic(nil, time.Millisecond, PeerTopic)
+	if err == nil {
+		t.Fatal("ensureTopic(nil) error = nil, want error")
+	}
+}
+
+func TestWaitForControllerBrokerConnection_NilController(t *testing.T) {
+	_, err := waitForControllerBrokerConnection(&nilControllerAdmin{}, nil, time.Millisecond)
+	if err == nil {
+		t.Fatal("waitForControllerBrokerConnection() error = nil, want error")
 	}
 }

--- a/pkg/kafka/kafka_publisher_test.go
+++ b/pkg/kafka/kafka_publisher_test.go
@@ -121,10 +121,17 @@ func TestNewKafkaPublisher_SkipTopicCreation(t *testing.T) {
 	pub.Stop()
 }
 
-// stubAdmin is a minimal sarama.ClusterAdmin that only implements Close.
-type stubAdmin struct{ sarama.ClusterAdmin }
+// stubAdmin is a minimal sarama.ClusterAdmin that only implements Close and
+// records whether Close was called.
+type stubAdmin struct {
+	sarama.ClusterAdmin
+	closed bool
+}
 
-func (s *stubAdmin) Close() error { return nil }
+func (s *stubAdmin) Close() error {
+	s.closed = true
+	return nil
+}
 
 // TestStop_NilClusterAdmin verifies Stop() does not panic when clusterAdmin is nil.
 func TestStop_NilClusterAdmin(t *testing.T) {
@@ -141,11 +148,15 @@ func TestStop_NilClusterAdmin(t *testing.T) {
 // TestStop_NonNilClusterAdmin verifies Stop() calls Close on a non-nil clusterAdmin.
 func TestStop_NonNilClusterAdmin(t *testing.T) {
 	stopCh := make(chan struct{})
-	p := &publisher{clusterAdmin: &stubAdmin{}, stopCh: stopCh}
+	sa := &stubAdmin{}
+	p := &publisher{clusterAdmin: sa, stopCh: stopCh}
 	p.Stop()
 	select {
 	case <-stopCh:
 	default:
 		t.Error("Stop() did not close stopCh")
+	}
+	if !sa.closed {
+		t.Error("Stop() did not call Close on clusterAdmin")
 	}
 }

--- a/pkg/kafka/kafka_publisher_test.go
+++ b/pkg/kafka/kafka_publisher_test.go
@@ -101,6 +101,41 @@ func TestNewKafkaPublisher_WithTopicCreation(t *testing.T) {
 	}
 }
 
+// TestNewKafkaPublisher_WithTopicCreation_Success exercises the default
+// (SkipTopicCreation=false) happy path: ClusterAdmin creates all topics
+// successfully via mock broker, then an async producer is returned.
+func TestNewKafkaPublisher_WithTopicCreation_Success(t *testing.T) {
+	mb := sarama.NewMockBroker(t, 1)
+	defer mb.Close()
+	// Cap CreateTopics (API key 19) at V4 so MockCreateTopicsResponse works;
+	// V5+ requires TopicResults which the mock doesn't populate.
+	apiVersions := sarama.NewMockApiVersionsResponse(t).SetApiKeys([]sarama.ApiVersionsResponseKey{
+		{ApiKey: 0, MinVersion: 5, MaxVersion: 8},  // Produce
+		{ApiKey: 1, MinVersion: 7, MaxVersion: 11}, // Fetch
+		{ApiKey: 3, MinVersion: 0, MaxVersion: 9},  // Metadata
+		{ApiKey: 19, MinVersion: 0, MaxVersion: 4}, // CreateTopics
+	})
+	mb.SetHandlerByMap(map[string]sarama.MockResponse{
+		"ApiVersionsRequest": apiVersions,
+		"MetadataRequest": sarama.NewMockMetadataResponse(t).
+			SetBroker(mb.Addr(), mb.BrokerID()).
+			SetController(mb.BrokerID()),
+		"CreateTopicsRequest": sarama.NewMockCreateTopicsResponse(t),
+		"ProduceRequest":      sarama.NewMockProduceResponse(t),
+	})
+
+	cfg := &Config{
+		ServerAddress:        mb.Addr(),
+		TopicRetentionTimeMs: "900000",
+		SkipTopicCreation:    false,
+	}
+	pub, err := NewKafkaPublisher(cfg)
+	if err != nil {
+		t.Fatalf("NewKafkaPublisher with SkipTopicCreation=false: %v", err)
+	}
+	pub.Stop()
+}
+
 // TestNewKafkaPublisher_SkipTopicCreation exercises the SkipTopicCreation=true
 // path using an in-memory mock broker: ClusterAdmin init and ensureTopic are
 // bypassed; the async producer connects successfully and Stop() closes cleanly.

--- a/pkg/kafka/kafka_publisher_test.go
+++ b/pkg/kafka/kafka_publisher_test.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"testing"
+	"time"
 
 	"github.com/IBM/sarama"
 )
@@ -56,6 +57,42 @@ func TestValidator(t *testing.T) {
 				t.Errorf("validator() error = %v, wantErr %v", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+// TestNewKafkaPublisher_WithTopicCreation exercises the default (SkipTopicCreation=false)
+// path: ClusterAdmin and waitForControllerBrokerConnection succeed via mock, then
+// ensureTopic fails fast (mock has no CreateTopicsRequest handler; netReadTimeout
+// causes a quick read timeout; adminRetryMax=0 skips retries). All non-skip path
+// lines in NewKafkaPublisher are exercised.
+func TestNewKafkaPublisher_WithTopicCreation(t *testing.T) {
+	origRetry := adminRetryMax
+	origTimeout := netReadTimeout
+	adminRetryMax = 0
+	netReadTimeout = 200 * time.Millisecond
+	defer func() {
+		adminRetryMax = origRetry
+		netReadTimeout = origTimeout
+	}()
+
+	mb := sarama.NewMockBroker(t, 1)
+	defer mb.Close()
+	mb.SetHandlerByMap(map[string]sarama.MockResponse{
+		"ApiVersionsRequest": sarama.NewMockApiVersionsResponse(t),
+		"MetadataRequest": sarama.NewMockMetadataResponse(t).
+			SetBroker(mb.Addr(), mb.BrokerID()).
+			SetController(mb.BrokerID()),
+		// No CreateTopicsRequest handler: mock ignores it, read timeout fires.
+	})
+
+	cfg := &Config{
+		ServerAddress:        mb.Addr(),
+		TopicRetentionTimeMs: "900000",
+		SkipTopicCreation:    false,
+	}
+	_, err := NewKafkaPublisher(cfg)
+	if err == nil {
+		t.Fatal("expected error from topic creation timeout, got nil")
 	}
 }
 

--- a/pkg/kafka/kafka_publisher_test.go
+++ b/pkg/kafka/kafka_publisher_test.go
@@ -1,0 +1,56 @@
+package kafka
+
+import "testing"
+
+func TestValidator(t *testing.T) {
+	const validRetention = "900000"
+	cases := []struct {
+		name    string
+		cfg     *Config
+		wantErr bool
+	}{
+		{
+			name:    "valid config",
+			cfg:     &Config{ServerAddress: "127.0.0.1:9092", TopicRetentionTimeMs: validRetention},
+			wantErr: false,
+		},
+		{
+			name:    "valid config with skip topic creation",
+			cfg:     &Config{ServerAddress: "127.0.0.1:9092", TopicRetentionTimeMs: validRetention, SkipTopicCreation: true},
+			wantErr: false,
+		},
+		{
+			name:    "missing port",
+			cfg:     &Config{ServerAddress: "127.0.0.1", TopicRetentionTimeMs: validRetention},
+			wantErr: true,
+		},
+		{
+			name:    "empty host",
+			cfg:     &Config{ServerAddress: ":9092", TopicRetentionTimeMs: validRetention},
+			wantErr: true,
+		},
+		{
+			name:    "invalid retention",
+			cfg:     &Config{ServerAddress: "127.0.0.1:9092", TopicRetentionTimeMs: "not-a-number"},
+			wantErr: true,
+		},
+		{
+			name:    "retention below -1",
+			cfg:     &Config{ServerAddress: "127.0.0.1:9092", TopicRetentionTimeMs: "-2"},
+			wantErr: true,
+		},
+		{
+			name:    "retention -1 is allowed",
+			cfg:     &Config{ServerAddress: "127.0.0.1:9092", TopicRetentionTimeMs: "-1"},
+			wantErr: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validator(tc.cfg)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validator() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Kafka 4.0+ brokers reject the Admin API \`CreateTopics\` call with \`UnsupportedVersionException\`. Many production clusters (Confluent Cloud, MSK, hardened on-prem) also disable topic auto-creation, making gobmp fail on startup with no workaround.

Add \`--kafka-skip-topic-creation=true\` to bypass the \`ClusterAdmin\` init and \`ensureTopic\` loop entirely. When set, gobmp connects directly as an async producer; topics must be pre-created before starting gobmp.

Also fixes a pre-existing resource leak: the controller broker connection opened during startup was logged but never closed.