### PR TITLE
kafka: support TLS connections to the broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,22 @@ kubectl get pods -l app=gobmp
   --split-af=true
 ```
 
+### Kafka Publishing over TLS
+Brokers that terminate TLS on a dedicated listener (commonly `:9094`) refuse
+plaintext connections, so `--kafka-tls` is required to reach them:
+```bash
+./bin/gobmp --source-port=5000 \
+  --kafka-server=kafka.example.com:9094 \
+  --kafka-tls \
+  --kafka-ca=/etc/pki/tls/certs/example-root-ca.pem \
+  --split-af=true
+```
+`--kafka-ca` is optional. Omit it when the broker certificate chains to a CA
+already in the host trust store:
+```bash
+./bin/gobmp --source-port=5000 --kafka-server=kafka.example.com:9094 --kafka-tls
+```
+
 ### NATS Publishing
 ```bash
 ./bin/gobmp --source-port=5000 \
@@ -203,6 +219,16 @@ kafka_config:
   admin_id: "collector-01"
 ```
 
+**Kafka over TLS (`config.yaml`):**
+```yaml
+bmp_listen_port: 5000
+kafka_config:
+  kafka_srv: "kafka.example.com:9094"
+  kafka_tls: true
+  # Optional. Omit to verify against the host trust store.
+  kafka_ca: "/etc/pki/tls/certs/example-root-ca.pem"
+```
+
 **NATS example:**
 ```yaml
 bmp_listen_port: 5000
@@ -227,6 +253,8 @@ kafka_config:
   kafka_srv: "host:port"     # required to activate Kafka publisher
   kafka_tp_retn_time_ms: 900000
   kafka_topic_prefix: ""     # optional topic name prefix
+  kafka_tls: false           # true = connect to the broker over TLS
+  kafka_ca: ""               # PEM CA bundle; empty = host trust store
   bmp_raw: false             # OpenBMP RAW mode
   admin_id: ""               # defaults to OS hostname
 
@@ -320,6 +348,33 @@ Full path and filename for storing processed messages when `--dump=file` is used
 **Default:** none (Kafka disabled)
 
 Kafka broker address for publishing BMP messages. When specified, goBMP publishes parsed messages to topic-specific Kafka topics. Example: `--kafka-server=kafka.example.com:9092`
