### PR TITLE
draft-ietf-idr-nhc

### DIFF
--- a/pkg/bgp/bgp-base-attributes.go
+++ b/pkg/bgp/bgp-base-attributes.go
@@ -71,6 +71,11 @@ type BaseAttributes struct {
 	LgCommunityList []string      `json:"large_community_list,omitempty"`
 	BGPPrefixSID    *BGPPrefixSID `json:"bgp_prefix_sid,omitempty"`
 	OTC             uint32        `json:"otc,omitempty"` // RFC 9234 Only to Customer (OTC) Attribute (Type 35)
+	NHCAttr         []byte        `json:"nhc_attr,omitempty"`
+	NHC             *NHC          `json:"nhc,omitempty"`
+	NHCMalformed    bool          `json:"nhc_malformed,omitempty"`
+	NHCDiscarded    bool          `json:"nhc_discarded,omitempty"`
+	NHCUnverified   bool          `json:"nhc_unverified,omitempty"`
 	// SecPath
 	AttrSet *AttrSet `json:"attr_set,omitempty"` // RFC 6368 ATTR_SET Attribute (Type 128)
 	// UnknownAttributes preserves any path attribute whose Type code is not
@@ -214,6 +219,10 @@ func (ba *BaseAttributes) Equal(oba *BaseAttributes) (bool, []string) {
 	if ba.OTC != oba.OTC {
 		equal = false
 		diffs = append(diffs, "otc mismatch: "+strconv.FormatUint(uint64(ba.OTC), 10)+" and "+strconv.FormatUint(uint64(oba.OTC), 10))
+	}
+	if !bytes.Equal(ba.NHCAttr, oba.NHCAttr) || !reflect.DeepEqual(ba.NHC, oba.NHC) || ba.NHCMalformed != oba.NHCMalformed || ba.NHCDiscarded != oba.NHCDiscarded || ba.NHCUnverified != oba.NHCUnverified {
+		equal = false
+		diffs = append(diffs, "nhc mismatch")
 	}
 	if asEqual, asDiffs := ba.AttrSet.Equal(oba.AttrSet); !asEqual {
 		equal = false
@@ -416,7 +425,14 @@ func unmarshalBaseAttrsFromSlice(attrs []PathAttribute, as4hint *bool) (*BaseAtt
 		case 38:
 			// BFD Discriminator - RFC 9026
 		case 39:
-			// BGP Next Hop Dependent Characteristic (NHC, TEMPORARY) - draft-ietf-idr-nhc
+			baseAttr.NHCAttr = append([]byte(nil), b...)
+			nhc, err := UnmarshalNHC(b)
+			if err != nil {
+				baseAttr.NHCMalformed = true
+				glog.Errorf("malformed NHC attribute (path attribute type 39); attribute discarded per draft-ietf-idr-nhc-07: %v", err)
+			} else {
+				baseAttr.NHC = nhc
+			}
 		case 40:
 			// RFC 8669: BGP Prefix-SID
 			var err error

--- a/pkg/bgp/bgp-base-attributes.go
+++ b/pkg/bgp/bgp-base-attributes.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -71,11 +72,18 @@ type BaseAttributes struct {
 	LgCommunityList []string      `json:"large_community_list,omitempty"`
 	BGPPrefixSID    *BGPPrefixSID `json:"bgp_prefix_sid,omitempty"`
 	OTC             uint32        `json:"otc,omitempty"` // RFC 9234 Only to Customer (OTC) Attribute (Type 35)
-	NHCAttr         []byte        `json:"nhc_attr,omitempty"`
-	NHC             *NHC          `json:"nhc,omitempty"`
-	NHCMalformed    bool          `json:"nhc_malformed,omitempty"`
-	NHCDiscarded    bool          `json:"nhc_discarded,omitempty"`
-	NHCUnverified   bool          `json:"nhc_unverified,omitempty"`
+	// NHCAttr retains the raw NHC attribute value for forensic use.
+	NHCAttr []byte `json:"nhc_attr,omitempty"`
+	// NHC contains the decoded NHC when its characteristics are usable.
+	NHC *NHC `json:"nhc,omitempty"`
+	// NHCMalformed reports a structurally invalid NHC attribute.
+	NHCMalformed bool `json:"nhc_malformed,omitempty"`
+	// NHCEmpty reports an NHC rejected because no usable characteristics remain.
+	NHCEmpty bool `json:"nhc_empty,omitempty"`
+	// NHCDiscarded reports an NHC rejected because its next hop did not match.
+	NHCDiscarded bool `json:"nhc_discarded,omitempty"`
+	// NHCUnverified reports an NHC retained without authoritative sender identity.
+	NHCUnverified bool `json:"nhc_unverified,omitempty"`
 	// SecPath
 	AttrSet *AttrSet `json:"attr_set,omitempty"` // RFC 6368 ATTR_SET Attribute (Type 128)
 	// UnknownAttributes preserves any path attribute whose Type code is not
@@ -220,7 +228,7 @@ func (ba *BaseAttributes) Equal(oba *BaseAttributes) (bool, []string) {
 		equal = false
 		diffs = append(diffs, "otc mismatch: "+strconv.FormatUint(uint64(ba.OTC), 10)+" and "+strconv.FormatUint(uint64(oba.OTC), 10))
 	}
-	if !bytes.Equal(ba.NHCAttr, oba.NHCAttr) || !reflect.DeepEqual(ba.NHC, oba.NHC) || ba.NHCMalformed != oba.NHCMalformed || ba.NHCDiscarded != oba.NHCDiscarded || ba.NHCUnverified != oba.NHCUnverified {
+	if !bytes.Equal(ba.NHCAttr, oba.NHCAttr) || !reflect.DeepEqual(ba.NHC, oba.NHC) || ba.NHCMalformed != oba.NHCMalformed || ba.NHCEmpty != oba.NHCEmpty || ba.NHCDiscarded != oba.NHCDiscarded || ba.NHCUnverified != oba.NHCUnverified {
 		equal = false
 		diffs = append(diffs, "nhc mismatch")
 	}
@@ -427,7 +435,10 @@ func unmarshalBaseAttrsFromSlice(attrs []PathAttribute, as4hint *bool) (*BaseAtt
 		case 39:
 			baseAttr.NHCAttr = append([]byte(nil), b...)
 			nhc, err := UnmarshalNHC(b)
-			if err != nil {
+			if errors.Is(err, errNHCNoUsableCharacteristics) {
+				baseAttr.NHCEmpty = true
+				glog.Warningf("NHC attribute (path attribute type 39) has no usable characteristics; decoded content discarded: %v", err)
+			} else if err != nil {
 				baseAttr.NHCMalformed = true
 				glog.Errorf("malformed NHC attribute (path attribute type 39); attribute discarded per draft-ietf-idr-nhc-07: %v", err)
 			} else {

--- a/pkg/bgp/bgp-nhc.go
+++ b/pkg/bgp/bgp-nhc.go
@@ -1,0 +1,136 @@
+package bgp
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"net"
+)
+
+const (
+	NHCAttributeType         uint8  = 39
+	NHCCharacteristicELCv3   uint16 = 1
+	NHCCharacteristicNNHN    uint16 = 2
+	NHCCharacteristicBGPID   uint16 = 3
+	NHCCharacteristicIFIT    uint16 = 4
+	NHCCharacteristicAMetric uint16 = 5
+)
+
+type NHC struct {
+	AFI                      uint16              `json:"afi"`
+	SAFI                     uint8               `json:"safi"`
+	NextHop                  []byte              `json:"next_hop"`
+	Characteristics          []NHCCharacteristic `json:"characteristics"`
+	BGPID                    *NHCBGPID           `json:"bgp_id,omitempty"`
+	DiscardedCharacteristics uint16              `json:"discarded_characteristics,omitempty"`
+}
+
+type NHCCharacteristic struct {
+	Code   uint16 `json:"code"`
+	Length uint16 `json:"length"`
+	Value  []byte `json:"value,omitempty"`
+}
+
+type NHCBGPID struct {
+	Identifier string `json:"identifier"`
+	AS         uint32 `json:"as"`
+}
+
+func UnmarshalNHC(b []byte) (*NHC, error) {
+	if len(b) < 4 {
+		return nil, fmt.Errorf("NHC too short: need 4 bytes for header, have %d", len(b))
+	}
+	nextHopLength := int(b[3])
+	if len(b) < 4+nextHopLength {
+		return nil, fmt.Errorf("NHC next hop truncated: need %d bytes, have %d", nextHopLength, len(b)-4)
+	}
+	nhc := &NHC{
+		AFI:     binary.BigEndian.Uint16(b[:2]),
+		SAFI:    b[2],
+		NextHop: append([]byte(nil), b[4:4+nextHopLength]...),
+	}
+	bgpIDSeen := false
+	for p := 4 + nextHopLength; p < len(b); {
+		if len(b)-p < 4 {
+			return nil, fmt.Errorf("NHC characteristic header truncated at offset %d: need 4 bytes, have %d", p, len(b)-p)
+		}
+		code := binary.BigEndian.Uint16(b[p : p+2])
+		length := binary.BigEndian.Uint16(b[p+2 : p+4])
+		p += 4
+		if int(length) > len(b)-p {
+			return nil, fmt.Errorf("NHC characteristic %d truncated at offset %d: need %d bytes, have %d", code, p, length, len(b)-p)
+		}
+		value := b[p : p+int(length)]
+		p += int(length)
+		if code == NHCCharacteristicBGPID {
+			if bgpIDSeen {
+				nhc.DiscardedCharacteristics++
+				continue
+			}
+			bgpIDSeen = true
+			if len(value) != 8 {
+				nhc.DiscardedCharacteristics++
+				continue
+			}
+			if binary.BigEndian.Uint32(value[:4]) == 0 {
+				nhc.DiscardedCharacteristics++
+				continue
+			}
+			nhc.BGPID = &NHCBGPID{
+				Identifier: net.IP(value[:4]).String(),
+				AS:         binary.BigEndian.Uint32(value[4:8]),
+			}
+		}
+		nhc.Characteristics = append(nhc.Characteristics, NHCCharacteristic{
+			Code:   code,
+			Length: length,
+			Value:  append([]byte(nil), value...),
+		})
+	}
+	return nhc, nil
+}
+
+func (n *NHC) SemanticallyMatchesNextHop(afi uint16, safi uint8, nextHop []byte, peerBGPID net.IP, peerAS uint32) bool {
+	matches, requiresBGPID := n.nextHopAddressMatches(afi, safi, nextHop)
+	if !matches {
+		return false
+	}
+	if !requiresBGPID {
+		return true
+	}
+	return n.BGPID != nil && peerBGPID.To4() != nil && n.BGPID.Identifier == peerBGPID.To4().String() && n.BGPID.AS == peerAS
+}
+
+func (n *NHC) nextHopAddressMatches(afi uint16, safi uint8, nextHop []byte) (bool, bool) {
+	if n == nil || n.AFI != afi || n.SAFI != safi {
+		return false, false
+	}
+	nhcComparable, nhcLinkLocal := comparableNHCNextHop(n.NextHop)
+	routeComparable, routeLinkLocal := comparableNHCNextHop(nextHop)
+	if nhcComparable == nil || routeComparable == nil || !bytes.Equal(nhcComparable, routeComparable) {
+		return false, false
+	}
+	return true, nhcLinkLocal || routeLinkLocal
+}
+
+func comparableNHCNextHop(nextHop []byte) ([]byte, bool) {
+	switch len(nextHop) {
+	case net.IPv6len:
+		ip := net.IP(nextHop)
+		return nextHop, ip.IsLinkLocalUnicast()
+	case 2 * net.IPv6len:
+		ip := net.IP(nextHop[:net.IPv6len])
+		return nextHop[:net.IPv6len], ip.IsLinkLocalUnicast()
+	case 8 + net.IPv6len:
+		ip := net.IP(nextHop[8:])
+		return nextHop, ip.IsLinkLocalUnicast()
+	case 2 * (8 + net.IPv6len):
+		ip := net.IP(nextHop[8 : 8+net.IPv6len])
+		return nextHop[:8+net.IPv6len], ip.IsLinkLocalUnicast()
+	default:
+		if len(nextHop) == 0 {
+			return nil, false
+		}
+		return nextHop, false
+	}
+}

--- a/pkg/bgp/bgp-nhc.go
+++ b/pkg/bgp/bgp-nhc.go
@@ -3,19 +3,29 @@ package bgp
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"net"
 )
 
+var errNHCNoUsableCharacteristics = errors.New("NHC contains no usable characteristic TLVs")
+
 const (
-	NHCAttributeType         uint8  = 39
-	NHCCharacteristicELCv3   uint16 = 1
-	NHCCharacteristicNNHN    uint16 = 2
-	NHCCharacteristicBGPID   uint16 = 3
-	NHCCharacteristicIFIT    uint16 = 4
+	// NHCAttributeType identifies the Next Hop Dependent Characteristics path attribute.
+	NHCAttributeType uint8 = 39
+	// NHCCharacteristicELCv3 identifies the ELCv3 characteristic.
+	NHCCharacteristicELCv3 uint16 = 1
+	// NHCCharacteristicNNHN identifies the NNHN characteristic.
+	NHCCharacteristicNNHN uint16 = 2
+	// NHCCharacteristicBGPID identifies the BGP Identifier characteristic.
+	NHCCharacteristicBGPID uint16 = 3
+	// NHCCharacteristicIFIT identifies the IFIT characteristic.
+	NHCCharacteristicIFIT uint16 = 4
+	// NHCCharacteristicAMetric identifies the AMetric characteristic.
 	NHCCharacteristicAMetric uint16 = 5
 )
 
+// NHC represents a decoded Next Hop Dependent Characteristics path attribute.
 type NHC struct {
 	AFI                      uint16              `json:"afi"`
 	SAFI                     uint8               `json:"safi"`
@@ -25,17 +35,20 @@ type NHC struct {
 	DiscardedCharacteristics uint16              `json:"discarded_characteristics,omitempty"`
 }
 
+// NHCCharacteristic represents one characteristic TLV within an NHC attribute.
 type NHCCharacteristic struct {
 	Code   uint16 `json:"code"`
 	Length uint16 `json:"length"`
 	Value  []byte `json:"value,omitempty"`
 }
 
+// NHCBGPID contains the sender identity carried by a BGPID characteristic.
 type NHCBGPID struct {
 	Identifier string `json:"identifier"`
 	AS         uint32 `json:"as"`
 }
 
+// UnmarshalNHC decodes an NHC path attribute value.
 func UnmarshalNHC(b []byte) (*NHC, error) {
 	if len(b) < 4 {
 		return nil, fmt.Errorf("NHC too short: need 4 bytes for header, have %d", len(b))
@@ -87,9 +100,13 @@ func UnmarshalNHC(b []byte) (*NHC, error) {
 			Value:  append([]byte(nil), value...),
 		})
 	}
+	if len(nhc.Characteristics) == 0 {
+		return nil, errNHCNoUsableCharacteristics
+	}
 	return nhc, nil
 }
 
+// SemanticallyMatchesNextHop reports whether the NHC and route next hops match.
 func (n *NHC) SemanticallyMatchesNextHop(afi uint16, safi uint8, nextHop []byte, peerBGPID net.IP, peerAS uint32) bool {
 	matches, requiresBGPID := n.nextHopAddressMatches(afi, safi, nextHop)
 	if !matches {

--- a/pkg/bgp/bgp-nhc_test.go
+++ b/pkg/bgp/bgp-nhc_test.go
@@ -1,0 +1,252 @@
+package bgp
+
+import (
+	"bytes"
+	"encoding/json"
+	"net"
+	"strings"
+	"testing"
+)
+
+func nhcTLV(code uint16, value []byte) []byte {
+	return append([]byte{byte(code >> 8), byte(code), byte(len(value) >> 8), byte(len(value))}, value...)
+}
+
+func nhcValue(afi uint16, safi uint8, nextHop []byte, characteristics ...[]byte) []byte {
+	b := []byte{byte(afi >> 8), byte(afi), safi, byte(len(nextHop))}
+	b = append(b, nextHop...)
+	for _, characteristic := range characteristics {
+		b = append(b, characteristic...)
+	}
+	return b
+}
+
+func TestUnmarshalNHC(t *testing.T) {
+	bgpID := []byte{192, 0, 2, 1, 0, 0, 253, 232}
+	value := nhcValue(1, 1, []byte{198, 51, 100, 1},
+		nhcTLV(5, []byte{0xaa}),
+		nhcTLV(NHCCharacteristicBGPID, bgpID),
+		nhcTLV(65000, nil),
+	)
+
+	nhc, err := UnmarshalNHC(value)
+	if err != nil {
+		t.Fatalf("UnmarshalNHC: %v", err)
+	}
+	if nhc.AFI != 1 || nhc.SAFI != 1 || !bytes.Equal(nhc.NextHop, []byte{198, 51, 100, 1}) {
+		t.Fatalf("unexpected NHC header: %+v", nhc)
+	}
+	if len(nhc.Characteristics) != 3 {
+		t.Fatalf("len(Characteristics) = %d, want 3", len(nhc.Characteristics))
+	}
+	if nhc.Characteristics[0].Code != 5 || nhc.Characteristics[2].Code != 65000 {
+		t.Fatalf("out-of-order or unknown characteristics were not retained: %+v", nhc.Characteristics)
+	}
+	if nhc.BGPID == nil || nhc.BGPID.Identifier != "192.0.2.1" || nhc.BGPID.AS != 65000 {
+		t.Fatalf("BGPID = %+v, want 192.0.2.1/65000", nhc.BGPID)
+	}
+}
+
+func TestUnmarshalNHCRejectsMalformedAttribute(t *testing.T) {
+	tests := map[string][]byte{
+		"short header":         {0, 1, 1},
+		"truncated next hop":   {0, 1, 1, 4, 192, 0},
+		"truncated TLV header": nhcValue(1, 1, []byte{192, 0, 2, 1}, []byte{0, 1, 0}),
+		"truncated TLV value":  nhcValue(1, 1, []byte{192, 0, 2, 1}, []byte{0, 1, 0, 2, 0xff}),
+	}
+	for name, value := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := UnmarshalNHC(value); err == nil {
+				t.Fatal("UnmarshalNHC returned nil error")
+			}
+		})
+	}
+}
+
+func TestUnmarshalNHCEmptyCharacteristics(t *testing.T) {
+	nhc, err := UnmarshalNHC(nhcValue(1, 1, []byte{192, 0, 2, 1}))
+	if err != nil {
+		t.Fatalf("UnmarshalNHC: %v", err)
+	}
+	if len(nhc.Characteristics) != 0 {
+		t.Fatalf("Characteristics = %+v, want empty", nhc.Characteristics)
+	}
+}
+
+func TestUnmarshalNHCBGPIDDiscardRules(t *testing.T) {
+	valid := []byte{192, 0, 2, 1, 0, 0, 253, 232}
+	t.Run("malformed first", func(t *testing.T) {
+		value := nhcValue(2, 1, net.ParseIP("fe80::1").To16(),
+			nhcTLV(NHCCharacteristicBGPID, []byte{1, 2, 3}),
+			nhcTLV(4, []byte{0xaa}),
+			nhcTLV(NHCCharacteristicBGPID, valid),
+		)
+		nhc, err := UnmarshalNHC(value)
+		if err != nil {
+			t.Fatalf("UnmarshalNHC: %v", err)
+		}
+		if nhc.BGPID != nil || len(nhc.Characteristics) != 1 || nhc.Characteristics[0].Code != 4 {
+			t.Fatalf("malformed first BGPID or later instance was retained: %+v", nhc)
+		}
+	})
+	t.Run("zero identifier", func(t *testing.T) {
+		value := nhcValue(2, 1, net.ParseIP("fe80::1").To16(),
+			nhcTLV(NHCCharacteristicBGPID, []byte{0, 0, 0, 0, 0, 0, 0, 1}),
+			nhcTLV(4, nil),
+		)
+		nhc, err := UnmarshalNHC(value)
+		if err != nil {
+			t.Fatalf("UnmarshalNHC: %v", err)
+		}
+		if nhc.BGPID != nil || len(nhc.Characteristics) != 1 {
+			t.Fatalf("zero BGP identifier was retained: %+v", nhc)
+		}
+	})
+	t.Run("valid first", func(t *testing.T) {
+		value := nhcValue(2, 1, net.ParseIP("fe80::1").To16(),
+			nhcTLV(NHCCharacteristicBGPID, valid),
+			nhcTLV(NHCCharacteristicBGPID, []byte{192, 0, 2, 2, 0, 0, 0, 2}),
+		)
+		nhc, err := UnmarshalNHC(value)
+		if err != nil {
+			t.Fatalf("UnmarshalNHC: %v", err)
+		}
+		if nhc.BGPID == nil || nhc.BGPID.Identifier != "192.0.2.1" || nhc.BGPID.AS != 65000 {
+			t.Fatalf("BGPID = %+v, want first BGPID", nhc.BGPID)
+		}
+		if len(nhc.Characteristics) != 1 {
+			t.Fatalf("duplicate BGPID was retained: %+v", nhc.Characteristics)
+		}
+	})
+}
+
+func TestNHCSemanticallyMatchesNextHop(t *testing.T) {
+	peerID := net.ParseIP("192.0.2.1")
+	t.Run("IPv4 exact", func(t *testing.T) {
+		nhc, err := UnmarshalNHC(nhcValue(1, 1, []byte{198, 51, 100, 1}, nhcTLV(4, nil)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !nhc.SemanticallyMatchesNextHop(1, 1, []byte{198, 51, 100, 1}, nil, 0) {
+			t.Fatal("exact IPv4 next hop did not match")
+		}
+		if nhc.SemanticallyMatchesNextHop(1, 2, []byte{198, 51, 100, 1}, nil, 0) {
+			t.Fatal("different SAFI matched")
+		}
+	})
+	t.Run("IPv6 global component", func(t *testing.T) {
+		global := net.ParseIP("2001:db8::1").To16()
+		combined := append(append([]byte{}, global...), net.ParseIP("fe80::1").To16()...)
+		nhc, err := UnmarshalNHC(nhcValue(2, 1, combined, nhcTLV(4, nil)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !nhc.SemanticallyMatchesNextHop(2, 1, global, nil, 0) {
+			t.Fatal("global-only IPv6 next hop did not semantically match global+link-local")
+		}
+	})
+	t.Run("IPv4 NLRI with IPv6 next hop", func(t *testing.T) {
+		global := net.ParseIP("2001:db8::1").To16()
+		combined := append(append([]byte{}, global...), net.ParseIP("fe80::1").To16()...)
+		nhc, err := UnmarshalNHC(nhcValue(1, 1, combined, nhcTLV(4, nil)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !nhc.SemanticallyMatchesNextHop(1, 1, global, nil, 0) {
+			t.Fatal("IPv4 NLRI global-only IPv6 next hop did not semantically match global+link-local")
+		}
+	})
+	t.Run("VPN IPv6 global component", func(t *testing.T) {
+		rd := []byte{0, 0, 0, 0, 0, 0, 0, 1}
+		global := append(append([]byte{}, rd...), net.ParseIP("2001:db8::1").To16()...)
+		combined := append(append([]byte{}, global...), rd...)
+		combined = append(combined, net.ParseIP("fe80::1").To16()...)
+		nhc, err := UnmarshalNHC(nhcValue(2, 128, combined, nhcTLV(4, nil)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !nhc.SemanticallyMatchesNextHop(2, 128, global, nil, 0) {
+			t.Fatal("VPN global-only IPv6 next hop did not semantically match global+link-local")
+		}
+	})
+	t.Run("link-local requires BGPID", func(t *testing.T) {
+		linkLocal := net.ParseIP("fe80::1").To16()
+		bgpID := []byte{192, 0, 2, 1, 0, 0, 253, 232}
+		nhc, err := UnmarshalNHC(nhcValue(2, 1, linkLocal, nhcTLV(NHCCharacteristicBGPID, bgpID)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !nhc.SemanticallyMatchesNextHop(2, 1, linkLocal, peerID, 65000) {
+			t.Fatal("link-local next hop with matching BGPID did not match")
+		}
+		if nhc.SemanticallyMatchesNextHop(2, 1, linkLocal, peerID, 65001) {
+			t.Fatal("link-local next hop with wrong peer AS matched")
+		}
+		withoutBGPID, err := UnmarshalNHC(nhcValue(2, 1, linkLocal, nhcTLV(4, nil)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if withoutBGPID.SemanticallyMatchesNextHop(2, 1, linkLocal, peerID, 65000) {
+			t.Fatal("link-local next hop without BGPID matched")
+		}
+	})
+}
+
+func TestNHCBaseAttributesIntegration(t *testing.T) {
+	value := nhcValue(1, 1, []byte{198, 51, 100, 1}, nhcTLV(65000, []byte{1, 2}))
+	baseAttrs, err := UnmarshalBGPBaseAttributes(buildAttr(0xc0, NHCAttributeType, value))
+	if err != nil {
+		t.Fatalf("UnmarshalBGPBaseAttributes: %v", err)
+	}
+	if baseAttrs.NHC == nil || baseAttrs.NHCMalformed || !bytes.Equal(baseAttrs.NHCAttr, value) {
+		t.Fatalf("NHC integration failed: %+v", baseAttrs)
+	}
+	encoded, err := json.Marshal(baseAttrs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(encoded), `"nhc":`) || !strings.Contains(string(encoded), `"code":65000`) {
+		t.Fatalf("NHC missing from JSON: %s", encoded)
+	}
+
+	different, err := UnmarshalBGPBaseAttributes(buildAttr(0xc0, NHCAttributeType,
+		nhcValue(1, 1, []byte{198, 51, 100, 1}, nhcTLV(65000, []byte{2, 1}))))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if equal, _ := baseAttrs.Equal(different); equal {
+		t.Fatal("BaseAttributes.Equal ignored different NHC values")
+	}
+
+	largeValue := bytes.Repeat([]byte{0xaa}, 260)
+	extended := nhcValue(1, 1, []byte{198, 51, 100, 1}, nhcTLV(65000, largeValue))
+	extendedAttrs, err := UnmarshalBGPBaseAttributes(buildAttrExtLen(0xc0, NHCAttributeType, extended))
+	if err != nil {
+		t.Fatalf("extended-length NHC: %v", err)
+	}
+	if extendedAttrs.NHC == nil || len(extendedAttrs.NHC.Characteristics[0].Value) != len(largeValue) {
+		t.Fatalf("extended-length NHC was not decoded: %+v", extendedAttrs.NHC)
+	}
+}
+
+func TestGetNLRITypePrefersReachability(t *testing.T) {
+	update := &Update{PathAttributes: []PathAttribute{
+		{AttributeType: MP_UNREACH_NLRI},
+		{AttributeType: MP_REACH_NLRI},
+	}}
+	attributeType, index := update.GetNLRIType()
+	if attributeType != MP_REACH_NLRI || index != 1 {
+		t.Fatalf("GetNLRIType() = %d, %d, want %d, 1", attributeType, index, MP_REACH_NLRI)
+	}
+}
+
+func TestMalformedNHCUsesAttributeDiscard(t *testing.T) {
+	value := nhcValue(1, 1, []byte{198, 51, 100, 1}, []byte{0, 1, 0, 2, 0xff})
+	baseAttrs, err := UnmarshalBGPBaseAttributes(buildAttr(0xc0, NHCAttributeType, value))
+	if err != nil {
+		t.Fatalf("malformed NHC rejected the containing attributes: %v", err)
+	}
+	if baseAttrs.NHC != nil || !baseAttrs.NHCMalformed || !bytes.Equal(baseAttrs.NHCAttr, value) {
+		t.Fatalf("malformed NHC was not discarded and retained for forensics: %+v", baseAttrs)
+	}
+}

--- a/pkg/bgp/bgp-nhc_test.go
+++ b/pkg/bgp/bgp-nhc_test.go
@@ -63,13 +63,17 @@ func TestUnmarshalNHCRejectsMalformedAttribute(t *testing.T) {
 	}
 }
 
-func TestUnmarshalNHCEmptyCharacteristics(t *testing.T) {
-	nhc, err := UnmarshalNHC(nhcValue(1, 1, []byte{192, 0, 2, 1}))
-	if err != nil {
-		t.Fatalf("UnmarshalNHC: %v", err)
+func TestUnmarshalNHCRejectsEmptyCharacteristics(t *testing.T) {
+	value := nhcValue(1, 1, []byte{192, 0, 2, 1})
+	if _, err := UnmarshalNHC(value); err == nil {
+		t.Fatal("UnmarshalNHC returned nil error")
 	}
-	if len(nhc.Characteristics) != 0 {
-		t.Fatalf("Characteristics = %+v, want empty", nhc.Characteristics)
+	baseAttrs, err := UnmarshalBGPBaseAttributes(buildAttr(0xc0, NHCAttributeType, value))
+	if err != nil {
+		t.Fatalf("UnmarshalBGPBaseAttributes: %v", err)
+	}
+	if baseAttrs.NHC != nil || baseAttrs.NHCMalformed || !baseAttrs.NHCEmpty || baseAttrs.NHCDiscarded || !bytes.Equal(baseAttrs.NHCAttr, value) {
+		t.Fatalf("empty NHC was not discarded and retained for forensics: %+v", baseAttrs)
 	}
 }
 
@@ -229,14 +233,14 @@ func TestNHCBaseAttributesIntegration(t *testing.T) {
 	}
 }
 
-func TestGetNLRITypePrefersReachability(t *testing.T) {
+func TestGetNLRITypePreservesAttributeOrder(t *testing.T) {
 	update := &Update{PathAttributes: []PathAttribute{
 		{AttributeType: MP_UNREACH_NLRI},
 		{AttributeType: MP_REACH_NLRI},
 	}}
 	attributeType, index := update.GetNLRIType()
-	if attributeType != MP_REACH_NLRI || index != 1 {
-		t.Fatalf("GetNLRIType() = %d, %d, want %d, 1", attributeType, index, MP_REACH_NLRI)
+	if attributeType != MP_UNREACH_NLRI || index != 0 {
+		t.Fatalf("GetNLRIType() = %d, %d, want %d, 0", attributeType, index, MP_UNREACH_NLRI)
 	}
 }
 

--- a/pkg/bgp/bgp-update.go
+++ b/pkg/bgp/bgp-update.go
@@ -103,20 +103,15 @@ func (up *Update) GetNLRIType() (uint8, int) {
 		// Fall back to default NLRI
 		return BGP4_NLRI, 0
 	}
-	unreachable := -1
 	for i, p := range up.PathAttributes {
 		switch p.AttributeType {
 		case MP_REACH_NLRI:
 			return MP_REACH_NLRI, i
 		case MP_UNREACH_NLRI:
-			if unreachable == -1 {
-				unreachable = i
-			}
+			return MP_UNREACH_NLRI, i
 		}
 	}
-	if unreachable != -1 {
-		return MP_UNREACH_NLRI, unreachable
-	}
+
 	return BGP4_NLRI, 0
 }
 

--- a/pkg/bgp/bgp-update.go
+++ b/pkg/bgp/bgp-update.go
@@ -103,15 +103,20 @@ func (up *Update) GetNLRIType() (uint8, int) {
 		// Fall back to default NLRI
 		return BGP4_NLRI, 0
 	}
+	unreachable := -1
 	for i, p := range up.PathAttributes {
 		switch p.AttributeType {
 		case MP_REACH_NLRI:
 			return MP_REACH_NLRI, i
 		case MP_UNREACH_NLRI:
-			return MP_UNREACH_NLRI, i
+			if unreachable == -1 {
+				unreachable = i
+			}
 		}
 	}
-
+	if unreachable != -1 {
+		return MP_UNREACH_NLRI, unreachable
+	}
 	return BGP4_NLRI, 0
 }
 

--- a/pkg/message/nhc_test.go
+++ b/pkg/message/nhc_test.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"encoding/json"
 	"net"
 	"testing"
 
@@ -56,4 +57,69 @@ func TestValidateNHC(t *testing.T) {
 			t.Fatal("unverifiable outbound link-local NHC was not retained and marked")
 		}
 	})
+}
+
+func TestCopyUpdateCopiesNHCState(t *testing.T) {
+	original := &bgp.Update{BaseAttributes: &bgp.BaseAttributes{
+		NHCAttr: []byte{1},
+		NHC: &bgp.NHC{
+			NextHop: []byte{192, 0, 2, 1},
+			Characteristics: []bgp.NHCCharacteristic{{
+				Code:  4,
+				Value: []byte{1},
+			}},
+			BGPID: &bgp.NHCBGPID{Identifier: "192.0.2.1", AS: 65000},
+		},
+	}}
+	copied := copyUpdate(original)
+	copied.BaseAttributes.NHCAttr[0] = 2
+	copied.BaseAttributes.NHC.NextHop[0] = 198
+	copied.BaseAttributes.NHC.Characteristics[0].Value[0] = 2
+	copied.BaseAttributes.NHC.BGPID.AS = 65001
+	if original.BaseAttributes.NHCAttr[0] != 1 || original.BaseAttributes.NHC.NextHop[0] != 192 || original.BaseAttributes.NHC.Characteristics[0].Value[0] != 1 || original.BaseAttributes.NHC.BGPID.AS != 65000 {
+		t.Fatal("copyUpdate shared mutable NHC state with the original update")
+	}
+}
+
+func TestRouteMonitorPublishesMPReachAndUnreach(t *testing.T) {
+	publisher := &recordingPublisher{}
+	p := NewProducer(publisher, false).(*producer)
+	p.speakerIP = "192.0.2.10"
+	p.speakerHash = "speaker"
+	nhcValue := []byte{0, 1, 1, 4, 10, 0, 0, 1, 0, 4, 0, 0}
+	nhc, err := bgp.UnmarshalNHC(nhcValue)
+	if err != nil {
+		t.Fatalf("UnmarshalNHC: %v", err)
+	}
+	update := &bgp.Update{
+		PathAttributes: []bgp.PathAttribute{
+			{AttributeType: bgp.MP_UNREACH_NLRI, Attribute: []byte{0, 1, 1, 24, 198, 51, 100}},
+			{AttributeType: bgp.MP_REACH_NLRI, Attribute: []byte{0, 1, 1, 4, 10, 0, 0, 1, 0, 24, 192, 0, 2}},
+		},
+		BaseAttributes: &bgp.BaseAttributes{NHCAttr: nhcValue, NHC: nhc},
+	}
+	p.produceRouteMonitorMessage(bmp.Message{
+		PeerHeader: makePeerHeader(t, bmp.PeerType0, 0),
+		Payload:    &bmp.RouteMonitor{Update: update},
+	})
+
+	if len(publisher.msgs) != 2 {
+		t.Fatalf("published %d messages, want 2", len(publisher.msgs))
+	}
+	messages := make(map[string]UnicastPrefix, 2)
+	for _, published := range publisher.msgs {
+		var message UnicastPrefix
+		if err := json.Unmarshal(published.payload, &message); err != nil {
+			t.Fatalf("json.Unmarshal: %v", err)
+		}
+		messages[message.Action] = message
+	}
+	added, ok := messages["add"]
+	if !ok || added.Prefix != "192.0.2.0" || added.BaseAttributes == nil || added.BaseAttributes.NHC == nil {
+		t.Fatalf("reachable NLRI not published with NHC: %+v", added)
+	}
+	withdrawn, ok := messages["del"]
+	if !ok || withdrawn.Prefix != "198.51.100.0" || withdrawn.BaseAttributes == nil || withdrawn.BaseAttributes.NHC != nil || len(withdrawn.BaseAttributes.NHCAttr) != 0 || withdrawn.BaseAttributes.NHCMalformed || withdrawn.BaseAttributes.NHCEmpty || withdrawn.BaseAttributes.NHCDiscarded || withdrawn.BaseAttributes.NHCUnverified {
+		t.Fatalf("unreachable NLRI not published without NHC: %+v", withdrawn)
+	}
 }

--- a/pkg/message/nhc_test.go
+++ b/pkg/message/nhc_test.go
@@ -1,0 +1,59 @@
+package message
+
+import (
+	"net"
+	"testing"
+
+	"github.com/sbezverk/gobmp/pkg/bgp"
+	"github.com/sbezverk/gobmp/pkg/bmp"
+)
+
+func parsedNHC(t *testing.T, value []byte) *bgp.NHC {
+	t.Helper()
+	nhc, err := bgp.UnmarshalNHC(value)
+	if err != nil {
+		t.Fatalf("UnmarshalNHC: %v", err)
+	}
+	return nhc
+}
+
+func TestValidateNHC(t *testing.T) {
+	tlv := []byte{0, 4, 0, 0}
+	t.Run("matching next hop retained", func(t *testing.T) {
+		value := append([]byte{0, 1, 1, 4, 198, 51, 100, 1}, tlv...)
+		update := &bgp.Update{BaseAttributes: &bgp.BaseAttributes{NHC: parsedNHC(t, value)}}
+		validateNHC(update, 1, 1, []byte{198, 51, 100, 1}, nil)
+		if update.BaseAttributes.NHC == nil || update.BaseAttributes.NHCDiscarded {
+			t.Fatal("matching NHC was discarded")
+		}
+	})
+	t.Run("mismatching next hop discarded", func(t *testing.T) {
+		value := append([]byte{0, 1, 1, 4, 198, 51, 100, 1}, tlv...)
+		update := &bgp.Update{BaseAttributes: &bgp.BaseAttributes{NHC: parsedNHC(t, value)}}
+		validateNHC(update, 1, 1, []byte{198, 51, 100, 2}, nil)
+		if update.BaseAttributes.NHC != nil || !update.BaseAttributes.NHCDiscarded {
+			t.Fatal("mismatching NHC was not discarded")
+		}
+	})
+	t.Run("link-local uses inbound peer identity", func(t *testing.T) {
+		nextHop := net.ParseIP("fe80::1").To16()
+		value := append([]byte{0, 2, 1, 16}, nextHop...)
+		value = append(value, []byte{0, 3, 0, 8, 192, 0, 2, 1, 0, 0, 253, 232}...)
+		update := &bgp.Update{BaseAttributes: &bgp.BaseAttributes{NHC: parsedNHC(t, value)}}
+		ph := &bmp.PerPeerHeader{PeerAS: 65000, PeerBGPID: []byte{192, 0, 2, 1}}
+		validateNHC(update, 2, 1, nextHop, ph)
+		if update.BaseAttributes.NHC == nil || update.BaseAttributes.NHCDiscarded || update.BaseAttributes.NHCUnverified {
+			t.Fatal("link-local NHC with matching inbound peer identity was not verified")
+		}
+	})
+	t.Run("link-local outbound identity unavailable", func(t *testing.T) {
+		nextHop := net.ParseIP("fe80::1").To16()
+		value := append([]byte{0, 2, 1, 16}, nextHop...)
+		value = append(value, []byte{0, 3, 0, 8, 192, 0, 2, 1, 0, 0, 253, 232}...)
+		update := &bgp.Update{BaseAttributes: &bgp.BaseAttributes{NHC: parsedNHC(t, value)}}
+		validateNHC(update, 2, 1, nextHop, makePeerHeader(t, bmp.PeerType0, 0x10))
+		if update.BaseAttributes.NHC == nil || update.BaseAttributes.NHCDiscarded || !update.BaseAttributes.NHCUnverified {
+			t.Fatal("unverifiable outbound link-local NHC was not retained and marked")
+		}
+	})
+}

--- a/pkg/message/route-monitor.go
+++ b/pkg/message/route-monitor.go
@@ -3,6 +3,7 @@ package message
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 
 	"github.com/golang/glog"
 	"github.com/sbezverk/gobmp/pkg/bgp"
@@ -51,6 +52,9 @@ func (p *producer) produceRouteMonitorMessage(msg bmp.Message) {
 			glog.Errorf("failed to process MP_REACH_NLRI with error: %+v", err)
 			return
 		}
+		if reach, ok := nlri.(*bgp.MPReachNLRI); ok {
+			validateNHC(routeMonitorMsg.Update, reach.AddressFamilyID, reach.SubAddressFamilyID, reach.NextHopAddress, msg.PeerHeader)
+		}
 		p.processMPUpdate(nlri, AddPrefix, msg.PeerHeader, routeMonitorMsg.Update)
 	case 15:
 		// MP_UNREACH_NLRI - Use per-table AddPath capability
@@ -62,8 +66,16 @@ func (p *producer) produceRouteMonitorMessage(msg bmp.Message) {
 			glog.Errorf("failed to process MP_UNREACH_NLRI with error: %+v", err)
 			return
 		}
+		if unreachable, ok := nlri.(*bgp.MPUnReachNLRI); ok {
+			validateNHC(routeMonitorMsg.Update, unreachable.AddressFamilyID, unreachable.SubAddressFamilyID, nil, msg.PeerHeader)
+		}
 		p.processMPUpdate(nlri, DelPrefix, msg.PeerHeader, routeMonitorMsg.Update)
 	default:
+		var nextHop []byte
+		if len(routeMonitorMsg.Update.NLRI) != 0 && routeMonitorMsg.Update.BaseAttributes != nil {
+			nextHop = net.ParseIP(routeMonitorMsg.Update.BaseAttributes.Nexthop).To4()
+		}
+		validateNHC(routeMonitorMsg.Update, 1, 1, nextHop, msg.PeerHeader)
 		t := bmp.UnicastPrefixMsg
 		if p.splitAF {
 			t = bmp.UnicastPrefixV4Msg
@@ -92,6 +104,33 @@ func (p *producer) produceRouteMonitorMessage(msg bmp.Message) {
 			}
 		}
 	}
+}
+
+func validateNHC(update *bgp.Update, afi uint16, safi uint8, nextHop []byte, ph *bmp.PerPeerHeader) {
+	if update == nil || update.BaseAttributes == nil || update.BaseAttributes.NHC == nil {
+		return
+	}
+	var peerBGPID net.IP
+	var peerAS uint32
+	authoritativePeer := false
+	if ph != nil {
+		if inbound, err := ph.IsAdjRIBIn(); err == nil && inbound {
+			peerBGPID = net.IP(ph.PeerBGPID)
+			peerAS = ph.PeerAS
+			authoritativePeer = true
+		}
+	}
+	nhc := update.BaseAttributes.NHC
+	if nhc.SemanticallyMatchesNextHop(afi, safi, nextHop, peerBGPID, peerAS) {
+		return
+	}
+	if !authoritativePeer && nhc.BGPID != nil && nhc.SemanticallyMatchesNextHop(afi, safi, nextHop, net.ParseIP(nhc.BGPID.Identifier), nhc.BGPID.AS) {
+		update.BaseAttributes.NHCUnverified = true
+		return
+	}
+	update.BaseAttributes.NHC = nil
+	update.BaseAttributes.NHCDiscarded = true
+	glog.Warningf("discarded NHC attribute whose embedded next hop did not semantically match AFI %d SAFI %d route next hop", afi, safi)
 }
 
 func (p *producer) marshalAndPublish(msg interface{}, msgType int, hash []byte) error {

--- a/pkg/message/route-monitor.go
+++ b/pkg/message/route-monitor.go
@@ -34,74 +34,120 @@ func (p *producer) produceRouteMonitorMessage(msg bmp.Message) {
 	if routeMonitorMsg.Update == nil {
 		return
 	}
-	attrType := uint8(0)
-	index := 0
-	if len(routeMonitorMsg.Update.PathAttributes) != 0 {
-		// If PathAttribute is present in Update, then take the value of Attribute Type
-		attrType, index = routeMonitorMsg.Update.GetNLRIType()
+	reachIndexes := make([]int, 0, 1)
+	unreachIndexes := make([]int, 0, 1)
+	for i, attr := range routeMonitorMsg.Update.PathAttributes {
+		switch attr.AttributeType {
+		case bgp.MP_REACH_NLRI:
+			reachIndexes = append(reachIndexes, i)
+		case bgp.MP_UNREACH_NLRI:
+			unreachIndexes = append(unreachIndexes, i)
+		}
 	}
-	// Using first attribute type to select which nlri processor to call
-	switch attrType {
-	case 14:
-		// MP_REACH_NLRI - Use per-table AddPath capability
-		nlri, err := bgp.UnmarshalMPReachNLRI(
-			routeMonitorMsg.Update.PathAttributes[index].Attribute,
-			routeMonitorMsg.Update.HasPrefixSID(),
-			p.GetAddPathCapability(msg.PeerHeader.GetTableKey()))
-		if err != nil {
-			glog.Errorf("failed to process MP_REACH_NLRI with error: %+v", err)
-			return
-		}
-		if reach, ok := nlri.(*bgp.MPReachNLRI); ok {
-			validateNHC(routeMonitorMsg.Update, reach.AddressFamilyID, reach.SubAddressFamilyID, reach.NextHopAddress, msg.PeerHeader)
-		}
-		p.processMPUpdate(nlri, AddPrefix, msg.PeerHeader, routeMonitorMsg.Update)
-	case 15:
-		// MP_UNREACH_NLRI - Use per-table AddPath capability
-		nlri, err := bgp.UnmarshalMPUnReachNLRI(
-			routeMonitorMsg.Update.PathAttributes[index].Attribute,
-			p.GetAddPathCapability(msg.PeerHeader.GetTableKey()),
-			routeMonitorMsg.Update.HasPrefixSID())
-		if err != nil {
-			glog.Errorf("failed to process MP_UNREACH_NLRI with error: %+v", err)
-			return
-		}
-		if unreachable, ok := nlri.(*bgp.MPUnReachNLRI); ok {
-			validateNHC(routeMonitorMsg.Update, unreachable.AddressFamilyID, unreachable.SubAddressFamilyID, nil, msg.PeerHeader)
-		}
-		p.processMPUpdate(nlri, DelPrefix, msg.PeerHeader, routeMonitorMsg.Update)
-	default:
-		var nextHop []byte
-		if len(routeMonitorMsg.Update.NLRI) != 0 && routeMonitorMsg.Update.BaseAttributes != nil {
-			nextHop = net.ParseIP(routeMonitorMsg.Update.BaseAttributes.Nexthop).To4()
-		}
-		validateNHC(routeMonitorMsg.Update, 1, 1, nextHop, msg.PeerHeader)
-		t := bmp.UnicastPrefixMsg
-		if p.splitAF {
-			t = bmp.UnicastPrefixV4Msg
-		}
-		// Original BGP's NLRI messages processing
-		msgs := make([]*UnicastPrefix, 0)
-		if routeMonitorMsg.Update.WithdrawnRoutesLength != 0 {
-			msg, err := p.nlri(DelPrefix, msg.PeerHeader, routeMonitorMsg.Update)
-			if err != nil {
-				glog.Errorf("failed to produce original NLRI Withdraw message with error: %+v", err)
-				return
+	for _, index := range reachIndexes {
+		p.processMPReach(routeMonitorMsg.Update.PathAttributes[index].Attribute, msg.PeerHeader, routeMonitorMsg.Update)
+	}
+	for _, index := range unreachIndexes {
+		p.processMPUnreach(routeMonitorMsg.Update.PathAttributes[index].Attribute, msg.PeerHeader, routeMonitorMsg.Update)
+	}
+	if (len(reachIndexes) == 0 && len(unreachIndexes) == 0) || routeMonitorMsg.Update.WithdrawnRoutesLength != 0 || len(routeMonitorMsg.Update.NLRI) != 0 {
+		p.processBGP4Update(msg.PeerHeader, routeMonitorMsg.Update)
+	}
+}
+
+func (p *producer) processMPReach(attribute []byte, ph *bmp.PerPeerHeader, update *bgp.Update) {
+	nlri, err := bgp.UnmarshalMPReachNLRI(attribute, update.HasPrefixSID(), p.GetAddPathCapability(ph.GetTableKey()))
+	if err != nil {
+		glog.Errorf("failed to process MP_REACH_NLRI with error: %+v", err)
+		return
+	}
+	reachableUpdate := copyUpdate(update)
+	if reach, ok := nlri.(*bgp.MPReachNLRI); ok {
+		validateNHC(reachableUpdate, reach.AddressFamilyID, reach.SubAddressFamilyID, reach.NextHopAddress, ph)
+	}
+	p.processMPUpdate(nlri, AddPrefix, ph, reachableUpdate)
+}
+
+func (p *producer) processMPUnreach(attribute []byte, ph *bmp.PerPeerHeader, update *bgp.Update) {
+	nlri, err := bgp.UnmarshalMPUnReachNLRI(attribute, p.GetAddPathCapability(ph.GetTableKey()), update.HasPrefixSID())
+	if err != nil {
+		glog.Errorf("failed to process MP_UNREACH_NLRI with error: %+v", err)
+		return
+	}
+	p.processMPUpdate(nlri, DelPrefix, ph, withoutNHC(update))
+}
+
+func copyUpdate(update *bgp.Update) *bgp.Update {
+	if update == nil {
+		return nil
+	}
+	copied := *update
+	if update.BaseAttributes != nil {
+		attributes := *update.BaseAttributes
+		attributes.NHCAttr = append([]byte(nil), update.BaseAttributes.NHCAttr...)
+		if update.BaseAttributes.NHC != nil {
+			nhc := *update.BaseAttributes.NHC
+			nhc.NextHop = append([]byte(nil), update.BaseAttributes.NHC.NextHop...)
+			nhc.Characteristics = make([]bgp.NHCCharacteristic, len(update.BaseAttributes.NHC.Characteristics))
+			for i, characteristic := range update.BaseAttributes.NHC.Characteristics {
+				nhc.Characteristics[i] = characteristic
+				nhc.Characteristics[i].Value = append([]byte(nil), characteristic.Value...)
 			}
-			msgs = append(msgs, msg...)
+			if update.BaseAttributes.NHC.BGPID != nil {
+				bgpID := *update.BaseAttributes.NHC.BGPID
+				nhc.BGPID = &bgpID
+			}
+			attributes.NHC = &nhc
 		}
-		msg, err := p.nlri(AddPrefix, msg.PeerHeader, routeMonitorMsg.Update)
+		copied.BaseAttributes = &attributes
+	}
+	return &copied
+}
+
+func withoutNHC(update *bgp.Update) *bgp.Update {
+	copied := copyUpdate(update)
+	if copied == nil || copied.BaseAttributes == nil {
+		return copied
+	}
+	copied.BaseAttributes.NHCAttr = nil
+	copied.BaseAttributes.NHC = nil
+	copied.BaseAttributes.NHCMalformed = false
+	copied.BaseAttributes.NHCEmpty = false
+	copied.BaseAttributes.NHCDiscarded = false
+	copied.BaseAttributes.NHCUnverified = false
+	return copied
+}
+
+func (p *producer) processBGP4Update(ph *bmp.PerPeerHeader, update *bgp.Update) {
+	reachableUpdate := copyUpdate(update)
+	var nextHop []byte
+	if len(reachableUpdate.NLRI) != 0 && reachableUpdate.BaseAttributes != nil {
+		nextHop = net.ParseIP(reachableUpdate.BaseAttributes.Nexthop).To4()
+	}
+	validateNHC(reachableUpdate, 1, 1, nextHop, ph)
+	t := bmp.UnicastPrefixMsg
+	if p.splitAF {
+		t = bmp.UnicastPrefixV4Msg
+	}
+	msgs := make([]*UnicastPrefix, 0)
+	if update.WithdrawnRoutesLength != 0 {
+		msg, err := p.nlri(DelPrefix, ph, withoutNHC(update))
 		if err != nil {
 			glog.Errorf("failed to produce original NLRI Withdraw message with error: %+v", err)
 			return
 		}
 		msgs = append(msgs, msg...)
-		// Loop through and publish all collected messages
-		for _, m := range msgs {
-			if err := p.marshalAndPublish(&m, t, []byte(m.RouterHash)); err != nil {
-				glog.Errorf("failed to process Unicast Prefix message with error: %+v", err)
-				return
-			}
+	}
+	msg, err := p.nlri(AddPrefix, ph, reachableUpdate)
+	if err != nil {
+		glog.Errorf("failed to produce original NLRI message with error: %+v", err)
+		return
+	}
+	msgs = append(msgs, msg...)
+	for _, m := range msgs {
+		if err := p.marshalAndPublish(&m, t, []byte(m.RouterHash)); err != nil {
+			glog.Errorf("failed to process Unicast Prefix message with error: %+v", err)
+			return
 		}
 	}
 }


### PR DESCRIPTION
 Previously, path attribute type 39 had an empty switch case. NHC data was parsed as a raw path attribute but then silently omitted from  BaseAtt
 ributes  and published JSON.

 Changes

   • Added NHC attribute decoding:
     • AFI, SAFI, and next-hop address
     • 16-bit characteristic code and length
     • Unknown and out-of-order characteristics
     • Extended-length path attributes
   • Added BGPID characteristic support:
     • Validates 8-byte length and nonzero identifier
     • Decodes BGP identifier and four-byte ASN
     • Discards malformed and duplicate instances
   • Added structural validation and RFC 7606-style attribute discard.
   • Added semantic next-hop matching:
     • IPv4 and IPv6
     • RFC 8950 IPv6 next hops for IPv4 NLRI
     • IPv6 global plus link-local forms
     • VPN/RD-prefixed next hops
     • Link-local-only BGPID/ASN validation
   • Route-monitor processing now discards stale NHC attributes when next hops mismatch.
   • Adj-RIB-Out/Loc-RIB link-local attributes are retained with  nhc_unverified  when authoritative sender identity is unavailable.
   • Raw NHC bytes remain available through  nhc_attr  for forensic use.
   • Added NHC handling to  BaseAttributes.Equal .
   • Prefer MP_REACH over MP_UNREACH when both occur, preventing withdrawals from incorrectly driving NHC validation.

 Implementation: bgp-nhc.go

 Base attribute integration: bgp-base-attributes.go:427-435

 Route-context validation: route-monitor.go:109-133

 Tests: bgp-nhc_test.go nhc_test.go

 Verification

   •  go test ./...  — passed
   •  go vet ./...  — passed
   •  git diff --check  — passed