### PR TITLE
message: take speaker identity from the connection when Peer Up has none

### DIFF
--- a/pkg/message/peer.go
+++ b/pkg/message/peer.go
@@ -62,7 +62,7 @@ func (p *producer) producePeerMessage(op int, msg bmp.Message) {
 		// first PeerUp the fields are immutable — no data race with readers
 		// that wait on speakerReady.
 		p.speakerReadyOnce.Do(func() {
-			p.speakerIP = m.LocalIP
+			p.speakerIP = speakerAddress(m.LocalIP, msg.SpeakerIP)
 			md5Sum := md5.Sum([]byte(p.speakerIP))
 			p.speakerHash = hex.EncodeToString(md5Sum[:])
 			close(p.speakerReady)
@@ -144,4 +144,34 @@ func (p *producer) producePeerMessage(op int, msg bmp.Message) {
 		glog.Errorf("failed to process peer message with error: %+v", err)
 		return
 	}
+}
+
+// speakerAddress picks the address that identifies the BMP speaker for this
+// connection.  The Peer Up Local Address is preferred, so the identity of an
+// established session is unchanged, but it is not always an address: RFC 9069
+// Section 4.2 has a Loc-RIB Instance Peer zero-fill it, and a speaker whose
+// first Peer Up describes the Loc-RIB therefore latches on 0.0.0.0 (or :: for
+// an IPv6 peer).  Every such speaker then hashes to md5("0.0.0.0") and two of
+// them become indistinguishable to a collector that keys on router_hash.
+//
+// connIP is the remote address of the TCP connection the message arrived on,
+// which the server already resolves per client.  It identifies the speaker
+// whenever the Peer Up does not, and it cannot collide between two connections.
+func speakerAddress(localIP, connIP string) string {
+	if isSpecificAddress(localIP) {
+		return localIP
+	}
+	if isSpecificAddress(connIP) {
+		return connIP
+	}
+	// Neither identifies anything.  Keep the Peer Up value rather than invent
+	// one, leaving the message exactly as it was before this fallback existed.
+	return localIP
+}
+
+// isSpecificAddress reports whether s is an IP address that names one host,
+// as opposed to being absent or the unspecified address 0.0.0.0 / ::.
+func isSpecificAddress(s string) bool {
+	ip := net.ParseIP(s)
+	return ip != nil && !ip.IsUnspecified()
 }

--- a/pkg/message/peer.go
+++ b/pkg/message/peer.go
@@ -149,7 +149,7 @@ func (p *producer) producePeerMessage(op int, msg bmp.Message) {
 // speakerAddress picks the address that identifies the BMP speaker for this
 // connection.  The Peer Up Local Address is preferred, so the identity of an
 // established session is unchanged, but it is not always an address: RFC 9069
-// Section 4.2 has a Loc-RIB Instance Peer zero-fill it, and a speaker whose
+// Section 5.2 has a Loc-RIB Instance Peer zero-fill it, and a speaker whose
 // first Peer Up describes the Loc-RIB therefore latches on 0.0.0.0 (or :: for
 // an IPv6 peer).  Every such speaker then hashes to md5("0.0.0.0") and two of
 // them become indistinguishable to a collector that keys on router_hash.

--- a/pkg/message/speaker_identity_test.go
+++ b/pkg/message/speaker_identity_test.go
@@ -105,7 +105,7 @@ func TestSpeakerAddress(t *testing.T) {
 }
 
 // TestSpeakerIdentity_LocRIBPeerUpUsesConnectionAddress verifies that a PeerUp
-// describing a Loc-RIB Instance Peer, which RFC 9069 Section 4.2 zero-fills,
+// describing a Loc-RIB Instance Peer, which RFC 9069 Section 5.2 zero-fills,
 // does not latch the speaker onto the unspecified address.
 func TestSpeakerIdentity_LocRIBPeerUpUsesConnectionAddress(t *testing.T) {
 	p := NewProducer(&recordingPublisher{}, false).(*producer)

--- a/pkg/message/speaker_identity_test.go
+++ b/pkg/message/speaker_identity_test.go
@@ -1,0 +1,179 @@
+package message
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/sbezverk/gobmp/pkg/bmp"
+)
+
+func md5Hex(s string) string {
+	sum := md5.Sum([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+// assertSpeakerReady fails unless the producer released the route monitor and
+// stats goroutines waiting on the first PeerUp.  Choosing a different address
+// for the speaker must never turn into a decision not to latch at all: those
+// goroutines block on this channel and would never produce a message again.
+func assertSpeakerReady(t *testing.T, p *producer) {
+	t.Helper()
+	select {
+	case <-p.speakerReady:
+	default:
+		t.Fatal("speakerReady is still open after PeerUp, route monitor messages would block forever")
+	}
+}
+
+// publishPeerUp feeds one PeerUp through the producer and returns the
+// PeerStateChange a consumer receives.
+func publishPeerUp(t *testing.T, p *producer, peerType bmp.PeerType, localIP, connIP string) PeerStateChange {
+	t.Helper()
+	rec := p.publisher.(*recordingPublisher)
+
+	p.producePeerMessage(peerUP, bmp.Message{
+		PeerHeader: makePeerHeader(t, peerType, 0x00),
+		Payload:    buildPeerUpMessage(t, localIP),
+		SpeakerIP:  connIP,
+	})
+
+	if len(rec.msgs) != 1 {
+		t.Fatalf("published %d messages, want 1", len(rec.msgs))
+	}
+	var got PeerStateChange
+	if err := json.Unmarshal(rec.msgs[0].payload, &got); err != nil {
+		t.Fatalf("unmarshal published message failed: %v", err)
+	}
+	return got
+}
+
+// TestSpeakerAddress covers the address selection itself.
+func TestSpeakerAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		localIP string
+		connIP  string
+		want    string
+	}{
+		{
+			name:    "Peer Up local address wins",
+			localIP: "192.168.1.1",
+			connIP:  "10.20.0.1",
+			want:    "192.168.1.1",
+		},
+		{
+			name:    "zero-filled IPv4 local address falls back to the connection",
+			localIP: "0.0.0.0",
+			connIP:  "10.20.0.1",
+			want:    "10.20.0.1",
+		},
+		{
+			name:    "zero-filled IPv6 local address falls back to the connection",
+			localIP: "::",
+			connIP:  "2001:db8:20::1",
+			want:    "2001:db8:20::1",
+		},
+		{
+			name:    "absent local address falls back to the connection",
+			localIP: "",
+			connIP:  "10.20.0.1",
+			want:    "10.20.0.1",
+		},
+		{
+			name:    "local address is kept when the connection address is absent",
+			localIP: "192.168.1.1",
+			connIP:  "",
+			want:    "192.168.1.1",
+		},
+		{
+			name:    "neither identifies a host, the Peer Up value is kept",
+			localIP: "0.0.0.0",
+			connIP:  "",
+			want:    "0.0.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := speakerAddress(tt.localIP, tt.connIP); got != tt.want {
+				t.Errorf("speakerAddress(%q, %q) = %q, want %q", tt.localIP, tt.connIP, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSpeakerIdentity_LocRIBPeerUpUsesConnectionAddress verifies that a PeerUp
+// describing a Loc-RIB Instance Peer, which RFC 9069 Section 4.2 zero-fills,
+// does not latch the speaker onto the unspecified address.
+func TestSpeakerIdentity_LocRIBPeerUpUsesConnectionAddress(t *testing.T) {
+	p := NewProducer(&recordingPublisher{}, false).(*producer)
+
+	got := publishPeerUp(t, p, bmp.PeerType3, "0.0.0.0", "10.20.0.1")
+
+	if got.RouterIP != "10.20.0.1" {
+		t.Errorf("RouterIP = %q, want %q", got.RouterIP, "10.20.0.1")
+	}
+	if want := md5Hex("10.20.0.1"); got.RouterHash != want {
+		t.Errorf("RouterHash = %q, want %q", got.RouterHash, want)
+	}
+	assertSpeakerReady(t, p)
+}
+
+// TestSpeakerIdentity_TwoLocRIBSpeakersStayDistinct is the regression this fix
+// exists for.  The server builds one producer per connection, so two speakers
+// whose first PeerUp is a Loc-RIB one used to latch on the same zero-filled
+// address and hash identically.  A collector keyed on router_hash then merged
+// their tables: observations of the same peer collapsed onto one entry, and a
+// PeerDown from one speaker flushed routes the other was still reporting.
+func TestSpeakerIdentity_TwoLocRIBSpeakersStayDistinct(t *testing.T) {
+	speakers := []string{"10.20.0.1", "10.20.0.2"}
+	hashes := make([]string, 0, len(speakers))
+
+	for _, connIP := range speakers {
+		p := NewProducer(&recordingPublisher{}, false).(*producer)
+
+		got := publishPeerUp(t, p, bmp.PeerType3, "0.0.0.0", connIP)
+
+		if want := md5Hex(connIP); got.RouterHash != want {
+			t.Errorf("speaker %s: RouterHash = %q, want %q", connIP, got.RouterHash, want)
+		}
+		hashes = append(hashes, got.RouterHash)
+	}
+
+	if hashes[0] == hashes[1] {
+		t.Fatalf("both speakers hashed to %q, they are indistinguishable to a collector", hashes[0])
+	}
+}
+
+// TestSpeakerIdentity_EstablishedSessionUnchanged pins the behaviour every
+// existing consumer already sees: when the PeerUp carries a local address, it
+// remains the speaker identity and the connection address is not consulted.
+func TestSpeakerIdentity_EstablishedSessionUnchanged(t *testing.T) {
+	p := NewProducer(&recordingPublisher{}, false).(*producer)
+
+	got := publishPeerUp(t, p, bmp.PeerType0, "192.168.1.1", "10.20.0.1")
+
+	if got.RouterIP != "192.168.1.1" {
+		t.Errorf("RouterIP = %q, want %q", got.RouterIP, "192.168.1.1")
+	}
+	if want := md5Hex("192.168.1.1"); got.RouterHash != want {
+		t.Errorf("RouterHash = %q, want %q", got.RouterHash, want)
+	}
+	assertSpeakerReady(t, p)
+}
+
+// TestSpeakerIdentity_NoConnectionAddress covers the case where nothing
+// identifies the speaker: the message keeps the address the PeerUp reported,
+// and the producer still latches so route production is not blocked.
+func TestSpeakerIdentity_NoConnectionAddress(t *testing.T) {
+	p := NewProducer(&recordingPublisher{}, false).(*producer)
+
+	got := publishPeerUp(t, p, bmp.PeerType3, "0.0.0.0", "")
+
+	if got.RouterIP != "0.0.0.0" {
+		t.Errorf("RouterIP = %q, want %q", got.RouterIP, "0.0.0.0")
+	}
+	assertSpeakerReady(t, p)
+}


### PR DESCRIPTION
The producer latches the BMP speaker's identity on the first Peer Up it sees,
taking it from that message's Local Address. RFC 9069 Section 5.2 zero-fills
that field for a Loc-RIB Instance Peer, so a speaker whose first Peer Up
describes the Loc-RIB latches on `0.0.0.0`, and every message it produces then
carries `router_ip "0.0.0.0"` and `router_hash md5("0.0.0.0")`.

Two such speakers are indistinguishable. A collector keyed on `router_hash`
merges their tables: observations of the same peer collapse onto a single
entry, and a Peer Down from one speaker flushes routes the other is still
reporting. Measured against a lab with two route reflectors, a 20-route
baseline arrived as 12 routes and produced 8 spurious change events; with this
fix the same run reports 20 routes across 2 distinct sources and no spurious
events.

Fall back to the remote address of the TCP connection, which the server
already resolves per client and passes down as `bmp.Message.SpeakerIP` for RAW
messages. A Peer Up that does carry a local address still wins, so output is
unchanged for every session that was already identified correctly.

The latch itself always completes. Route monitor and stats goroutines block on
`speakerReady` before producing anything, so declining to latch on an
uninformative Peer Up would stall them for the life of the connection; when
neither the Peer Up nor the connection names a host, the Peer Up value is kept
rather than an identity invented.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/message/...` — new `speaker_identity_test.go` covers: local
      address wins, IPv4/IPv6 zero-fill falls back to the connection address,
      two Loc-RIB-only speakers stay distinct, established sessions are
      unchanged, and the case where neither address is available still lets
      the producer latch (no goroutine block).