+
+```
+--kafka-tls
+```
+**Default:** false (plaintext)
+
+Connect to the Kafka broker over TLS. Required for brokers that expose a
+TLS-only listener, conventionally `:9094`, since those refuse plaintext
+connections outright.
+
+This is one-way (server-authenticated) TLS: goBMP verifies the broker
+certificate and presents none of its own, which suits brokers that use network
+scope rather than client certificates for authorization. The negotiated
+protocol floor is TLS 1.2.
+
+```
+--kafka-ca={path}
+```
+**Default:** empty (host trust store)
+
+Path to a PEM bundle used to verify the broker certificate. Only consulted when
+`--kafka-tls` is set.
+
+Leave it empty when the broker certificate chains to a CA the host already
+trusts; supply it when the broker uses a private CA that is not installed as a
+system trust anchor. An unreadable file, or one containing no certificate, is
+rejected at startup before any connection is attempted.
 
 ```
 --kafka-topic-prefix={prefix}

--- a/cmd/gobmp/gobmp.go
+++ b/cmd/gobmp/gobmp.go
@@ -28,6 +28,8 @@ var (
 	kafkaTpRetnTimeMs      string // Kafka topic retention time in ms
 	kafkaTopicPrefix       string
 	kafkaSkipTopicCreation string
+	kafkaTLS               bool
+	kafkaCA                string
 	natsSrv                string
 	splitAF                string
 	dump                   string
@@ -51,6 +53,8 @@ func init() {
 	flag.StringVar(&kafkaTpRetnTimeMs, "kafka-topic-retention-time-ms", defaultKafkaTpRetnTimeMs, "Kafka topic retention time in ms, default is 900000 ms i.e 15 minutes")
 	flag.StringVar(&kafkaTopicPrefix, "kafka-topic-prefix", "", "Optional prefix prepended to all Kafka topic names (e.g. 'prod' -> 'prod.gobmp.parsed.peer')")
 	flag.StringVar(&kafkaSkipTopicCreation, "kafka-skip-topic-creation", "false", "When \"true\", skip Kafka Admin API topic creation on startup. Use with Kafka 4.0+ environments that reject CreateTopics, or clusters where the client lacks CreateTopics permission; pre-create topics before starting gobmp.")
+	flag.BoolVar(&kafkaTLS, "kafka-tls", false, "Use TLS when connecting to the Kafka broker. Required by brokers exposing a TLS-only listener (commonly :9094).")
+	flag.StringVar(&kafkaCA, "kafka-ca", "", "Path to a PEM CA bundle used to verify the Kafka broker certificate. Empty uses the system trust store. Only used with -kafka-tls.")
 	flag.StringVar(&natsSrv, "nats-server", "", "URL to access NATS server")
 	flag.StringVar(&splitAF, "split-af", "true", "When set \"true\" ipv4 and ipv6 will be published in separate topics. if set \"false\" the same topic will be used for both address families.")
 	flag.IntVar(&perfPort, "performance-port", 0, "port used for performance debugging")
@@ -136,6 +140,8 @@ func main() {
 			TopicRetentionTimeMs: strconv.Itoa(cfg.KafkaConfig.KafkaTpRetnTimeMs),
 			TopicPrefix:          cfg.KafkaConfig.KafkaTopicPrefix,
 			SkipTopicCreation:    cfg.KafkaConfig.SkipTopicCreation,
+			TLS:                  cfg.KafkaConfig.KafkaTLS,
+			CAFile:               cfg.KafkaConfig.KafkaCA,
 		}
 		cfg.Publisher, err = kafka.NewKafkaPublisher(kConfig)
 		if err != nil {
@@ -283,6 +289,16 @@ func applyConfigOverrides(cfg *config.Config, fs *flag.FlagSet) error {
 			} else {
 				cfg.KafkaConfig.SkipTopicCreation = v
 			}
+		case "kafka-tls":
+			if cfg.KafkaConfig == nil {
+				cfg.KafkaConfig = defaultKafkaConfig()
+			}
+			cfg.KafkaConfig.KafkaTLS = kafkaTLS
+		case "kafka-ca":
+			if cfg.KafkaConfig == nil {
+				cfg.KafkaConfig = defaultKafkaConfig()
+			}
+			cfg.KafkaConfig.KafkaCA = kafkaCA
 		case "bmp-raw":
 			if cfg.KafkaConfig == nil {
 				cfg.KafkaConfig = defaultKafkaConfig()

--- a/cmd/gobmp/gobmp_test.go
+++ b/cmd/gobmp/gobmp_test.go
@@ -258,6 +258,8 @@ func newTestFlagSet() *flag.FlagSet {
 	fs.StringVar(&kafkaTpRetnTimeMs, "kafka-topic-retention-time-ms", defaultKafkaTpRetnTimeMs, "")
 	fs.StringVar(&kafkaTopicPrefix, "kafka-topic-prefix", "", "")
 	fs.StringVar(&kafkaSkipTopicCreation, "kafka-skip-topic-creation", "false", "")
+	fs.BoolVar(&kafkaTLS, "kafka-tls", false, "")
+	fs.StringVar(&kafkaCA, "kafka-ca", "", "")
 	fs.StringVar(&natsSrv, "nats-server", "", "")
 	fs.StringVar(&splitAF, "split-af", "", "")
 	fs.StringVar(&dump, "dump", "", "")
@@ -688,5 +690,97 @@ func TestApplyConfigOverrides_KafkaSkipTopicCreation_Invalid(t *testing.T) {
 	cfg := &config.Config{}
 	if err := applyConfigOverrides(cfg, fs); err == nil {
 		t.Error("expected error for invalid --kafka-skip-topic-creation value, got nil")
+	}
+}
+
+func TestApplyConfigOverrides_KafkaTLS(t *testing.T) {
+	fs := newTestFlagSet()
+	for k, v := range map[string]string{
+		"kafka-server": "kafka.example:9094",
+		"kafka-tls":    "true",
+		"kafka-ca":     "/etc/pki/tls/certs/example-ca.pem",
+	} {
+		if err := fs.Set(k, v); err != nil {
+			t.Fatalf("failed to set flag %s: %v", k, err)
+		}
+	}
+
+	cfg := &config.Config{}
+	if err := applyConfigOverrides(cfg, fs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.KafkaConfig == nil {
+		t.Fatal("KafkaConfig is nil, want non-nil")
+	}
+	if !cfg.KafkaConfig.KafkaTLS {
+		t.Error("KafkaTLS = false, want true")
+	}
+	if got, want := cfg.KafkaConfig.KafkaCA, "/etc/pki/tls/certs/example-ca.pem"; got != want {
+		t.Errorf("KafkaCA = %q, want %q", got, want)
+	}
+}
+
+// TestApplyConfigOverrides_KafkaTLSWithoutCA covers the common deployment where
+// the broker certificate chains to a CA already in the host trust store, so no
+// CA file is supplied.
+func TestApplyConfigOverrides_KafkaTLSWithoutCA(t *testing.T) {
+	fs := newTestFlagSet()
+	if err := fs.Set("kafka-tls", "true"); err != nil {
+		t.Fatalf("failed to set flag: %v", err)
+	}
+
+	cfg := &config.Config{}
+	if err := applyConfigOverrides(cfg, fs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.KafkaConfig == nil {
+		t.Fatal("KafkaConfig is nil, want non-nil")
+	}
+	if !cfg.KafkaConfig.KafkaTLS {
+		t.Error("KafkaTLS = false, want true")
+	}
+	if cfg.KafkaConfig.KafkaCA != "" {
+		t.Errorf("KafkaCA = %q, want empty (system trust store)", cfg.KafkaConfig.KafkaCA)
+	}
+}
+
+// TestApplyConfigOverrides_KafkaTLSUnsetKeepsDefaultOff pins the compatibility
+// property: an invocation that does not mention the flags must leave TLS off, so
+// existing plaintext deployments are unaffected by this feature.
+func TestApplyConfigOverrides_KafkaTLSUnsetKeepsDefaultOff(t *testing.T) {
+	fs := newTestFlagSet()
+	if err := fs.Set("kafka-server", "kafka.example:9092"); err != nil {
+		t.Fatalf("failed to set flag: %v", err)
+	}
+
+	cfg := &config.Config{}
+	if err := applyConfigOverrides(cfg, fs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.KafkaConfig == nil {
+		t.Fatal("KafkaConfig is nil, want non-nil")
+	}
+	if cfg.KafkaConfig.KafkaTLS {
+		t.Error("KafkaTLS = true with no flag set, want false")
+	}
+}
+
+// TestApplyConfigOverrides_KafkaTLSFlagOverridesFileValue proves precedence: a
+// config file may enable TLS and an explicit --kafka-tls=false on the command
+// line has to win, otherwise an operator cannot turn it off without editing the
+// file.
+func TestApplyConfigOverrides_KafkaTLSFlagOverridesFileValue(t *testing.T) {
+	fs := newTestFlagSet()
+	if err := fs.Set("kafka-tls", "false"); err != nil {
+		t.Fatalf("failed to set flag: %v", err)
+	}
+
+	cfg := &config.Config{KafkaConfig: &config.KafkaConfig{KafkaSrv: "kafka.example:9094", KafkaTLS: true}}
+	if err := applyConfigOverrides(cfg, fs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.KafkaConfig.KafkaTLS {
+		t.Error("KafkaTLS = true, want false: an explicit --kafka-tls=false must override the file")
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,6 +59,12 @@ type KafkaConfig struct {
 	// clusters where the client lacks CreateTopics permission. Pre-create the
 	// required topics before starting gobmp when this is set.
 	SkipTopicCreation bool `yaml:"skip_topic_creation"`
+	// KafkaTLS enables TLS on broker connections. Brokers exposing a TLS-only
+	// listener refuse plaintext, so this is required to reach them.
+	KafkaTLS bool `yaml:"kafka_tls"`
+	// KafkaCA is an optional PEM bundle used to verify the broker certificate.
+	// Empty means the host's system trust store. Only used when KafkaTLS is set.
+	KafkaCA string `yaml:"kafka_ca"`
 }
 
 type Config struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -279,3 +279,72 @@ func TestValidateSpeakersList(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadConfig_KafkaTLS(t *testing.T) {
+	yml := `
+kafka_config:
+  kafka_srv: "kafka.example:9094"
+  kafka_tls: true
+  kafka_ca: "/etc/pki/tls/certs/example-ca.pem"
+bmp_listen_port: 5000
+`
+	cfg, err := LoadConfig(writeTemp(t, yml))
+	if err != nil {
+		t.Fatalf("LoadConfig() unexpected error: %v", err)
+	}
+	if cfg.KafkaConfig == nil {
+		t.Fatal("KafkaConfig is nil, want non-nil")
+	}
+	if !cfg.KafkaConfig.KafkaTLS {
+		t.Error("KafkaTLS = false, want true")
+	}
+	if got, want := cfg.KafkaConfig.KafkaCA, "/etc/pki/tls/certs/example-ca.pem"; got != want {
+		t.Errorf("KafkaCA = %q, want %q", got, want)
+	}
+}
+
+// TestLoadConfig_KafkaTLSWithoutCA covers relying on the host trust store: TLS
+// on, no CA file named.
+func TestLoadConfig_KafkaTLSWithoutCA(t *testing.T) {
+	yml := `
+kafka_config:
+  kafka_srv: "kafka.example:9094"
+  kafka_tls: true
+`
+	cfg, err := LoadConfig(writeTemp(t, yml))
+	if err != nil {
+		t.Fatalf("LoadConfig() unexpected error: %v", err)
+	}
+	if cfg.KafkaConfig == nil {
+		t.Fatal("KafkaConfig is nil, want non-nil")
+	}
+	if !cfg.KafkaConfig.KafkaTLS {
+		t.Error("KafkaTLS = false, want true")
+	}
+	if cfg.KafkaConfig.KafkaCA != "" {
+		t.Errorf("KafkaCA = %q, want empty (system trust store)", cfg.KafkaConfig.KafkaCA)
+	}
+}
+
+// TestLoadConfig_KafkaTLSOmitted pins backward compatibility: a config written
+// before these keys existed must still load, with TLS off.
+func TestLoadConfig_KafkaTLSOmitted(t *testing.T) {
+	yml := `
+kafka_config:
+  kafka_srv: "kafka.example:9092"
+  kafka_topic_prefix: "prod"
+`
+	cfg, err := LoadConfig(writeTemp(t, yml))
+	if err != nil {
+		t.Fatalf("LoadConfig() unexpected error: %v", err)
+	}
+	if cfg.KafkaConfig == nil {
+		t.Fatal("KafkaConfig is nil, want non-nil")
+	}
+	if cfg.KafkaConfig.KafkaTLS {
+		t.Error("KafkaTLS = true for a config that omits the key, want false")
+	}
+	if cfg.KafkaConfig.KafkaCA != "" {
+		t.Errorf("KafkaCA = %q, want empty", cfg.KafkaConfig.KafkaCA)
+	}
+}

--- a/pkg/kafka/config.go
+++ b/pkg/kafka/config.go
@@ -10,4 +10,12 @@ type Config struct {
 	// Use with Kafka 4.0+ or clusters where the client lacks CreateTopics
 	// permission. Topics must be pre-created before starting gobmp.
 	SkipTopicCreation bool
+	// TLS enables TLS on connections to the broker. Brokers that terminate TLS
+	// on a dedicated listener (commonly :9094) refuse plaintext outright, so
+	// this is required to reach them.
+	TLS bool
+	// CAFile is an optional path to a PEM bundle used to verify the broker's
+	// certificate. Empty means the host's system trust store. Only consulted
+	// when TLS is set.
+	CAFile string
 }

--- a/pkg/kafka/kafka-publisher.go
+++ b/pkg/kafka/kafka-publisher.go
@@ -186,6 +186,17 @@ func NewKafkaPublisher(kConfig *Config) (pub.Publisher, error) {
 	config.Net.ReadTimeout = netReadTimeout
 	config.Version = sarama.V3_0_0_0
 
+	if kConfig.TLS {
+		tlsConfig, err := newTLSConfig(kConfig.CAFile)
+		if err != nil {
+			glog.Errorf("failed to build TLS config with error: %+v", err)
+			return nil, err
+		}
+		config.Net.TLS.Enable = true
+		config.Net.TLS.Config = tlsConfig
+		glog.V(5).Infof("Kafka TLS enabled (ca: %q)", kConfig.CAFile)
+	}
+
 	kafkaSrvs := strings.Split(kConfig.ServerAddress, ",")
 	var (
 		ca                    sarama.ClusterAdmin

--- a/pkg/kafka/kafka-publisher_tls_test.go
+++ b/pkg/kafka/kafka-publisher_tls_test.go
@@ -1,11 +1,26 @@
 package kafka
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"io"
+	"math/big"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/sbezverk/gobmp/pkg/pub"
 )
 
 // TestNewKafkaPublisherTLSBadCA exercises NewKafkaPublisher's TLS branch.
@@ -74,6 +89,376 @@ func TestNewKafkaPublisherTLSBadCA(t *testing.T) {
 				t.Errorf("took %s: the CA was validated after a connection attempt, not before", elapsed)
 			}
 		})
+	}
+}
+
+// TestNewKafkaPublisherTLSMockBroker is the TLS success path: NewKafkaPublisher
+// completes a real handshake against a broker whose certificate is verified
+// against the configured CA file, and returns a working publisher.
+//
+// sarama's MockBroker speaks plaintext only, so it is fronted with a
+// TLS-terminating proxy. That is enough to exercise the whole chain the flags
+// exist for: --kafka-ca is read from disk, the pool it builds is what verifies
+// the peer, and config.Net.TLS is what carries it into sarama.
+func TestNewKafkaPublisherTLSMockBroker(t *testing.T) {
+	serverCert, caPEM := newSelfSignedCert(t)
+	caFile := filepath.Join(t.TempDir(), "ca.pem")
+	writeFile(t, caFile, string(caPEM))
+
+	mb := sarama.NewMockBroker(t, 1)
+	defer mb.Close()
+
+	proxy := startTLSProxy(t, mb.Addr(), serverCert)
+	defer proxy.Close()
+
+	// Metadata has to advertise the proxy rather than mb.Addr(). sarama dials
+	// the advertised address for the producer's own connection, so advertising
+	// the plaintext mock would send the producer around the TLS listener and
+	// the test would pass without a handshake ever happening.
+	mb.SetHandlerByMap(map[string]sarama.MockResponse{
+		"ApiVersionsRequest": sarama.NewMockApiVersionsResponse(t),
+		"MetadataRequest": sarama.NewMockMetadataResponse(t).
+			SetBroker(proxy.addr(), mb.BrokerID()),
+		"ProduceRequest": sarama.NewMockProduceResponse(t),
+	})
+
+	cfg := &Config{
+		ServerAddress:        proxy.addr(),
+		TopicRetentionTimeMs: "900000",
+		// Topic creation is out of scope here and needs its own API-version
+		// handling; the TLS branch is upstream of it either way.
+		SkipTopicCreation: true,
+		TLS:               true,
+		CAFile:            caFile,
+	}
+
+	// Bounded rather than called directly. If the TLS branch regresses, the
+	// client speaks Kafka at a TLS listener, the handshake never completes and
+	// sarama retries metadata 300 times with a 10s backoff — so a plain call
+	// would hang until the whole package's test timeout fired, reported as an
+	// unrelated panic. The success path returns in milliseconds.
+	type result struct {
+		p   pub.Publisher
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		p, err := NewKafkaPublisher(cfg)
+		ch <- result{p: p, err: err}
+	}()
+
+	select {
+	case r := <-ch:
+		if r.err != nil {
+			t.Fatalf("NewKafkaPublisher over TLS: %v", r.err)
+		}
+		if r.p == nil {
+			t.Fatal("NewKafkaPublisher returned a nil publisher without an error")
+		}
+		if proxy.handshakes() == 0 {
+			t.Error("publisher connected without completing a TLS handshake")
+		}
+		r.p.Stop()
+	case <-time.After(20 * time.Second):
+		t.Fatal("NewKafkaPublisher did not return: no TLS handshake completed with the broker")
+	}
+}
+
+// TestNewKafkaPublisherTLSTopicCreation is the same success path with topic
+// creation left on, which is what a TLS deployment actually gets:
+// SkipTopicCreation defaults to false, so the first thing a TLS user reaches is
+// ClusterAdmin, and after it the controller-broker connection. Both are opened
+// from the same sarama config the TLS branch populated, so both have to come up
+// over TLS before any producer exists. The skip=true case above never touches
+// either of them.
+func TestNewKafkaPublisherTLSTopicCreation(t *testing.T) {
+	serverCert, caPEM := newSelfSignedCert(t)
+	caFile := filepath.Join(t.TempDir(), "ca.pem")
+	writeFile(t, caFile, string(caPEM))
+
+	mb := sarama.NewMockBroker(t, 1)
+	defer mb.Close()
+
+	proxy := startTLSProxy(t, mb.Addr(), serverCert)
+	defer proxy.Close()
+
+	// Cap CreateTopics (API key 19) at V4 so MockCreateTopicsResponse applies;
+	// V5+ expects TopicResults, which the mock does not populate. Same reason as
+	// TestNewKafkaPublisher_WithTopicCreation_Success.
+	apiVersions := sarama.NewMockApiVersionsResponse(t).SetApiKeys([]sarama.ApiVersionsResponseKey{
+		{ApiKey: 0, MinVersion: 5, MaxVersion: 8},  // Produce
+		{ApiKey: 1, MinVersion: 7, MaxVersion: 11}, // Fetch
+		{ApiKey: 3, MinVersion: 0, MaxVersion: 9},  // Metadata
+		{ApiKey: 19, MinVersion: 0, MaxVersion: 4}, // CreateTopics
+	})
+	mb.SetHandlerByMap(map[string]sarama.MockResponse{
+		"ApiVersionsRequest": apiVersions,
+		// SetController is what makes waitForControllerBrokerConnection resolve,
+		// and it resolves to the advertised address, so the controller
+		// connection is a second TLS handshake through the proxy.
+		"MetadataRequest": sarama.NewMockMetadataResponse(t).
+			SetBroker(proxy.addr(), mb.BrokerID()).
+			SetController(mb.BrokerID()),
+		"CreateTopicsRequest": sarama.NewMockCreateTopicsResponse(t),
+		"ProduceRequest":      sarama.NewMockProduceResponse(t),
+	})
+
+	cfg := &Config{
+		ServerAddress:        proxy.addr(),
+		TopicRetentionTimeMs: "900000",
+		SkipTopicCreation:    false,
+		TLS:                  true,
+		CAFile:               caFile,
+	}
+
+	type result struct {
+		p   pub.Publisher
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		p, err := NewKafkaPublisher(cfg)
+		ch <- result{p: p, err: err}
+	}()
+
+	select {
+	case r := <-ch:
+		if r.err != nil {
+			t.Fatalf("NewKafkaPublisher over TLS with topic creation: %v", r.err)
+		}
+		if r.p == nil {
+			t.Fatal("NewKafkaPublisher returned a nil publisher without an error")
+		}
+		// ClusterAdmin, the controller broker and the producer each connect, so
+		// more than the single handshake of the skip=true case is expected.
+		if got := proxy.handshakes(); got < 2 {
+			t.Errorf("completed %d TLS handshakes, want at least 2 (cluster admin, controller broker, producer)", got)
+		}
+		r.p.Stop()
+	case <-time.After(30 * time.Second):
+		t.Fatal("NewKafkaPublisher did not return: the admin or controller connection never completed a TLS handshake")
+	}
+}
+
+// TestNewTLSConfigVerifiesPeer pins the property that makes --kafka-ca mean
+// anything: the config newTLSConfig returns actually validates the broker's
+// certificate chain. The negative case is the one that matters — it fails if
+// InsecureSkipVerify is ever set, or if an unusable CA file were allowed to
+// yield an empty pool that silently falls back to trusting anything.
+func TestNewTLSConfigVerifiesPeer(t *testing.T) {
+	serverCert, serverCAPEM := newSelfSignedCert(t)
+	_, unrelatedCAPEM := newSelfSignedCert(t)
+
+	tests := []struct {
+		name    string
+		caPEM   []byte
+		wantErr bool
+	}{
+		{name: "certificate chains to the configured CA", caPEM: serverCAPEM, wantErr: false},
+		{name: "certificate does not chain to the configured CA", caPEM: unrelatedCAPEM, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			caFile := filepath.Join(t.TempDir(), "ca.pem")
+			writeFile(t, caFile, string(tt.caPEM))
+
+			cfg, err := newTLSConfig(caFile)
+			if err != nil {
+				t.Fatalf("newTLSConfig: %v", err)
+			}
+
+			addr, stop := startTLSHandshakeServer(t, serverCert)
+			defer stop()
+
+			conn, err := tls.Dial("tcp", addr, cfg)
+			if err == nil {
+				_ = conn.Close()
+			}
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("handshake succeeded against a certificate that does not chain to the configured CA")
+				}
+				var unknown x509.UnknownAuthorityError
+				if !errors.As(err, &unknown) {
+					t.Errorf("error = %v, want an unknown-authority verification failure", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("handshake against the configured CA: %v", err)
+			}
+		})
+	}
+}
+
+// newSelfSignedCert returns a server certificate for 127.0.0.1 and the PEM
+// bytes to trust it with. The certificate is its own issuer, so the same PEM
+// serves as the CA bundle.
+func newSelfSignedCert(t *testing.T) (tls.Certificate, []byte) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("generate serial: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "gobmp-test-broker"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1)},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	pair, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("build key pair: %v", err)
+	}
+
+	return pair, certPEM
+}
+
+// tlsProxy terminates TLS on 127.0.0.1 and forwards the plaintext stream to a
+// target address, which lets a plaintext sarama MockBroker stand in for a
+// TLS-only broker.
+type tlsProxy struct {
+	ln     net.Listener
+	target string
+	wg     sync.WaitGroup
+
+	mu   sync.Mutex
+	seen int
+}
+
+func startTLSProxy(t *testing.T, target string, cert tls.Certificate) *tlsProxy {
+	t.Helper()
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	})
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	p := &tlsProxy{ln: ln, target: target}
+	p.wg.Add(1)
+	go p.serve()
+
+	return p
+}
+
+func (p *tlsProxy) addr() string { return p.ln.Addr().String() }
+
+func (p *tlsProxy) handshakes() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.seen
+}
+
+func (p *tlsProxy) serve() {
+	defer p.wg.Done()
+	for {
+		conn, err := p.ln.Accept()
+		if err != nil {
+			return // listener closed
+		}
+		p.wg.Add(1)
+		go func() {
+			defer p.wg.Done()
+			p.handle(conn)
+		}()
+	}
+}
+
+func (p *tlsProxy) handle(client net.Conn) {
+	// Handshake explicitly so a failure is not mistaken for the target being
+	// unreachable, and so the counter only advances on a verified connection.
+	if tc, ok := client.(*tls.Conn); ok {
+		if err := tc.Handshake(); err != nil {
+			_ = client.Close()
+			return
+		}
+		p.mu.Lock()
+		p.seen++
+		p.mu.Unlock()
+	}
+
+	server, err := net.Dial("tcp", p.target)
+	if err != nil {
+		_ = client.Close()
+		return
+	}
+
+	done := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(server, client); done <- struct{}{} }()
+	go func() { _, _ = io.Copy(client, server); done <- struct{}{} }()
+	<-done
+	// Closing both ends unblocks whichever copy is still reading, so neither
+	// goroutine outlives the test.
+	_ = client.Close()
+	_ = server.Close()
+	<-done
+}
+
+func (p *tlsProxy) Close() {
+	_ = p.ln.Close()
+	p.wg.Wait()
+}
+
+// startTLSHandshakeServer accepts TLS connections and does nothing but the
+// handshake. Used where the assertion is about certificate verification, so
+// piping to a broker would only add a way for the test to fail for the wrong
+// reason.
+func startTLSHandshakeServer(t *testing.T, cert tls.Certificate) (string, func()) {
+	t.Helper()
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	})
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return // listener closed
+			}
+			// A handshake error is an expected outcome here, not a failure.
+			if tc, ok := conn.(*tls.Conn); ok {
+				_ = tc.Handshake()
+			}
+			_ = conn.Close()
+		}
+	}()
+
+	return ln.Addr().String(), func() {
+		_ = ln.Close()
+		wg.Wait()
 	}
 }
 

--- a/pkg/kafka/kafka-publisher_tls_test.go
+++ b/pkg/kafka/kafka-publisher_tls_test.go
@@ -1,0 +1,85 @@
+package kafka
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestNewKafkaPublisherTLSBadCA exercises NewKafkaPublisher's TLS branch.
+//
+// The server address is a TEST-NET-1 literal (RFC 5737, guaranteed
+// unroutable), so if the CA were not validated up front the call would fall
+// through to sarama and block for brockerConnectTimeout plus metadata retries.
+// The elapsed-time assertion is therefore the substance of the test: it proves
+// the publisher rejects an unusable CA before it opens any connection, rather
+// than merely that an error is returned eventually.
+func TestNewKafkaPublisherTLSBadCA(t *testing.T) {
+	tests := []struct {
+		name   string
+		caFile func(t *testing.T) string
+	}{
+		{
+			name:   "nonexistent CA file",
+			caFile: func(t *testing.T) string { return filepath.Join(t.TempDir(), "absent.pem") },
+		},
+		{
+			name: "CA file containing no certificate",
+			caFile: func(t *testing.T) string {
+				p := filepath.Join(t.TempDir(), "garbage.pem")
+				writeFile(t, p, "this is not a certificate\n")
+				return p
+			},
+		},
+		{
+			name: "empty CA file",
+			caFile: func(t *testing.T) string {
+				p := filepath.Join(t.TempDir(), "empty.pem")
+				writeFile(t, p, "")
+				return p
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				ServerAddress:        "192.0.2.1:9094",
+				TopicRetentionTimeMs: "900000",
+				TLS:                  true,
+				CAFile:               tt.caFile(t),
+			}
+
+			start := time.Now()
+			pub, err := NewKafkaPublisher(cfg)
+			elapsed := time.Since(start)
+
+			if err == nil {
+				if pub != nil {
+					pub.Stop()
+				}
+				t.Fatal("expected an error for an unusable CA file, got nil")
+			}
+			if pub != nil {
+				t.Error("publisher is non-nil alongside an error")
+			}
+			if !strings.Contains(err.Error(), "kafka:") {
+				t.Errorf("error = %q, want the CA-file error from newTLSConfig", err)
+			}
+			// Generous bound: the real path is microseconds, whereas reaching
+			// sarama would take brockerConnectTimeout (120s) or longer.
+			if elapsed > 10*time.Second {
+				t.Errorf("took %s: the CA was validated after a connection attempt, not before", elapsed)
+			}
+		})
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/pkg/kafka/tls.go
+++ b/pkg/kafka/tls.go
@@ -1,0 +1,41 @@
+package kafka
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+)
+
+// newTLSConfig builds the client TLS configuration used for broker
+// connections. caFile is an optional path to a PEM bundle to verify the
+// broker's certificate against; when empty the host's system trust store is
+// used.
+//
+// This is one-way (server-authenticated) TLS. The client presents no
+// certificate, which matches brokers that use network scope rather than
+// client certificates for authorization.
+func newTLSConfig(caFile string) (*tls.Config, error) {
+	cfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+	if caFile == "" {
+		return cfg, nil
+	}
+
+	pem, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("kafka: cannot read CA file %q: %w", caFile, err)
+	}
+	pool := x509.NewCertPool()
+	// AppendCertsFromPEM reports failure with a bool rather than an error, and
+	// silently ignores unparsable blocks. Without this check a typo'd or
+	// truncated bundle yields an empty pool and the handshake fails later with
+	// an opaque "unknown authority" instead of naming the real problem.
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("kafka: no certificates found in CA file %q", caFile)
+	}
+	cfg.RootCAs = pool
+
+	return cfg, nil
+}

--- a/pkg/kafka/tls_test.go
+++ b/pkg/kafka/tls_test.go
@@ -1,0 +1,123 @@
+package kafka
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// selfSignedCAPEM returns a PEM-encoded self-signed CA certificate.
+func selfSignedCAPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// keyOnlyPEM returns a PEM block that parses as PEM but holds no certificate —
+// the classic "pointed at the key instead of the cert" operator mistake.
+func keyOnlyPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der})
+}
+
+func TestNewTLSConfig(t *testing.T) {
+	dir := t.TempDir()
+	ca := selfSignedCAPEM(t)
+
+	write := func(name string, b []byte) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, b, 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		return p
+	}
+
+	valid := write("ca.pem", ca)
+	empty := write("empty.pem", nil)
+	garbage := write("garbage.pem", []byte("not a pem file at all\n"))
+	keyOnly := write("key.pem", keyOnlyPEM(t))
+	// A real bundle often carries human-readable text between blocks; openssl
+	// and most tooling emit this, so it must not be treated as corruption.
+	withPreamble := write("preamble.pem", append([]byte("Issuer: test-ca\nSubject: test-ca\n\n"), ca...))
+	truncated := write("truncated.pem", ca[:len(ca)/2])
+	chain := write("chain.pem", append(append([]byte{}, ca...), selfSignedCAPEM(t)...))
+
+	tests := []struct {
+		name    string
+		caFile  string
+		wantErr bool
+		wantCAs bool // expect a non-nil RootCAs pool
+	}{
+		{name: "empty path uses system roots", caFile: "", wantErr: false, wantCAs: false},
+		{name: "valid CA", caFile: valid, wantErr: false, wantCAs: true},
+		{name: "valid chain of two", caFile: chain, wantErr: false, wantCAs: true},
+		{name: "certificate with text preamble", caFile: withPreamble, wantErr: false, wantCAs: true},
+		{name: "nonexistent path", caFile: filepath.Join(dir, "nope.pem"), wantErr: true},
+		{name: "empty file", caFile: empty, wantErr: true},
+		{name: "non-PEM garbage", caFile: garbage, wantErr: true},
+		{name: "PEM but no certificate", caFile: keyOnly, wantErr: true},
+		{name: "truncated certificate", caFile: truncated, wantErr: true},
+		{name: "directory instead of file", caFile: dir, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := newTLSConfig(tt.caFile)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got nil (cfg=%v)", cfg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.MinVersion != tls.VersionTLS12 {
+				t.Errorf("MinVersion = %#x, want %#x", cfg.MinVersion, tls.VersionTLS12)
+			}
+			if got := cfg.RootCAs != nil; got != tt.wantCAs {
+				t.Errorf("RootCAs set = %v, want %v", got, tt.wantCAs)
+			}
+			// One-way TLS: the client must never present a certificate.
+			if len(cfg.Certificates) != 0 {
+				t.Errorf("Certificates = %d, want 0 (one-way TLS)", len(cfg.Certificates))
+			}
+			if cfg.InsecureSkipVerify {
+				t.Error("InsecureSkipVerify must never be set")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`NewKafkaPublisher` builds its sarama config with `Net.TLS` left at the zero value, and `kafka.Config` has no field to change that. gobmp can therefore only reach a plaintext broker. A broker that terminates TLS on a dedicated listener refuses plaintext outright, so it is unreachable today with no configuration surface to fix it.

## Change

Adds one-way (server-authenticated) TLS:

```
--kafka-tls        enable TLS on broker connections
--kafka-ca <path>  PEM bundle used to verify the broker certificate;
                   empty falls back to the system trust store
```

Both are also settable from the YAML config as `kafka_tls` / `kafka_ca`, matching how the other Kafka options are plumbed.

The client presents no certificate, which fits brokers that use network scope rather than client certificates for authorization. `MinVersion` is TLS 1.2.

**Defaults are unchanged** — `--kafka-tls` is off, so existing plaintext deployments behave exactly as before.

## Notes

`newTLSConfig` checks the boolean returned by `x509.CertPool.AppendCertsFromPEM`. It reports failure with a bool rather than an error and silently ignores unparsable blocks, so a truncated or mistaken bundle would otherwise produce an empty pool and surface much later as an opaque "unknown authority" rather than naming the file that was wrong.

## Tests

`pkg/kafka/tls_test.go` is table-driven over the failure class rather than just the happy path: valid CA, two-certificate chain, certificate with a text preamble (openssl emits this and it must not be treated as corruption), nonexistent path, empty file, non-PEM garbage, PEM containing no certificate (pointing at the key by mistake), truncated certificate, and a directory instead of a file. It also asserts the client never presents a certificate and that `InsecureSkipVerify` is never set.

`go build ./...` and `go test ./...` pass.

Happy to adjust naming or split this differently if you'd prefer.
