### PR TITLE
fix eor message

### DIFF
--- a/pkg/message/base-nlri.go
+++ b/pkg/message/base-nlri.go
@@ -48,6 +48,7 @@ func (p *producer) nlri(op int, ph *bmp.PerPeerHeader, update *bgp.Update) ([]*U
 			RouterHash:    p.speakerHash,
 			RouterIP:      p.speakerIP,
 			PeerHash:      ph.GetPeerHash(),
+			PeerIP:        ph.GetPeerAddrString(),
 			PeerASN:       ph.PeerAS,
 			Timestamp:     ph.GetPeerTimestamp(),
 			PeerType:      uint8(ph.PeerType),

--- a/pkg/message/message_handlers_test.go
+++ b/pkg/message/message_handlers_test.go
@@ -370,6 +370,9 @@ func TestBaseNLRI_EoR(t *testing.T) {
 	if !msgs[0].IsEOR {
 		t.Error("IsEOR = false, want true")
 	}
+	if msgs[0].PeerIP != ph.GetPeerAddrString() {
+		t.Errorf("PeerIP = %q, want %q", msgs[0].PeerIP, ph.GetPeerAddrString())
+	}
 }
 
 // TestMVPN_LocRIB_TableName verifies MVPN handler sets TableName for LocRIB peers.
@@ -474,6 +477,9 @@ func TestUnicast_EoR_RIBFlags(t *testing.T) {
 	}
 	if !r.IsIPv4 {
 		t.Error("IsIPv4 = false, want true for IPv4")
+	}
+	if r.PeerIP != ph.GetPeerAddrString() {
+		t.Errorf("PeerIP = %q, want %q", r.PeerIP, ph.GetPeerAddrString())
 	}
 	if !r.IsAdjRIBOut {
 		t.Error("IsAdjRIBOut = false, want true")

--- a/pkg/message/message_handlers_test.go
+++ b/pkg/message/message_handlers_test.go
@@ -659,6 +659,79 @@ func TestProcessMPUpdate_UnicastBranches(t *testing.T) {
 	}
 }
 
+func TestProcessMPUpdate_MPUnreachEORTopics(t *testing.T) {
+	tests := []struct {
+		name          string
+		unreach       []byte
+		wantTopicType int
+		wantIsIPv4    bool
+		wantL3VPN     bool
+	}{
+		{"IPv4 Unicast", []byte{0x00, 0x01, 0x01}, bmp.UnicastPrefixV4Msg, true, false},
+		{"IPv4 Labeled Unicast", []byte{0x00, 0x01, 0x04}, bmp.UnicastPrefixV4Msg, true, false},
+		{"IPv6 Unicast", []byte{0x00, 0x02, 0x01}, bmp.UnicastPrefixV6Msg, false, false},
+		{"VPNv4", []byte{0x00, 0x01, 0x80}, bmp.L3VPNV4Msg, true, true},
+		{"VPNv6", []byte{0x00, 0x02, 0x80}, bmp.L3VPNV6Msg, false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := &recordingPublisher{}
+			p := NewProducer(rec, true).(*producer)
+			p.speakerIP = "10.0.0.1"
+			p.speakerHash = "abc123"
+
+			ph := makePeerHeader(t, bmp.PeerType0, 0x00)
+			update := &bgp.Update{BaseAttributes: &bgp.BaseAttributes{}}
+
+			nlri, err := bgp.UnmarshalMPUnReachNLRI(tt.unreach, map[int]bool{})
+			if err != nil {
+				t.Fatalf("UnmarshalMPUnReachNLRI: %v", err)
+			}
+
+			p.processMPUpdate(nlri, 1, ph, update)
+
+			if len(rec.msgs) != 1 {
+				t.Fatalf("published %d messages, want 1", len(rec.msgs))
+			}
+			if rec.msgs[0].msgType != tt.wantTopicType {
+				t.Errorf("topic type = %d, want %d", rec.msgs[0].msgType, tt.wantTopicType)
+			}
+
+			if tt.wantL3VPN {
+				var got L3VPNPrefix
+				if err := json.Unmarshal(rec.msgs[0].payload, &got); err != nil {
+					t.Fatalf("Unmarshal published L3VPN message: %v", err)
+				}
+				if !got.IsEOR {
+					t.Error("IsEOR = false, want true")
+				}
+				if got.IsIPv4 != tt.wantIsIPv4 {
+					t.Errorf("IsIPv4 = %v, want %v", got.IsIPv4, tt.wantIsIPv4)
+				}
+				if got.PeerIP != ph.GetPeerAddrString() {
+					t.Errorf("PeerIP = %q, want %q", got.PeerIP, ph.GetPeerAddrString())
+				}
+				return
+			}
+
+			var got UnicastPrefix
+			if err := json.Unmarshal(rec.msgs[0].payload, &got); err != nil {
+				t.Fatalf("Unmarshal published unicast message: %v", err)
+			}
+			if !got.IsEOR {
+				t.Error("IsEOR = false, want true")
+			}
+			if got.IsIPv4 != tt.wantIsIPv4 {
+				t.Errorf("IsIPv4 = %v, want %v", got.IsIPv4, tt.wantIsIPv4)
+			}
+			if got.PeerIP != ph.GetPeerAddrString() {
+				t.Errorf("PeerIP = %q, want %q", got.PeerIP, ph.GetPeerAddrString())
+			}
+		})
+	}
+}
+
 // TestProcessMPUpdate_UnknownAFISAFI verifies default case logs warning for unknown types.
 func TestProcessMPUpdate_UnknownAFISAFI(t *testing.T) {
 	p := NewProducer(&mockPublisher{}, false).(*producer)

--- a/pkg/message/mp-unicast.go
+++ b/pkg/message/mp-unicast.go
@@ -43,6 +43,7 @@ func (p *producer) unicast(nlri bgp.MPNLRI, op int, ph *bmp.PerPeerHeader, updat
 			RouterHash: p.speakerHash,
 			RouterIP:   p.speakerIP,
 			PeerHash:   ph.GetPeerHash(),
+			PeerIP:     ph.GetPeerAddrString(),
 			PeerASN:    ph.PeerAS,
 			Timestamp:  ph.GetPeerTimestamp(),
 			PeerType:   uint8(ph.PeerType),

--- a/pkg/unicast/unicast.go
+++ b/pkg/unicast/unicast.go
@@ -19,7 +19,7 @@ func UnmarshalUnicastNLRI(b []byte, pathID bool) (*base.MPNLRI, error) {
 		glog.Infof("MP Unicast NLRI Raw: %s", tools.MessageHex(b))
 	}
 	if len(b) == 0 {
-		return nil, fmt.Errorf("NLRI length is 0")
+		return &base.MPNLRI{NLRI: make([]base.Route, 0)}, nil
 	}
 	mpnlri := base.MPNLRI{}
 	r, err := base.UnmarshalRoutes(b, pathID)

--- a/pkg/unicast/unicast_test.go
+++ b/pkg/unicast/unicast_test.go
@@ -17,6 +17,14 @@ func TestUnmarshalUnicastNLRI(t *testing.T) {
 		pathID bool
 	}{
 		{
+			name:  "empty input returns empty NLRI",
+			input: []byte{},
+			expect: &base.MPNLRI{
+				NLRI: []base.Route{},
+			},
+			pathID: false,
+		},
+		{
 			name:  "mp unicast nlri 1",
 			input: []byte{0x18, 0x0a, 0x00, 0x82},
 			expect: &base.MPNLRI{


### PR DESCRIPTION
currently EoR message does not have Peer IP populated making it difficult to track live cycle of bgp session.