### PR TITLE
Change peer tracking speakerIP assignment from m.LocalIP to msg.SpeakerIP

### DIFF
--- a/pkg/message/peer.go
+++ b/pkg/message/peer.go
@@ -62,7 +62,7 @@ func (p *producer) producePeerMessage(op int, msg bmp.Message) {
 		// first PeerUp the fields are immutable — no data race with readers
 		// that wait on speakerReady.
 		p.speakerReadyOnce.Do(func() {
-			p.speakerIP = m.LocalIP
+			p.speakerIP = msg.SpeakerIP
 			md5Sum := md5.Sum([]byte(p.speakerIP))
 			p.speakerHash = hex.EncodeToString(md5Sum[:])
 			close(p.speakerReady)


### PR DESCRIPTION
After running gobmp against a production router with ~400 or so peers, I noticed that `router_ip` and `router_hash` were being populated with a random IP address/hash, which appeared to be just the first up peer it processed.

This PR updates `pkg/message/peer.go` to change `p.speakerIP` from `m.LocalIP` to `msg.SpeakerIP`, given that  `p.speakerIP` should be populated from the BMP speaker's IP rather than the first connected peer's `LocalIP`. This fixes `router_ip` from being populated incorrectly.