### PR TITLE
add ASPath Segments field

### DIFF
--- a/pkg/bgp/bgp-base-attributes.go
+++ b/pkg/bgp/bgp-base-attributes.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -107,9 +108,24 @@ func (ba *BaseAttributes) Equal(oba *BaseAttributes) (bool, []string) {
 			equal = false
 			diffs = append(diffs, fmt.Sprintf("as_path_segments[%d] type mismatch: %d and %d", i, seg.Type, oseg.Type))
 		}
-		if !reflect.DeepEqual(seg.ASNs, oseg.ASNs) {
+		if len(seg.ASNs) != len(oseg.ASNs) {
 			equal = false
-			diffs = append(diffs, fmt.Sprintf("as_path_segments[%d] ASNs mismatch: %v and %v", i, seg.ASNs, oseg.ASNs))
+			diffs = append(diffs, fmt.Sprintf("as_path_segments[%d] length mismatch: %d and %d", i, len(seg.ASNs), len(oseg.ASNs)))
+		}
+		switch seg.Type {
+		case 1, 4: // AS_SET or AS_CONFED_SET
+			for _, asn := range seg.ASNs {
+				if !slices.Contains(oseg.ASNs, asn) {
+					equal = false
+					diffs = append(diffs, fmt.Sprintf("as_path_segments[%d] ASNs mismatch: %v and %v", i, seg.ASNs, oseg.ASNs))
+					break
+				}
+			}
+		case 2, 3: // AS_SEQUENCE or AS_CONFED_SEQUENCE
+			if !reflect.DeepEqual(seg.ASNs, oseg.ASNs) {
+				equal = false
+				diffs = append(diffs, fmt.Sprintf("as_path_segments[%d] ASNs mismatch: %v and %v", i, seg.ASNs, oseg.ASNs))
+			}
 		}
 	}
 	if len(ba.ASPathSegments) < len(oba.ASPathSegments) {

--- a/pkg/bgp/bgp-base-attributes.go
+++ b/pkg/bgp/bgp-base-attributes.go
@@ -97,40 +97,42 @@ func (ba *BaseAttributes) Equal(oba *BaseAttributes) (bool, []string) {
 		equal = false
 		diffs = append(diffs, "as_path_count mismatch: "+strconv.Itoa(int(ba.ASPathCount))+" and "+strconv.Itoa(int(oba.ASPathCount)))
 	}
-	for i, seg := range ba.ASPathSegments {
-		if i >= len(oba.ASPathSegments) {
+	if len(ba.ASPathSegments) != 0 {
+		if len(ba.ASPathSegments) < len(oba.ASPathSegments) {
 			equal = false
-			diffs = append(diffs, "as_path_segments mismatch: additional segment in first BaseAttributes")
-			break
+			diffs = append(diffs, "as_path_segments mismatch: additional segment in second BaseAttributes")
 		}
-		oseg := oba.ASPathSegments[i]
-		if seg.Type != oseg.Type {
-			equal = false
-			diffs = append(diffs, fmt.Sprintf("as_path_segments[%d] type mismatch: %d and %d", i, seg.Type, oseg.Type))
-		}
-		if len(seg.ASNs) != len(oseg.ASNs) {
-			equal = false
-			diffs = append(diffs, fmt.Sprintf("as_path_segments[%d] length mismatch: %d and %d", i, len(seg.ASNs), len(oseg.ASNs)))
-		}
-		switch seg.Type {
-		case 1, 4: // AS_SET or AS_CONFED_SET
-			for _, asn := range seg.ASNs {
-				if !slices.Contains(oseg.ASNs, asn) {
+		for i, seg := range ba.ASPathSegments {
+			if i >= len(oba.ASPathSegments) {
+				equal = false
+				diffs = append(diffs, "as_path_segments mismatch: additional segment in first BaseAttributes")
+				break
+			}
+			oseg := oba.ASPathSegments[i]
+			if seg.Type != oseg.Type {
+				equal = false
+				diffs = append(diffs, fmt.Sprintf("as_path_segments[%d] type mismatch: %d and %d", i, seg.Type, oseg.Type))
+			}
+			if len(seg.ASNs) != len(oseg.ASNs) {
+				equal = false
+				diffs = append(diffs, fmt.Sprintf("as_path_segments[%d] length mismatch: %d and %d", i, len(seg.ASNs), len(oseg.ASNs)))
+			}
+			switch seg.Type {
+			case 1, 4: // AS_SET or AS_CONFED_SET
+				for _, asn := range seg.ASNs {
+					if !slices.Contains(oseg.ASNs, asn) {
+						equal = false
+						diffs = append(diffs, fmt.Sprintf("as_path_segments[%d] ASNs mismatch: %v and %v", i, seg.ASNs, oseg.ASNs))
+						break
+					}
+				}
+			case 2, 3: // AS_SEQUENCE or AS_CONFED_SEQUENCE
+				if !reflect.DeepEqual(seg.ASNs, oseg.ASNs) {
 					equal = false
 					diffs = append(diffs, fmt.Sprintf("as_path_segments[%d] ASNs mismatch: %v and %v", i, seg.ASNs, oseg.ASNs))
-					break
 				}
 			}
-		case 2, 3: // AS_SEQUENCE or AS_CONFED_SEQUENCE
-			if !reflect.DeepEqual(seg.ASNs, oseg.ASNs) {
-				equal = false
-				diffs = append(diffs, fmt.Sprintf("as_path_segments[%d] ASNs mismatch: %v and %v", i, seg.ASNs, oseg.ASNs))
-			}
 		}
-	}
-	if len(ba.ASPathSegments) < len(oba.ASPathSegments) {
-		equal = false
-		diffs = append(diffs, "as_path_segments mismatch: additional segment in second BaseAttributes")
 	}
 	if ba.Nexthop != oba.Nexthop {
 		equal = false

--- a/pkg/bgp/bgp-base-attributes.go
+++ b/pkg/bgp/bgp-base-attributes.go
@@ -18,20 +18,29 @@ import (
 	"github.com/sbezverk/tools/sort"
 )
 
+// ASPathSegment represents a single segment of an AS_PATH attribute, which can be one of four types.
+// Preserving the segment structure allows for more detailed analysis of the AS_PATH, including the ability to distinguish between AS_SET and AS_SEQUENCE segments, as well as handling of confederation segments.
+// Used in ASPA validation logic.
+type ASPathSegment struct {
+	Type uint8    `json:"type"` // 1 AS_SET, 2 AS_SEQUENCE, 3 AS_CONFED_SEQUENCE, 4 AS_CONFED_SET
+	ASNs []uint32 `json:"asns"`
+}
+
 // BaseAttributes defines a structure holding BGP's basic, non nlri based attributes,
 // codes for each can be found:
 // https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#bgp-parameters-2
 type BaseAttributes struct {
-	BaseAttrHash  string   `json:"base_attr_hash,omitempty"`
-	Origin        string   `json:"origin,omitempty"`
-	ASPath        []uint32 `json:"as_path,omitempty"`
-	ASPathCount   int32    `json:"as_path_count,omitempty"`
-	Nexthop       string   `json:"nexthop,omitempty"`
-	MED           uint32   `json:"med,omitempty"`
-	LocalPref     uint32   `json:"local_pref,omitempty"`
-	IsAtomicAgg   bool     `json:"is_atomic_agg"`
-	Aggregator    []byte   `json:"aggregator,omitempty"`
-	CommunityList []string `json:"community_list,omitempty"`
+	BaseAttrHash   string          `json:"base_attr_hash,omitempty"`
+	Origin         string          `json:"origin,omitempty"`
+	ASPath         []uint32        `json:"as_path,omitempty"`
+	ASPathCount    int32           `json:"as_path_count,omitempty"`
+	ASPathSegments []ASPathSegment `json:"as_path_segments,omitempty"`
+	Nexthop        string          `json:"nexthop,omitempty"`
+	MED            uint32          `json:"med,omitempty"`
+	LocalPref      uint32          `json:"local_pref,omitempty"`
+	IsAtomicAgg    bool            `json:"is_atomic_agg"`
+	Aggregator     []byte          `json:"aggregator,omitempty"`
+	CommunityList  []string        `json:"community_list,omitempty"`
 	// WellKnownCommunityList holds IANA symbolic names for any well-known
 	// communities present in CommunityList (RFC 1997 and related).
 	WellKnownCommunityList []string         `json:"well_known_community_list,omitempty"`
@@ -86,6 +95,26 @@ func (ba *BaseAttributes) Equal(oba *BaseAttributes) (bool, []string) {
 	if ba.ASPathCount != oba.ASPathCount {
 		equal = false
 		diffs = append(diffs, "as_path_count mismatch: "+strconv.Itoa(int(ba.ASPathCount))+" and "+strconv.Itoa(int(oba.ASPathCount)))
+	}
+	for i, seg := range ba.ASPathSegments {
+		if i >= len(oba.ASPathSegments) {
+			equal = false
+			diffs = append(diffs, "as_path_segments mismatch: additional segment in first BaseAttributes")
+			break
+		}
+		oseg := oba.ASPathSegments[i]
+		if seg.Type != oseg.Type {
+			equal = false
+			diffs = append(diffs, fmt.Sprintf("as_path_segments[%d] type mismatch: %d and %d", i, seg.Type, oseg.Type))
+		}
+		if !reflect.DeepEqual(seg.ASNs, oseg.ASNs) {
+			equal = false
+			diffs = append(diffs, fmt.Sprintf("as_path_segments[%d] ASNs mismatch: %v and %v", i, seg.ASNs, oseg.ASNs))
+		}
+	}
+	if len(ba.ASPathSegments) < len(oba.ASPathSegments) {
+		equal = false
+		diffs = append(diffs, "as_path_segments mismatch: additional segment in second BaseAttributes")
 	}
 	if ba.Nexthop != oba.Nexthop {
 		equal = false
@@ -199,10 +228,13 @@ func unmarshalBaseAttrsFromSlice(attrs []PathAttribute, as4hint *bool) (*BaseAtt
 			baseAttr.Origin = unmarshalAttrOrigin(b)
 		case 2:
 			var err error
-			baseAttr.ASPath, err = unmarshalAttrASPath(b, as4hint)
+			var segments []ASPathSegment
+			segments, err = unmarshalASPathSegments(b, as4hint)
 			if err != nil {
 				return nil, err
 			}
+			baseAttr.ASPathSegments = segments
+			baseAttr.ASPath = buildASPathFromSegments(segments)
 			baseAttr.ASPathCount = int32(len(baseAttr.ASPath))
 		case 3:
 			baseAttr.Nexthop = unmarshalAttrNextHop(b)
@@ -375,21 +407,24 @@ func unmarshalAttrOrigin(b []byte) string {
 	}
 }
 
-// unmarshalAttrASPath returns a slice with a list of ASes.
-// as4hint, when non-nil, overrides the heuristic: true means 4-byte ASNs, false means 2-byte.
-// Per RFC 7854 §4.2 the BMP Per-Peer A flag is authoritative for the encoding used.
-func unmarshalAttrASPath(b []byte, as4hint *bool) ([]uint32, error) {
-	if len(b) == 0 {
-		return []uint32{}, nil
+func buildASPathFromSegments(segments []ASPathSegment) []uint32 {
+	path := make([]uint32, 0)
+	for _, seg := range segments {
+		path = append(path, seg.ASNs...)
 	}
-	path := make([]uint32, 0, len(b)/2)
+	return path
+}
+
+// unmarshalASPAthSegments returns a slice of ASPathSegment structs, preserving the segment structure of the AS_PATH attribute.
+func unmarshalASPathSegments(b []byte, as4hint *bool) ([]ASPathSegment, error) {
+	if len(b) == 0 {
+		return []ASPathSegment{}, nil
+	}
+	segments := make([]ASPathSegment, 0)
 	var as4 bool
 	if as4hint != nil {
 		as4 = *as4hint
 	} else {
-		// Detect whether 2-byte or 4-byte ASNs are used. isASPath4 walks the whole
-		// buffer; the loop below re-checks segment type and per-segment bounds so
-		// the hinted path is validated identically.
 		var err error
 		as4, err = isASPath4(b)
 		if err != nil {
@@ -401,36 +436,37 @@ func unmarshalAttrASPath(b []byte, as4hint *bool) ([]uint32, error) {
 		asSize = 4
 	}
 	for p := 0; p < len(b); {
-		// Segment type byte — must be one of 0x01..0x04 per RFC 4271 §4.3 / RFC 5065.
-		// Loop condition guarantees p < len(b), so the byte is always readable.
 		segType := b[p]
 		if segType < 0x01 || segType > 0x04 {
 			return nil, fmt.Errorf("AS_PATH attribute invalid segment type 0x%02x at offset %d", segType, p)
 		}
-		p++ // skip segment type
-		// Segment length (number of ASNs in this segment)
+		p++
 		if p+1 > len(b) {
 			return nil, fmt.Errorf("AS_PATH attribute truncated: cannot read segment length at offset %d", p)
 		}
 		l := int(b[p])
 		p++
-		// Validate that all ASN values for this segment are present before reading any
 		if p+l*asSize > len(b) {
 			return nil, fmt.Errorf("AS_PATH attribute truncated: segment at offset %d claims %d ASes (%d bytes) but only %d bytes remain",
 				p, l, l*asSize, len(b)-p)
 		}
+		asns := make([]uint32, 0, l)
 		for n := 0; n < l; n++ {
 			if as4 {
-				path = append(path, binary.BigEndian.Uint32(b[p:p+4]))
+				asns = append(asns, binary.BigEndian.Uint32(b[p:p+4]))
 				p += 4
 			} else {
-				path = append(path, uint32(binary.BigEndian.Uint16(b[p:p+2])))
+				asns = append(asns, uint32(binary.BigEndian.Uint16(b[p:p+2])))
 				p += 2
 			}
 		}
+		segments = append(segments, ASPathSegment{
+			Type: segType,
+			ASNs: asns,
+		})
 	}
 
-	return path, nil
+	return segments, nil
 }
 
 func isASPath4(b []byte) (bool, error) {

--- a/pkg/bgp/bgp-base-attributes_test.go
+++ b/pkg/bgp/bgp-base-attributes_test.go
@@ -17,10 +17,14 @@ func TestUnmarshaBaseAttributes(t *testing.T) {
 			name:  "panic 1",
 			input: []byte{0x40, 0x01, 0x01, 0x00, 0x40, 0x02, 0x20, 0x02, 0x06, 0x00, 0x00, 0x88, 0x38, 0x00, 0x00, 0x9a, 0x6d, 0x00, 0x00, 0x19, 0x35, 0x00, 0x00, 0x0a, 0x7f, 0x00, 0x00, 0x65, 0x20, 0x00, 0x00, 0x53, 0x4e, 0x01, 0x01, 0x00, 0x00, 0x12, 0xc9, 0x40, 0x03, 0x04, 0xc2, 0x1c, 0x62, 0x25, 0x80, 0x04, 0x04, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x07, 0x08, 0x00, 0x00, 0x65, 0x20, 0xc0, 0x78, 0x51, 0x88, 0xc0, 0x08, 0x18, 0x00, 0x00, 0x9a, 0x6d, 0x19, 0x35, 0x00, 0x56, 0x19, 0x35, 0x0b, 0xb8, 0x19, 0x35, 0x0c, 0x1c, 0x19, 0x35, 0x0c, 0x1e, 0x9a, 0x6d, 0xc2, 0x02, 0xc0, 0x20, 0x30, 0x00, 0x00, 0x88, 0x38, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x00, 0xd3, 0x00, 0x00, 0x88, 0x38, 0x00, 0x00, 0x00, 0x0b, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x88, 0x38, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x31, 0x00, 0x00, 0x88, 0x38, 0x00, 0x00, 0x00, 0x7a, 0x00, 0x00, 0x00, 0x01},
 			expect: &BaseAttributes{
-				BaseAttrHash:    "fd52d710c305d5c5bd62a4d86e97c5de",
-				Origin:          "igp",
-				ASPath:          []uint32{34872, 39533, 6453, 2687, 25888, 21326, 4809},
-				ASPathCount:     7,
+				BaseAttrHash: "fd52d710c305d5c5bd62a4d86e97c5de",
+				Origin:       "igp",
+				ASPath:       []uint32{34872, 39533, 6453, 2687, 25888, 21326, 4809},
+				ASPathCount:  7,
+				ASPathSegments: []ASPathSegment{
+					{Type: 2, ASNs: []uint32{34872, 39533, 6453, 2687, 25888, 21326}},
+					{Type: 1, ASNs: []uint32{4809}},
+				},
 				Nexthop:         "194.28.98.37",
 				Aggregator:      []byte{0, 0, 101, 32, 192, 120, 81, 136},
 				CommunityList:   []string{"0:39533", "6453:86", "6453:3000", "6453:3100", "6453:3102", "39533:49666"},
@@ -157,10 +161,11 @@ func TestUnmarshalASPath(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		r, err := unmarshalAttrASPath(tt.input, nil)
+		segments, err := unmarshalASPathSegments(tt.input, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+		r := buildASPathFromSegments(segments)
 		if !reflect.DeepEqual(tt.asPath, r) {
 			t.Fatalf("expected %+v and result %+v as path do not match", tt.asPath, r)
 		}
@@ -215,11 +220,12 @@ func TestUnmarshalAttrASPathAs4Hint(t *testing.T) {
 
 	t.Run("as4=true hint parses 4-byte ASNs correctly", func(t *testing.T) {
 		hint := true
-		got, err := unmarshalAttrASPath(as4bytes, &hint)
+		segments, err := unmarshalASPathSegments(as4bytes, &hint)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		want := []uint32{1, 2}
+		got := buildASPathFromSegments(segments)
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
 		}
@@ -227,22 +233,24 @@ func TestUnmarshalAttrASPathAs4Hint(t *testing.T) {
 
 	t.Run("as4=false hint parses 2-byte ASNs correctly", func(t *testing.T) {
 		hint := false
-		got, err := unmarshalAttrASPath(as2bytes, &hint)
+		segments, err := unmarshalASPathSegments(as2bytes, &hint)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		want := []uint32{1, 2}
+		got := buildASPathFromSegments(segments)
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
 		}
 	})
 
 	t.Run("nil hint falls back to heuristic for 4-byte input", func(t *testing.T) {
-		got, err := unmarshalAttrASPath(as4bytes, nil)
+		segments, err := unmarshalASPathSegments(as4bytes, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		want := []uint32{1, 2}
+		got := buildASPathFromSegments(segments)
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
 		}
@@ -257,11 +265,12 @@ func TestUnmarshalAttrASPathAs4Hint(t *testing.T) {
 
 	t.Run("as4=true on ambiguous data yields single 4-byte ASN", func(t *testing.T) {
 		hint := true
-		got, err := unmarshalAttrASPath(ambiguous, &hint)
+		segments, err := unmarshalASPathSegments(ambiguous, &hint)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		want := []uint32{0xAABB0200}
+		got := buildASPathFromSegments(segments)
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
 		}
@@ -269,11 +278,12 @@ func TestUnmarshalAttrASPathAs4Hint(t *testing.T) {
 
 	t.Run("as4=false on ambiguous data yields single 2-byte ASN", func(t *testing.T) {
 		hint := false
-		got, err := unmarshalAttrASPath(ambiguous, &hint)
+		segments, err := unmarshalASPathSegments(ambiguous, &hint)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		want := []uint32{0xAABB}
+		got := buildASPathFromSegments(segments)
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
 		}

--- a/pkg/bgp/bgp-update_test.go
+++ b/pkg/bgp/bgp-update_test.go
@@ -72,7 +72,13 @@ func TestUnmarshalBGPUpdate(t *testing.T) {
 					BaseAttrHash: "8681ce86ce93dc0060f7582ae21cc6a1",
 					ASPath:       []uint32{65001, 65003},
 					ASPathCount:  2,
-					Origin:       "incomplete",
+					ASPathSegments: []ASPathSegment{
+						{
+							Type: 2,
+							ASNs: []uint32{65001, 65003},
+						},
+					},
+					Origin: "incomplete",
 				},
 				PathAttributes: []PathAttribute{
 					{

--- a/pkg/bgp/bgp_base_attributes_extra_test.go
+++ b/pkg/bgp/bgp_base_attributes_extra_test.go
@@ -453,6 +453,140 @@ func TestUnmarshalBGPBaseAttributesASPathSegments(t *testing.T) {
 	}
 }
 
+func TestBaseAttributesEqual_ASPathSegmentSemantics(t *testing.T) {
+	t.Run("AS_SET and AS_CONFED_SET are unordered", func(t *testing.T) {
+		a := &BaseAttributes{
+			ASPathSegments: []ASPathSegment{
+				{Type: 1, ASNs: []uint32{65001, 65002, 65003}},
+				{Type: 4, ASNs: []uint32{65101, 65102}},
+			},
+		}
+		b := &BaseAttributes{
+			ASPathSegments: []ASPathSegment{
+				{Type: 1, ASNs: []uint32{65003, 65001, 65002}},
+				{Type: 4, ASNs: []uint32{65102, 65101}},
+			},
+		}
+		equal, diffs := a.Equal(b)
+		if !equal {
+			t.Fatalf("expected equal for reordered set segments, diffs=%v", diffs)
+		}
+	})
+
+	t.Run("AS_SEQUENCE and AS_CONFED_SEQUENCE remain ordered", func(t *testing.T) {
+		a := &BaseAttributes{
+			ASPathSegments: []ASPathSegment{
+				{Type: 2, ASNs: []uint32{64512, 64513}},
+				{Type: 3, ASNs: []uint32{64520, 64521}},
+			},
+		}
+		b := &BaseAttributes{
+			ASPathSegments: []ASPathSegment{
+				{Type: 2, ASNs: []uint32{64513, 64512}},
+				{Type: 3, ASNs: []uint32{64521, 64520}},
+			},
+		}
+		equal, _ := a.Equal(b)
+		if equal {
+			t.Fatal("expected non-equal for reordered sequence segments")
+		}
+	})
+
+	t.Run("AS_SET different members with same length are not equal", func(t *testing.T) {
+		a := &BaseAttributes{ASPathSegments: []ASPathSegment{{Type: 1, ASNs: []uint32{65001, 65002}}}}
+		b := &BaseAttributes{ASPathSegments: []ASPathSegment{{Type: 1, ASNs: []uint32{65001, 65099}}}}
+		equal, _ := a.Equal(b)
+		if equal {
+			t.Fatal("expected non-equal for different AS_SET members")
+		}
+	})
+}
+
+func TestUnmarshalASPathSegments_MalformedInputs(t *testing.T) {
+	t.Run("invalid segment type with explicit AS4 hint", func(t *testing.T) {
+		hint := true
+		_, err := unmarshalASPathSegments([]byte{0x05, 0x00}, &hint)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "invalid segment type") {
+			t.Fatalf("expected invalid segment type error, got %v", err)
+		}
+	})
+
+	t.Run("truncated missing segment length with explicit AS2 hint", func(t *testing.T) {
+		hint := false
+		_, err := unmarshalASPathSegments([]byte{0x02}, &hint)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "cannot read segment length") {
+			t.Fatalf("expected segment length truncation error, got %v", err)
+		}
+	})
+
+	t.Run("truncated segment body with explicit AS4 hint", func(t *testing.T) {
+		hint := true
+		_, err := unmarshalASPathSegments([]byte{0x02, 0x02, 0x00, 0x00, 0x00, 0x01}, &hint)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "claims 2 ASes (8 bytes) but only 4 bytes remain") {
+			t.Fatalf("expected segment body truncation error, got %v", err)
+		}
+	})
+
+	t.Run("zero-length AS_SET segment parses without panic", func(t *testing.T) {
+		hint := false
+		segments, err := unmarshalASPathSegments([]byte{0x01, 0x00}, &hint)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []ASPathSegment{{Type: 1, ASNs: []uint32{}}}
+		if !reflect.DeepEqual(segments, want) {
+			t.Fatalf("segments=%+v, want=%+v", segments, want)
+		}
+	})
+}
+
+func TestUnmarshalASPathSegments_MultiSegmentMalformed(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []byte
+		hint    bool
+		wantErr string
+	}{
+		{
+			name: "invalid segment type after one valid AS2 segment",
+			// Segment #1: AS_SEQUENCE, one AS2 value (0x0001)
+			// Segment #2: invalid type 0x05
+			input:   []byte{0x02, 0x01, 0x00, 0x01, 0x05, 0x00},
+			hint:    false,
+			wantErr: "invalid segment type 0x05 at offset 4",
+		},
+		{
+			name: "second segment truncated after one valid AS2 segment",
+			// Segment #1: AS_SEQUENCE, one AS2 value (0x0001)
+			// Segment #2: AS_SET claims two AS2 values, but only one follows
+			input:   []byte{0x02, 0x01, 0x00, 0x01, 0x01, 0x02, 0x00, 0x02},
+			hint:    false,
+			wantErr: "claims 2 ASes (4 bytes) but only 2 bytes remain",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := unmarshalASPathSegments(tt.input, &tt.hint)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
 // TestBaseAttributes_TunnelEncapAttr_JSON locks the JSON output contract for
 // the Tunnel Encapsulation Attribute (path attribute 23). The field is []byte
 // so encoding/json renders it as a base64 string; assert both that the field

--- a/pkg/bgp/bgp_base_attributes_extra_test.go
+++ b/pkg/bgp/bgp_base_attributes_extra_test.go
@@ -3,6 +3,7 @@ package bgp
 import (
 	"encoding/base64"
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -382,7 +383,7 @@ func TestUnmarshalAttrASPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := unmarshalAttrASPath(tt.input, nil)
+			segments, err := unmarshalASPathSegments(tt.input, nil)
 			if tt.wantErr != "" {
 				if err == nil {
 					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
@@ -395,6 +396,7 @@ func TestUnmarshalAttrASPath(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
+			got := buildASPathFromSegments(segments)
 			if len(got) != len(tt.wantAS) {
 				t.Fatalf("got %v (len %d), want %v (len %d)", got, len(got), tt.wantAS, len(tt.wantAS))
 			}
@@ -404,6 +406,50 @@ func TestUnmarshalAttrASPath(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestUnmarshalBGPBaseAttributesASPathSegments(t *testing.T) {
+	raw := []byte{
+		// ORIGIN: IGP.
+		0x40, 0x01, 0x01, 0x00,
+		// AS_PATH with four 4-byte ASN segments.
+		0x40, 0x02, 0x24,
+		0x02, 0x02, 0x00, 0x00, 0xFD, 0xE9, 0x00, 0x00, 0xFD, 0xEA, // AS_SEQUENCE [65001, 65002]
+		0x01, 0x02, 0x00, 0x00, 0xFD, 0xEB, 0x00, 0x00, 0xFD, 0xEC, // AS_SET [65003, 65004]
+		0x03, 0x01, 0x00, 0x00, 0xFD, 0xED, // AS_CONFED_SEQUENCE [65005]
+		0x04, 0x02, 0x00, 0x00, 0xFD, 0xEE, 0x00, 0x00, 0xFD, 0xEF, // AS_CONFED_SET [65006, 65007]
+	}
+
+	got, err := UnmarshalBGPBaseAttributesWithAS4Hint(raw, true)
+	if err != nil {
+		t.Fatalf("UnmarshalBGPBaseAttributesWithAS4Hint() unexpected error: %v", err)
+	}
+
+	wantSegments := []ASPathSegment{
+		{Type: 2, ASNs: []uint32{65001, 65002}},
+		{Type: 1, ASNs: []uint32{65003, 65004}},
+		{Type: 3, ASNs: []uint32{65005}},
+		{Type: 4, ASNs: []uint32{65006, 65007}},
+	}
+	if !reflect.DeepEqual(got.ASPathSegments, wantSegments) {
+		t.Fatalf("ASPathSegments = %+v, want %+v", got.ASPathSegments, wantSegments)
+	}
+
+	wantPath := []uint32{65001, 65002, 65003, 65004, 65005, 65006, 65007}
+	if !reflect.DeepEqual(got.ASPath, wantPath) {
+		t.Fatalf("ASPath = %v, want %v", got.ASPath, wantPath)
+	}
+	if got.ASPathCount != int32(len(wantPath)) {
+		t.Fatalf("ASPathCount = %d, want %d", got.ASPathCount, len(wantPath))
+	}
+
+	out, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("json.Marshal() unexpected error: %v", err)
+	}
+	if !strings.Contains(string(out), `"as_path_segments"`) {
+		t.Fatalf("JSON output %s does not include as_path_segments", out)
 	}
 }
 


### PR DESCRIPTION
Currently AS_PATH attributes carries a flattened AS_PATH slice.  For ASPA validation is important to know whether the source for AS Path was 
AS_SEQUENCE
AS_SET
AS_CONFED_SEQUENCE
This pr adds ASPathSegments slice whicoh each element carries type and corresponding slice of unit32. 